### PR TITLE
Add Firebase-based Madia web app replacement

### DIFF
--- a/madia.new/.firebaserc
+++ b/madia.new/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "YOUR_FIREBASE_PROJECT_ID"
+  }
+}

--- a/madia.new/README.md
+++ b/madia.new/README.md
@@ -1,0 +1,165 @@
+# Madia Firebase Application
+
+This folder contains a modern Firebase implementation of the legacy `mafia.old/default.asp` forum and Mafia game helper. The new single-page app uses Firebase Authentication, Firestore, and Hosting to deliver a collaborative experience for players.
+
+## Features
+
+- **Threaded discussion board** with real-time updates backed by Cloud Firestore.
+- **Integrated Mafia game dashboard** to track player votes and notes.
+- **Google sign-in** via Firebase Authentication with guards around write operations.
+- **Firebase Hosting configuration** that deploys the static assets in `public/`.
+- **Emulator Suite support** for local development with Auth, Firestore, and Hosting.
+
+## Project structure
+
+```
+madia.new/
+├── .firebaserc          # Placeholder project alias mapping
+├── firebase.json        # Hosting + emulator configuration
+├── README.md            # This file with setup and deployment guidance
+└── public/
+    ├── index.html       # Application shell
+    ├── script.js        # Firebase-backed forum logic
+    └── styles.css       # Modernized styling
+```
+
+## Prerequisites
+
+- Node.js 18+ (for the Firebase CLI)
+- A Google account with access to the Google Cloud Console
+- The [Firebase CLI](https://firebase.google.com/docs/cli) (`npm install -g firebase-tools`)
+
+## 1. Create and configure the Firebase project
+
+1. Navigate to the [Firebase console](https://console.firebase.google.com/) and click **Add project**.
+2. Choose (or create) a Google Cloud project name, enable Google Analytics if desired, and finish the wizard.
+3. In the project dashboard:
+   - Go to **Build → Authentication → Sign-in method** and enable **Google**. Configure an authorized domain if you plan to use a custom domain.
+   - Go to **Build → Firestore Database** and create a database in production mode. Choose a region close to your players.
+   - (Optional) Under **Build → Storage**, create a Cloud Storage bucket if you plan to add media uploads later.
+4. Create a **Web app** registration (`</>` icon) to obtain the Firebase configuration snippet. Copy the settings (apiKey, authDomain, etc.).
+5. Update `public/script.js` with the copied configuration values (replace the `YOUR_*` placeholders).
+6. Update `.firebaserc` to set the default project ID: replace `YOUR_FIREBASE_PROJECT_ID` with the project ID shown in the Firebase console.
+
+### Recommended Firestore security rules
+
+In the Firebase console under **Build → Firestore Database → Rules**, replace the default rules with a stricter set:
+
+```firestore
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /threads/{threadId} {
+      allow read: if true;
+      allow create: if request.auth != null;
+      allow update, delete: if request.auth != null && request.auth.uid == resource.data.createdBy;
+
+      match /posts/{postId} {
+        allow read: if true;
+        allow create: if request.auth != null;
+      }
+    }
+
+    match /votes/{voteId} {
+      allow read: if true;
+      allow create: if request.auth != null;
+      allow delete: if request.auth != null && request.auth.uid == resource.data.recordedBy;
+    }
+  }
+}
+```
+
+These rules mirror the client-side checks in `script.js` and prevent anonymous writes.
+
+## 2. Install and authenticate the Firebase CLI
+
+1. Install the CLI (if not already):
+
+   ```bash
+   npm install -g firebase-tools
+   ```
+
+2. Authenticate with your Google account:
+
+   ```bash
+   firebase login
+   ```
+
+   This opens a browser window for OAuth consent.
+
+3. Verify the CLI can see your project:
+
+   ```bash
+   firebase projects:list
+   ```
+
+## 3. Initialize local development
+
+1. From the repository root, navigate into this directory and install any local tooling if desired (no dependencies are required for the static app):
+
+   ```bash
+   cd madia.new
+   ```
+
+2. (Optional) Connect additional Firebase resources if you extend the project:
+
+   ```bash
+   firebase use YOUR_FIREBASE_PROJECT_ID
+   ```
+
+3. Start the Emulator Suite for local testing:
+
+   ```bash
+   firebase emulators:start
+   ```
+
+   - Hosting will serve the app at `http://localhost:5000`.
+   - Firestore is available at `localhost:8080` and Auth at `localhost:9099`.
+   - The CLI prints a UI URL where you can inspect emulator data.
+
+4. When using emulators, override the SDK configuration at the top of `public/script.js` to point to the emulators:
+
+   ```js
+   import { connectAuthEmulator } from 'https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js';
+   import { connectFirestoreEmulator } from 'https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js';
+
+   connectAuthEmulator(auth, 'http://localhost:9099');
+   connectFirestoreEmulator(db, 'localhost', 8080);
+   ```
+
+   (Wrap these calls with a development-only flag or environment check.)
+
+## 4. Deploy to Firebase Hosting
+
+1. Build/prepare static assets. This project is already static, so no additional build step is required.
+2. Run a preview deploy to inspect the result without affecting production:
+
+   ```bash
+   firebase hosting:channel:deploy preview
+   ```
+
+3. When satisfied, deploy to production:
+
+   ```bash
+   firebase deploy --only hosting
+   ```
+
+   The CLI prints the live URL (e.g., `https://<project-id>.web.app`).
+
+4. (Optional) In the Firebase console under **Build → Hosting**, connect a custom domain and follow the DNS verification steps.
+
+## 5. Monitor and maintain
+
+- Use the [Google Cloud Console](https://console.cloud.google.com/) for project-wide settings, IAM roles, and usage metrics.
+- Set up alerts in **Google Cloud Monitoring** for Firestore and Hosting quotas if you anticipate heavy traffic.
+- Regularly review the **Authentication** user list to prune inactive accounts and update provider settings.
+- Export Firestore data using the [Managed Export and Import service](https://firebase.google.com/docs/firestore/manage-data/export-import) for backups.
+
+## 6. Next steps and customization ideas
+
+- Add Cloud Functions for scheduled tasks (e.g., nightly vote summaries).
+- Integrate push notifications with Firebase Cloud Messaging for day/night cycle alerts.
+- Replace the dialog-based forms with richer editors or markdown support.
+- Add role management (villager/mafia/host) by extending user profiles in Firestore.
+
+With this foundation you can gradually migrate content and users from the legacy ASP application into a scalable Firebase-backed solution.

--- a/madia.new/firebase.json
+++ b/madia.new/firebase.json
@@ -1,0 +1,21 @@
+{
+  "hosting": {
+    "public": "public",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ]
+  },
+  "emulators": {
+    "hosting": {
+      "port": 5000
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "auth": {
+      "port": 9099
+    }
+  }
+}

--- a/madia.new/public/index.html
+++ b/madia.new/public/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Madia Forum</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Madia</h1>
+      <p class="subtitle">Modern Firebase-powered forum and game lobby</p>
+      <div class="auth-controls">
+        <span id="authStatus">Not signed in</span>
+        <button id="signInButton">Sign in with Google</button>
+        <button id="signOutButton" class="secondary" hidden>Sign out</button>
+      </div>
+    </header>
+
+    <main>
+      <section class="panel" id="threadsPanel">
+        <div class="panel-header">
+          <h2>Active Threads</h2>
+          <button id="newThreadButton" class="primary">New thread</button>
+        </div>
+        <ul id="threadsList" class="list"></ul>
+      </section>
+
+      <section class="panel" id="threadViewPanel">
+        <div class="panel-header">
+          <h2 id="threadTitle">Select a thread</h2>
+          <div class="panel-actions">
+            <button id="refreshThread" class="secondary">Refresh</button>
+            <button id="deleteThread" class="danger" hidden>Delete thread</button>
+          </div>
+        </div>
+        <div id="threadMetadata" class="metadata"></div>
+        <ul id="postsList" class="list posts"></ul>
+        <form id="replyForm" class="form" hidden>
+          <textarea id="replyBody" rows="4" placeholder="Write your reply..."></textarea>
+          <button type="submit" class="primary">Post reply</button>
+        </form>
+      </section>
+
+      <section class="panel" id="gamePanel">
+        <div class="panel-header">
+          <h2>Game Dashboard</h2>
+          <button id="recordVoteButton" class="secondary">Record vote</button>
+        </div>
+        <table id="voteTable">
+          <thead>
+            <tr>
+              <th>Player</th>
+              <th>Votes</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </section>
+    </main>
+
+    <dialog id="threadDialog">
+      <form method="dialog" id="threadForm" class="form">
+        <h3>Create thread</h3>
+        <label>
+          Thread title
+          <input id="threadTitleInput" required />
+        </label>
+        <label>
+          Initial post
+          <textarea id="threadBodyInput" rows="5" required></textarea>
+        </label>
+        <menu class="dialog-actions">
+          <button value="cancel" class="secondary">Cancel</button>
+          <button value="default" class="primary">Create</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <dialog id="voteDialog">
+      <form method="dialog" id="voteForm" class="form">
+        <h3>Record vote</h3>
+        <label>
+          Player name
+          <input id="votePlayerInput" required />
+        </label>
+        <label>
+          Vote count
+          <input id="voteCountInput" type="number" min="0" step="1" value="1" required />
+        </label>
+        <label>
+          Notes
+          <textarea id="voteNotesInput" rows="3"></textarea>
+        </label>
+        <menu class="dialog-actions">
+          <button value="cancel" class="secondary">Cancel</button>
+          <button value="default" class="primary">Save</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <script type="module" src="script.js"></script>
+  </body>
+</html>

--- a/madia.new/public/script.js
+++ b/madia.new/public/script.js
@@ -1,0 +1,355 @@
+import { initializeApp } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-app.js";
+import {
+  getAuth,
+  onAuthStateChanged,
+  signInWithPopup,
+  signOut,
+  GoogleAuthProvider,
+} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
+import {
+  getFirestore,
+  collection,
+  addDoc,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  orderBy,
+  query,
+  serverTimestamp,
+  updateDoc,
+  getDoc,
+  increment,
+  getDocs,
+} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
+
+// TODO: Replace with your project's firebaseConfig. The README explains how.
+const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_STORAGE_BUCKET",
+  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+  appId: "YOUR_APP_ID",
+};
+
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+const db = getFirestore(app);
+const provider = new GoogleAuthProvider();
+
+const missingConfig = Object.values(firebaseConfig).some(
+  (value) => typeof value === "string" && value.startsWith("YOUR_")
+);
+
+if (missingConfig) {
+  const warning = document.createElement("aside");
+  warning.className = "config-warning";
+  warning.innerHTML = `
+    <strong>Firebase configuration required</strong>
+    <p>
+      Replace the <code>YOUR_*</code> values in <code>public/script.js</code> with
+      your Firebase web app credentials. See <code>madia.new/README.md</code> for
+      detailed setup instructions.
+    </p>
+  `;
+  document.body.prepend(warning);
+}
+
+const els = {
+  authStatus: document.getElementById("authStatus"),
+  signInButton: document.getElementById("signInButton"),
+  signOutButton: document.getElementById("signOutButton"),
+  newThreadButton: document.getElementById("newThreadButton"),
+  threadsList: document.getElementById("threadsList"),
+  threadTitle: document.getElementById("threadTitle"),
+  threadMetadata: document.getElementById("threadMetadata"),
+  postsList: document.getElementById("postsList"),
+  replyForm: document.getElementById("replyForm"),
+  replyBody: document.getElementById("replyBody"),
+  deleteThread: document.getElementById("deleteThread"),
+  refreshThread: document.getElementById("refreshThread"),
+  recordVoteButton: document.getElementById("recordVoteButton"),
+  voteTableBody: document.querySelector("#voteTable tbody"),
+  threadDialog: document.getElementById("threadDialog"),
+  threadForm: document.getElementById("threadForm"),
+  threadTitleInput: document.getElementById("threadTitleInput"),
+  threadBodyInput: document.getElementById("threadBodyInput"),
+  voteDialog: document.getElementById("voteDialog"),
+  voteForm: document.getElementById("voteForm"),
+  votePlayerInput: document.getElementById("votePlayerInput"),
+  voteCountInput: document.getElementById("voteCountInput"),
+  voteNotesInput: document.getElementById("voteNotesInput"),
+};
+
+if (missingConfig) {
+  els.authStatus.textContent = "Firebase project not configured";
+  els.signInButton.disabled = true;
+  els.signOutButton.disabled = true;
+  els.newThreadButton.disabled = true;
+  els.recordVoteButton.disabled = true;
+  const main = document.querySelector("main");
+  if (main) {
+    main.innerHTML = `<p class="empty-state">Configure Firebase to load threads and game data.</p>`;
+  }
+}
+
+let currentUser = null;
+let selectedThreadId = null;
+let unsubscribePosts = null;
+
+function requireAuth(action) {
+  return (...args) => {
+    if (!currentUser) {
+      alert("Sign in to perform this action.");
+      return;
+    }
+    action(...args);
+  };
+}
+
+function renderThread(threadId, data) {
+  const li = document.createElement("li");
+  li.dataset.id = threadId;
+  li.innerHTML = `
+    <div class="thread-title">${data.title}</div>
+    <div class="thread-meta">Created by ${data.createdByName || "Unknown"} · ${formatTimestamp(
+    data.createdAt
+  )}</div>
+    <div class="thread-count">${data.postCount || 1} posts</div>
+  `;
+  if (threadId === selectedThreadId) {
+    li.classList.add("active");
+  }
+  li.addEventListener("click", () => {
+    selectThread(threadId);
+  });
+  return li;
+}
+
+function formatTimestamp(timestamp) {
+  if (!timestamp) return "just now";
+  const date = timestamp.toDate ? timestamp.toDate() : timestamp;
+  return date.toLocaleString();
+}
+
+async function selectThread(threadId) {
+  if (unsubscribePosts) {
+    unsubscribePosts();
+    unsubscribePosts = null;
+  }
+  selectedThreadId = threadId;
+  els.postsList.innerHTML = "";
+  els.threadTitle.textContent = "Loading thread...";
+  els.threadMetadata.textContent = "";
+  els.deleteThread.hidden = true;
+  els.replyForm.hidden = !currentUser;
+
+  const threadRef = doc(db, "threads", threadId);
+  const snapshot = await getDoc(threadRef);
+  if (!snapshot.exists()) {
+    els.threadTitle.textContent = "Thread not found";
+    return;
+  }
+  const thread = snapshot.data();
+  els.threadTitle.textContent = thread.title;
+  els.threadMetadata.textContent = `Created by ${
+    thread.createdByName || "Unknown"
+  } on ${formatTimestamp(thread.createdAt)}`;
+  els.deleteThread.hidden = !currentUser || thread.createdBy !== currentUser.uid;
+
+  unsubscribePosts = onSnapshot(
+    query(collection(threadRef, "posts"), orderBy("createdAt", "asc")),
+    (snapshot) => {
+      els.postsList.innerHTML = "";
+      snapshot.forEach((docSnapshot) => {
+        const post = docSnapshot.data();
+        const li = document.createElement("li");
+        li.innerHTML = `
+          <div class="post-author">${post.authorName || "Unknown"}</div>
+          <div class="post-body">${post.body || ""}</div>
+          <div class="post-meta">${formatTimestamp(post.createdAt)}</div>
+        `;
+        els.postsList.appendChild(li);
+      });
+    }
+  );
+}
+
+function watchThreads() {
+  const threadsRef = collection(db, "threads");
+  const threadsQuery = query(threadsRef, orderBy("createdAt", "desc"));
+  return onSnapshot(threadsQuery, (snapshot) => {
+    els.threadsList.innerHTML = "";
+    snapshot.forEach((docSnapshot) => {
+      const thread = docSnapshot.data();
+      const li = renderThread(docSnapshot.id, thread);
+      els.threadsList.appendChild(li);
+    });
+  });
+}
+
+async function createThread(title, body) {
+  const threadsRef = collection(db, "threads");
+  const newThread = await addDoc(threadsRef, {
+    title,
+    createdBy: currentUser.uid,
+    createdByName: currentUser.displayName,
+    createdAt: serverTimestamp(),
+    postCount: 1,
+  });
+  const postRef = collection(db, "threads", newThread.id, "posts");
+  await addDoc(postRef, {
+    author: currentUser.uid,
+    authorName: currentUser.displayName,
+    body,
+    createdAt: serverTimestamp(),
+  });
+  selectThread(newThread.id);
+}
+
+async function deleteCurrentThread() {
+  if (!selectedThreadId) return;
+  if (!confirm("Delete this thread? This cannot be undone.")) return;
+  const postsRef = collection(db, "threads", selectedThreadId, "posts");
+  const postsSnapshot = await getDocs(postsRef);
+  await Promise.all(postsSnapshot.docs.map((docSnapshot) => deleteDoc(docSnapshot.ref)));
+  await deleteDoc(doc(db, "threads", selectedThreadId));
+  selectedThreadId = null;
+  els.threadTitle.textContent = "Select a thread";
+  els.threadMetadata.textContent = "";
+  els.postsList.innerHTML = "";
+}
+
+async function submitReply(event) {
+  event.preventDefault();
+  if (!selectedThreadId) return;
+  const body = els.replyBody.value.trim();
+  if (!body) return;
+  const postRef = collection(db, "threads", selectedThreadId, "posts");
+  await addDoc(postRef, {
+    author: currentUser.uid,
+    authorName: currentUser.displayName,
+    body,
+    createdAt: serverTimestamp(),
+  });
+  els.replyBody.value = "";
+  const threadRef = doc(db, "threads", selectedThreadId);
+  await updateDoc(threadRef, {
+    postCount: increment(1),
+  });
+}
+
+async function recordVote(player, votes, notes) {
+  const voteRef = collection(db, "votes");
+  await addDoc(voteRef, {
+    player,
+    votes,
+    notes,
+    recordedBy: currentUser.uid,
+    recordedByName: currentUser.displayName,
+    createdAt: serverTimestamp(),
+  });
+}
+
+function watchVotes() {
+  const voteRef = collection(db, "votes");
+  return onSnapshot(query(voteRef, orderBy("createdAt", "desc")), (snapshot) => {
+    els.voteTableBody.innerHTML = "";
+    snapshot.forEach((docSnapshot) => {
+      const vote = docSnapshot.data();
+      const tr = document.createElement("tr");
+      tr.innerHTML = `
+        <td>${vote.player}</td>
+        <td>${vote.votes}</td>
+        <td>
+          <div>${vote.notes || ""}</div>
+          <div class="post-meta">Recorded by ${vote.recordedByName || "Unknown"} · ${formatTimestamp(
+        vote.createdAt
+      )}</div>
+        </td>
+      `;
+      els.voteTableBody.appendChild(tr);
+    });
+  });
+}
+
+let unsubscribeThreads = null;
+let unsubscribeVotes = null;
+
+if (!missingConfig) {
+  unsubscribeThreads = watchThreads();
+  unsubscribeVotes = watchVotes();
+
+  els.signInButton.addEventListener("click", () => {
+    signInWithPopup(auth, provider).catch((error) => {
+      console.error(error);
+      alert("Failed to sign in. Check the console for details.");
+    });
+  });
+  els.signOutButton.addEventListener("click", () => signOut(auth));
+  els.newThreadButton.addEventListener("click", requireAuth(() => {
+    els.threadDialog.showModal();
+  }));
+  els.threadForm.addEventListener("close", () => {
+    if (els.threadForm.returnValue === "default") {
+      const title = els.threadTitleInput.value.trim();
+      const body = els.threadBodyInput.value.trim();
+      if (title && body) {
+        createThread(title, body).catch((error) => {
+          console.error(error);
+          alert("Unable to create thread.");
+        });
+      }
+    }
+    els.threadTitleInput.value = "";
+    els.threadBodyInput.value = "";
+  });
+  els.deleteThread.addEventListener("click", requireAuth(deleteCurrentThread));
+  els.replyForm.addEventListener("submit", requireAuth(submitReply));
+  els.refreshThread.addEventListener("click", () => {
+    if (selectedThreadId) {
+      selectThread(selectedThreadId);
+    }
+  });
+  els.recordVoteButton.addEventListener("click", requireAuth(() => {
+    els.voteDialog.showModal();
+  }));
+  els.voteForm.addEventListener("close", () => {
+    if (els.voteForm.returnValue === "default") {
+      const player = els.votePlayerInput.value.trim();
+      const votes = parseInt(els.voteCountInput.value, 10) || 0;
+      const notes = els.voteNotesInput.value.trim();
+      if (player) {
+        recordVote(player, votes, notes).catch((error) => {
+          console.error(error);
+          alert("Unable to record vote.");
+        });
+      }
+    }
+    els.votePlayerInput.value = "";
+    els.voteCountInput.value = "1";
+    els.voteNotesInput.value = "";
+  });
+
+  onAuthStateChanged(auth, (user) => {
+    currentUser = user;
+    if (user) {
+      els.authStatus.textContent = `Signed in as ${user.displayName}`;
+      els.signInButton.hidden = true;
+      els.signOutButton.hidden = false;
+      els.replyForm.hidden = !selectedThreadId;
+    } else {
+      els.authStatus.textContent = "Not signed in";
+      els.signInButton.hidden = false;
+      els.signOutButton.hidden = true;
+      els.replyForm.hidden = true;
+      els.deleteThread.hidden = true;
+    }
+  });
+
+  window.addEventListener("beforeunload", () => {
+    unsubscribeThreads?.();
+    unsubscribePosts?.();
+    unsubscribeVotes?.();
+  });
+}

--- a/madia.new/public/styles.css
+++ b/madia.new/public/styles.css
@@ -1,0 +1,237 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #0f172a;
+  color: #f1f5f9;
+  --panel-bg: rgba(30, 41, 59, 0.85);
+  --panel-border: rgba(148, 163, 184, 0.2);
+  --accent: #38bdf8;
+  --danger: #ef4444;
+  --muted: #94a3b8;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.2), transparent 45%),
+    radial-gradient(circle at bottom, rgba(248, 113, 113, 0.15), transparent 40%),
+    #0f172a;
+}
+
+.config-warning {
+  margin: 0;
+  padding: 1rem clamp(1rem, 3vw, 3rem);
+  background: rgba(250, 204, 21, 0.15);
+  border-bottom: 1px solid rgba(250, 204, 21, 0.4);
+  color: #fcd34d;
+  font-size: 0.95rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.config-warning code {
+  background: rgba(15, 23, 42, 0.6);
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.35rem;
+}
+
+header {
+  padding: 2rem clamp(1rem, 3vw, 3rem);
+  text-align: center;
+}
+
+h1 {
+  margin-bottom: 0.25rem;
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  letter-spacing: 0.05em;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--muted);
+}
+
+.auth-controls {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+main {
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.5rem clamp(1rem, 3vw, 3rem) 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.panel {
+  backdrop-filter: blur(16px);
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.55);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 3rem 1rem;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.5);
+  color: var(--muted);
+  font-size: 1rem;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.panel-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.list li {
+  border: 1px solid var(--panel-border);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.list li:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+}
+
+.list li.active {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
+}
+
+.metadata {
+  color: var(--muted);
+  font-size: 0.875rem;
+}
+
+.posts li {
+  cursor: default;
+}
+
+.posts .post-author {
+  font-weight: 600;
+}
+
+.posts .post-body {
+  margin: 0.5rem 0;
+  white-space: pre-wrap;
+}
+
+.posts .post-meta {
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+  border-radius: 0.6rem;
+  border: 1px solid transparent;
+  padding: 0.6rem 1rem;
+  background: rgba(15, 23, 42, 0.7);
+  color: inherit;
+}
+
+button {
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+button.primary {
+  background: linear-gradient(135deg, #38bdf8, #0ea5e9);
+  box-shadow: 0 10px 25px -10px rgba(14, 165, 233, 0.8);
+}
+
+button.secondary {
+  border-color: rgba(148, 163, 184, 0.2);
+}
+
+button.danger {
+  background: linear-gradient(135deg, #ef4444, #f97316);
+  box-shadow: 0 10px 25px -10px rgba(239, 68, 68, 0.8);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.form textarea,
+.form input {
+  width: 100%;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+#voteTable {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+#voteTable th,
+#voteTable td {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+
+#voteTable tbody tr:hover {
+  background: rgba(56, 189, 248, 0.1);
+}
+
+@media (max-width: 768px) {
+  header {
+    padding-bottom: 0.5rem;
+  }
+
+  main {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `madia.new` Firebase project that modernizes the legacy ASP forum and Mafia helper
- build a single-page application with Google sign-in, Firestore-backed threads, and a vote dashboard
- document Firebase CLI, Google Cloud Console setup, emulator usage, and deployment steps in README

## Testing
- not run (static Firebase web app)


------
https://chatgpt.com/codex/tasks/task_e_68d593679ac48328b47c4d3874b0c52a