### PR TITLE
feat: add legacy parity pages

### DIFF
--- a/madia.new/public/legacy/firebase.js
+++ b/madia.new/public/legacy/firebase.js
@@ -1,0 +1,27 @@
+import { initializeApp } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-app.js";
+import {
+  getAuth,
+  GoogleAuthProvider,
+} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
+import { getFirestore } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
+
+const firebaseConfig = {
+  apiKey: "AIzaSyDLVQ_ncruYo7Xd0tCzh8RIvlmzhrQYt_8",
+  authDomain: "mafia-c37ad.firebaseapp.com",
+  projectId: "mafia-c37ad",
+  storageBucket: "mafia-c37ad.firebasestorage.app",
+  messagingSenderId: "7209477847",
+  appId: "1:7209477847:web:19dd92af0e42324b62f292",
+};
+
+const missingConfig = Object.values(firebaseConfig).some(
+  (value) => typeof value === "string" && value.startsWith("YOUR_")
+);
+
+const app = initializeApp(firebaseConfig);
+
+const auth = getAuth(app);
+const db = getFirestore(app);
+const provider = new GoogleAuthProvider();
+
+export { app, auth, db, provider, firebaseConfig, missingConfig };

--- a/madia.new/public/legacy/game.html
+++ b/madia.new/public/legacy/game.html
@@ -32,6 +32,10 @@
             <tbody id="gameMeta"></tbody>
           </table>
 
+          <div class="smallfont" style="margin:6px 2px;">
+            <a id="playerListLink" href="#">view player list</a>
+          </div>
+
           <div id="postsContainer" style="margin-top:10px;"></div>
 
           <!-- Quick reply / actions -->

--- a/madia.new/public/legacy/game.js
+++ b/madia.new/public/legacy/game.js
@@ -1,13 +1,9 @@
-import { initializeApp } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-app.js";
 import {
-  getAuth,
   onAuthStateChanged,
   signInWithPopup,
   signOut,
-  GoogleAuthProvider,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
 import {
-  getFirestore,
   doc,
   getDoc,
   collection,
@@ -21,26 +17,12 @@ import {
   deleteDoc,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
 import { ubbToHtml } from "/legacy/ubb.js";
+import { auth, db, provider, missingConfig } from "./firebase.js";
 
 function getParam(name) {
   const params = new URLSearchParams(location.search);
   return params.get(name);
 }
-
-// Configure Firebase (fill with your values or share a config loader)
-const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_AUTH_DOMAIN",
-  projectId: "YOUR_PROJECT_ID",
-  storageBucket: "YOUR_BUCKET",
-  messagingSenderId: "YOUR_SENDER_ID",
-  appId: "YOUR_APP_ID",
-};
-
-const app = initializeApp(firebaseConfig);
-const auth = getAuth(app);
-const db = getFirestore(app);
-const provider = new GoogleAuthProvider();
 
 const els = {
   gameTitle: document.getElementById("gameTitle"),
@@ -59,6 +41,7 @@ const els = {
   toggleOpen: document.getElementById("toggleOpen"),
   toggleActive: document.getElementById("toggleActive"),
   nextDay: document.getElementById("nextDay"),
+  playerListLink: document.getElementById("playerListLink"),
 };
 
 onAuthStateChanged(auth, (user) => {
@@ -73,6 +56,10 @@ els.signOut.addEventListener("click", async () => signOut(auth));
 const gameId = getParam("g");
 if (!gameId) {
   els.gameTitle.textContent = "Missing game id";
+}
+
+if (els.playerListLink && gameId) {
+  els.playerListLink.href = `/legacy/playerlist.html?g=${encodeURIComponent(gameId)}`;
 }
 
 function wrapTbody(html) {
@@ -132,6 +119,12 @@ function postRow(post, alt) {
 }
 
 async function loadGame() {
+  if (missingConfig) {
+    els.gameTitle.textContent = "Firebase configuration required";
+    els.gameMeta.innerHTML = "";
+    els.postsContainer.innerHTML = "";
+    return;
+  }
   const gameRef = doc(db, "games", gameId);
   const gSnap = await getDoc(gameRef);
   if (!gSnap.exists()) {

--- a/madia.new/public/legacy/index.html
+++ b/madia.new/public/legacy/index.html
@@ -12,7 +12,7 @@
       <div class="page" style="width:98%; text-align:left">
         <div style="padding:0px 10px 0px 10px">
           <div style="margin:10px 0;">
-            <a href="#" id="siteSummaryLink">site summary</a>
+            <a href="/legacy/sitesummary.html" id="siteSummaryLink">site summary</a>
             <a href="/legacy/member.html" id="profileLink" style="margin-left:12px; display:none;">profile</a>
             <span style="float:right" class="smallfont" id="authArea">
               <button id="signIn" class="button">Sign in with Google</button>

--- a/madia.new/public/legacy/member.html
+++ b/madia.new/public/legacy/member.html
@@ -14,6 +14,7 @@
             <tr>
               <td class="page" valign="bottom" width="100%">
                 <span class="navbar"><a href="/legacy/index.html" accesskey="1">List of Games</a></span>
+                <span class="navbar">&gt; <a href="/legacy/userlist.html">Member List</a></span>
                 &raquo; <strong>View Profile</strong>
               </td>
             </tr>

--- a/madia.new/public/legacy/member.js
+++ b/madia.new/public/legacy/member.js
@@ -1,12 +1,5 @@
-import { initializeApp } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-app.js";
+import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
 import {
-  getAuth,
-  onAuthStateChanged,
-  signInWithPopup,
-  GoogleAuthProvider,
-} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
-import {
-  getFirestore,
   collection,
   collectionGroup,
   query,
@@ -16,26 +9,14 @@ import {
   doc,
   serverTimestamp,
   setDoc,
+  getDoc,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
+import { auth, db, missingConfig } from "./firebase.js";
 
 function getParam(name) {
   const params = new URLSearchParams(location.search);
   return params.get(name);
 }
-
-const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_AUTH_DOMAIN",
-  projectId: "YOUR_PROJECT_ID",
-  storageBucket: "YOUR_BUCKET",
-  messagingSenderId: "YOUR_SENDER_ID",
-  appId: "YOUR_APP_ID",
-};
-
-const app = initializeApp(firebaseConfig);
-const auth = getAuth(app);
-const db = getFirestore(app);
-const provider = new GoogleAuthProvider();
 
 const els = {
   profileInfo: document.getElementById("profileInfo"),
@@ -70,6 +51,11 @@ function renderProfileHeader() {
 }
 
 async function loadLists() {
+  if (missingConfig) {
+    els.gamesYouPlay.innerHTML = `<div class="smallfont" style="color:#F9A906;">Configure Firebase to load games.</div>`;
+    els.gamesYouOwn.innerHTML = `<div class="smallfont" style="color:#F9A906;">Configure Firebase to load games.</div>`;
+    return;
+  }
   els.gamesYouPlay.innerHTML = groupSectionSkeleton();
   els.gamesYouOwn.innerHTML = groupSectionSkeleton();
 
@@ -88,8 +74,12 @@ async function loadLists() {
   });
   const plays = [];
   for (const gid of gameIds) {
-    const d = await (await import("https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js")).getDoc(doc(db, "games", gid));
-    if (d.exists()) plays.push({ id: gid, ...d.data() });
+    try {
+      const d = await getDoc(doc(db, "games", gid));
+      if (d.exists()) plays.push({ id: gid, ...d.data() });
+    } catch (err) {
+      console.warn("Failed to load game", gid, err);
+    }
   }
   renderGrouped(els.gamesYouPlay, plays);
 }
@@ -113,7 +103,7 @@ function renderGrouped(container, games) {
   }
   for (const g of games.sort((a,b)=> (b.active - a.active) || ((b.open|0)-(a.open|0)) || String(a.gamename||"").localeCompare(String(b.gamename||"")))) {
     const a = document.createElement("div");
-    a.innerHTML = `<a href="/legacy/gamedisplay.html?g=${g.id}">${g.gamename || "(no name)"}</a>`;
+    a.innerHTML = `<a href="/legacy/game.html?g=${g.id}">${g.gamename || "(no name)"}</a>`;
     const bucket = g.active ? ((g.day||0)===0 ? open : running) : over;
     bucket.appendChild(a);
   }

--- a/madia.new/public/legacy/playerlist.html
+++ b/madia.new/public/legacy/playerlist.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Player List</title>
+    <link rel="stylesheet" href="/legacy/phalla.css" />
+  </head>
+  <body>
+    <div align="center">
+      <div class="page" style="width:98%; text-align:left">
+        <div style="padding:0px 10px 0px 10px">
+          <table class="page" cellpadding="4" cellspacing="1" border="0" width="100%" align="center">
+            <tr>
+              <td class="page" valign="bottom" width="100%">
+                <span class="navbar"><a href="/legacy/index.html" accesskey="1">List of Games</a></span>
+                <span class="navbar" id="gameBreadcrumb"></span>
+                &raquo; <strong>Player List</strong>
+              </td>
+            </tr>
+          </table>
+
+          <table class="tborder" cellpadding="4" cellspacing="1" border="0" width="100%" align="center">
+            <tr>
+              <td class="tcat" colspan="2">Players</td>
+            </tr>
+            <tbody id="playerRows">
+              <tr><td class="alt1" colspan="2" align="center">Loading players...</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <script type="module" src="/legacy/playerlist.js"></script>
+  </body>
+</html>

--- a/madia.new/public/legacy/playerlist.js
+++ b/madia.new/public/legacy/playerlist.js
@@ -1,0 +1,88 @@
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
+import { db, missingConfig } from "./firebase.js";
+
+const playerRows = document.getElementById("playerRows");
+const gameBreadcrumb = document.getElementById("gameBreadcrumb");
+
+const params = new URLSearchParams(location.search);
+const gameId = params.get("g");
+
+if (!gameId) {
+  playerRows.innerHTML = '<tr><td class="alt1" colspan="2" align="center">Missing game id.</td></tr>';
+} else if (missingConfig) {
+  renderConfigWarning();
+} else {
+  loadPlayers().catch((err) => renderError(err.message));
+}
+
+function renderConfigWarning() {
+  playerRows.innerHTML = `
+    <tr><td class="alt1" colspan="2" align="center" style="color:#F9A906;">Configure Firebase to load players.</td></tr>
+  `;
+}
+
+function renderError(message) {
+  playerRows.innerHTML = `
+    <tr><td class="alt1" colspan="2" align="center" style="color:#F9A906;">Failed to load players: ${message}</td></tr>
+  `;
+}
+
+async function loadPlayers() {
+  playerRows.innerHTML = "";
+  const gameRef = doc(db, "games", gameId);
+  const gameSnap = await getDoc(gameRef);
+  if (gameSnap.exists()) {
+    const gameName = gameSnap.data().gamename || "(no name)";
+    gameBreadcrumb.innerHTML = `&gt; <a href="/legacy/game.html?g=${encodeURIComponent(gameId)}">${escapeHtml(gameName)}</a>`;
+  }
+
+  const playersSnap = await getDocs(collection(gameRef, "players"));
+  if (playersSnap.empty) {
+    playerRows.innerHTML = '<tr><td class="alt1" colspan="2" align="center"><i>No players joined.</i></td></tr>';
+    return;
+  }
+
+  const entries = playersSnap.docs
+    .map((snap) => ({ id: snap.id, data: snap.data() }))
+    .sort((a, b) => {
+      const aName = (a.data.name || a.data.username || "").toLowerCase();
+      const bName = (b.data.name || b.data.username || "").toLowerCase();
+      return aName.localeCompare(bName);
+    });
+
+  entries.forEach((entry, idx) => {
+    playerRows.appendChild(renderRow(entry, idx % 2 === 0));
+  });
+}
+
+function renderRow(entry, even) {
+  const tr = document.createElement("tr");
+  tr.setAttribute("align", "left");
+
+  const nameTd = document.createElement("td");
+  nameTd.className = even ? "alt1Active" : "alt1";
+  nameTd.innerHTML = `${escapeHtml(entry.data.name || entry.data.username || entry.id)} <span class="smallfont" style="color:#888;">${entry.data.active === false ? "(inactive)" : ""}</span>`;
+
+  const roleTd = document.createElement("td");
+  roleTd.className = even ? "alt2" : "alt1";
+  const role = entry.data.role || entry.data.rolename || "";
+  roleTd.innerHTML = role ? escapeHtml(role) : "&nbsp;";
+
+  tr.appendChild(nameTd);
+  tr.appendChild(roleTd);
+  return tr;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/madia.new/public/legacy/sitesummary.html
+++ b/madia.new/public/legacy/sitesummary.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phalla Quick Site Summary</title>
+    <link rel="stylesheet" href="/legacy/phalla.css" />
+  </head>
+  <body>
+    <div align="center">
+      <div class="page" style="width:98%; text-align:left">
+        <div style="padding:0px 10px 0px 10px">
+          <a href="/legacy/index.html">list of games</a>
+          <div id="summaryContent" style="margin-top:12px;">
+            <div class="smallfont" style="color:#F9A906;">Loading summary...</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script type="module" src="/legacy/sitesummary.js"></script>
+  </body>
+</html>

--- a/madia.new/public/legacy/sitesummary.js
+++ b/madia.new/public/legacy/sitesummary.js
@@ -1,0 +1,252 @@
+import {
+  collection,
+  collectionGroup,
+  doc,
+  getDoc,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
+import { db, missingConfig } from "./firebase.js";
+
+const summaryContent = document.getElementById("summaryContent");
+
+if (missingConfig) {
+  renderConfigWarning();
+} else {
+  loadSummary().catch((err) => renderError(err.message));
+}
+
+function renderConfigWarning() {
+  summaryContent.innerHTML = `
+    <div class="smallfont" style="color:#F9A906;">
+      Firebase configuration required. Update <code>public/legacy/firebase.js</code> to load site metrics.
+    </div>
+  `;
+}
+
+function renderError(message) {
+  summaryContent.innerHTML = `
+    <div class="smallfont" style="color:#F9A906;">Failed to load summary: ${message}</div>
+  `;
+}
+
+async function loadSummary() {
+  summaryContent.innerHTML = "";
+  const sections = [
+    {
+      title: "Lastest Posts",
+      headers: ["Username", "Game", "Post Title", "Excerpt"],
+      rows: await fetchLatestPosts(),
+    },
+    {
+      title: "Lastest New Players",
+      headers: ["Player Id", "Username", "Game", "Joined"],
+      rows: await fetchLatestPlayers(),
+    },
+    {
+      title: "Lastest Users",
+      headers: ["User Id", "Username", "Joined"],
+      rows: await fetchLatestUsers(),
+    },
+  ];
+
+  for (const section of sections) {
+    summaryContent.appendChild(renderSection(section));
+  }
+}
+
+function renderSection({ title, headers, rows }) {
+  const wrapper = document.createElement("div");
+  wrapper.style.marginBottom = "24px";
+
+  const heading = document.createElement("h2");
+  heading.textContent = title;
+  heading.style.color = "black";
+  wrapper.appendChild(heading);
+
+  const table = document.createElement("table");
+  table.setAttribute("bgcolor", "#DDDDDD");
+  table.style.width = "100%";
+  table.style.borderCollapse = "collapse";
+
+  const theadRow = document.createElement("tr");
+  for (const header of headers) {
+    const th = document.createElement("th");
+    th.textContent = header;
+    th.style.textAlign = "left";
+    th.setAttribute("bgcolor", "#99AADD");
+    theadRow.appendChild(th);
+  }
+  table.appendChild(theadRow);
+
+  let alt = 1;
+  if (!rows.length) {
+    const td = document.createElement("td");
+    td.colSpan = headers.length;
+    td.textContent = "No data";
+    td.style.padding = "6px";
+    table.appendChild(createRow([td], "#DDDD"));
+  } else {
+    for (const row of rows) {
+      alt *= -1;
+      const base = alt === 1 ? "#DDDD" : "#BBBB";
+      const cells = row.map((value, idx) => {
+        const td = document.createElement("td");
+        td.textContent = value ?? "";
+        const shade = idx % 2 === 0 ? `${base}AA` : `${base}BB`;
+        td.setAttribute("bgcolor", shade);
+        td.style.padding = "4px";
+        td.style.verticalAlign = "top";
+        return td;
+      });
+      table.appendChild(createRow(cells));
+    }
+  }
+
+  wrapper.appendChild(table);
+  const hr = document.createElement("hr");
+  wrapper.appendChild(hr);
+  return wrapper;
+}
+
+function createRow(cells, color) {
+  const tr = document.createElement("tr");
+  if (color) {
+    tr.setAttribute("bgcolor", color);
+  }
+  for (const cell of cells) {
+    tr.appendChild(cell);
+  }
+  return tr;
+}
+
+async function fetchLatestPosts() {
+  const rows = [];
+  const gameCache = new Map();
+  const postsQuery = query(
+    collectionGroup(db, "posts"),
+    orderBy("createdAt", "desc"),
+    limit(5)
+  );
+  const postsSnap = await getDocs(postsQuery);
+  for (const snap of postsSnap.docs) {
+    const data = snap.data();
+    const pathParts = snap.ref.path.split("/");
+    const gameId = pathParts.length > 1 ? pathParts[1] : null;
+    let gameName = "";
+    if (gameId) {
+      if (!gameCache.has(gameId)) {
+        try {
+          const gameSnap = await getDoc(doc(db, "games", gameId));
+          gameCache.set(gameId, gameSnap.exists() ? gameSnap.data().gamename || "" : "");
+        } catch (err) {
+          gameCache.set(gameId, "");
+          console.warn("Failed to load game name", err);
+        }
+      }
+      gameName = gameCache.get(gameId) || "";
+    }
+    rows.push([
+      data.authorName || "Unknown",
+      gameName || gameId || "",
+      data.title || "(no title)",
+      truncate(stripHtml(data.body || ""), 80),
+    ]);
+  }
+  return rows;
+}
+
+async function fetchLatestPlayers() {
+  const rows = [];
+  const gameCache = new Map();
+  const playerSnaps = await getDocs(collectionGroup(db, "players"));
+  const docs = playerSnaps.docs
+    .map((snap) => ({
+      id: snap.id,
+      path: snap.ref.path,
+      data: snap.data(),
+    }))
+    .sort((a, b) => coerceMillis(b.data) - coerceMillis(a.data))
+    .slice(0, 5);
+
+  for (const entry of docs) {
+    const pathParts = entry.path.split("/");
+    const gameId = pathParts.length > 1 ? pathParts[1] : null;
+    let gameName = "";
+    if (gameId) {
+      if (!gameCache.has(gameId)) {
+        try {
+          const gameSnap = await getDoc(doc(db, "games", gameId));
+          gameCache.set(gameId, gameSnap.exists() ? gameSnap.data().gamename || "" : "");
+        } catch (err) {
+          gameCache.set(gameId, "");
+        }
+      }
+      gameName = gameCache.get(gameId) || "";
+    }
+    rows.push([
+      entry.id,
+      entry.data.name || entry.data.username || "Unknown",
+      gameName || gameId || "",
+      formatDate(entry.data.joinedAt || entry.data.createdAt || null),
+    ]);
+  }
+  return rows;
+}
+
+async function fetchLatestUsers() {
+  const rows = [];
+  const usersSnap = await getDocs(collection(db, "users"));
+  const docs = usersSnap.docs
+    .map((snap) => ({ id: snap.id, data: snap.data() }))
+    .sort((a, b) => coerceMillis(b.data) - coerceMillis(a.data))
+    .slice(0, 5);
+
+  for (const entry of docs) {
+    rows.push([
+      entry.id,
+      entry.data.displayName || entry.data.username || "Unknown",
+      formatDate(entry.data.createdAt || entry.data.joinedAt || null),
+    ]);
+  }
+  return rows;
+}
+
+function stripHtml(value) {
+  const tmp = document.createElement("div");
+  tmp.innerHTML = value;
+  return tmp.textContent || tmp.innerText || "";
+}
+
+function truncate(value, length) {
+  if (!value) return "";
+  return value.length > length ? `${value.slice(0, length)}...` : value;
+}
+
+function coerceMillis(data) {
+  const value = data?.joinedAt || data?.createdAt || data?.updatedAt || null;
+  if (!value) return 0;
+  if (typeof value.toDate === "function") {
+    return value.toDate().getTime();
+  }
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+  if (typeof value === "number") {
+    return value;
+  }
+  return 0;
+}
+
+function formatDate(value) {
+  if (!value) return "";
+  if (typeof value.toDate === "function") {
+    return value.toDate().toLocaleString();
+  }
+  if (value instanceof Date) {
+    return value.toLocaleString();
+  }
+  return "";
+}

--- a/madia.new/public/legacy/userlist.html
+++ b/madia.new/public/legacy/userlist.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Member List</title>
+    <link rel="stylesheet" href="/legacy/phalla.css" />
+  </head>
+  <body>
+    <div align="center">
+      <div class="page" style="width:98%; text-align:left">
+        <div style="padding:0px 10px 0px 10px">
+          <table class="page" cellpadding="4" cellspacing="1" border="0" width="100%" align="center">
+            <tr>
+              <td class="page" valign="bottom" width="100%">
+                <span class="navbar"><a href="/legacy/index.html" accesskey="1">List of Games</a></span>
+                &raquo; <strong>Members List</strong>
+              </td>
+            </tr>
+          </table>
+
+          <table class="tborder" cellpadding="4" cellspacing="1" border="0" width="100%" align="center">
+            <tr align="center">
+              <td class="thead" align="left" nowrap="nowrap">User Name</td>
+              <td class="thead" nowrap="nowrap">Sign-up Date</td>
+              <td class="thead" nowrap="nowrap">Avatar</td>
+            </tr>
+            <tbody id="userRows">
+              <tr><td class="alt1" colspan="3" align="center">Loading members...</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <script type="module" src="/legacy/userlist.js"></script>
+  </body>
+</html>

--- a/madia.new/public/legacy/userlist.js
+++ b/madia.new/public/legacy/userlist.js
@@ -1,0 +1,100 @@
+import { collection, getDocs } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
+import { db, missingConfig } from "./firebase.js";
+
+const userRows = document.getElementById("userRows");
+
+if (missingConfig) {
+  renderConfigWarning();
+} else {
+  loadUsers().catch((err) => renderError(err.message));
+}
+
+function renderConfigWarning() {
+  userRows.innerHTML = `
+    <tr><td class="alt1" colspan="3" align="center" style="color:#F9A906;">Configure Firebase to load members.</td></tr>
+  `;
+}
+
+function renderError(message) {
+  userRows.innerHTML = `
+    <tr><td class="alt1" colspan="3" align="center" style="color:#F9A906;">Failed to load members: ${message}</td></tr>
+  `;
+}
+
+async function loadUsers() {
+  userRows.innerHTML = "";
+  const snapshot = await getDocs(collection(db, "users"));
+  if (snapshot.empty) {
+    userRows.innerHTML = '<tr><td class="alt1" colspan="3" align="center"><i>No members found.</i></td></tr>';
+    return;
+  }
+
+  const docs = snapshot.docs
+    .map((docSnap) => ({ id: docSnap.id, data: docSnap.data() }))
+    .sort((a, b) => {
+      const aName = (a.data.displayName || a.data.username || "").toLowerCase();
+      const bName = (b.data.displayName || b.data.username || "").toLowerCase();
+      return aName.localeCompare(bName);
+    });
+
+  docs.forEach((entry, idx) => {
+    userRows.appendChild(renderRow(entry.id, entry.data, idx % 2 === 0));
+  });
+}
+
+function renderRow(id, data, even) {
+  const tr = document.createElement("tr");
+  tr.setAttribute("align", "center");
+
+  const nameTd = document.createElement("td");
+  nameTd.className = even ? "alt1Active" : "alt1";
+  nameTd.setAttribute("align", "left");
+  nameTd.id = `u-${id}`;
+  const displayName = data.displayName || data.username || "Unknown";
+  const title = data.title || "";
+  nameTd.innerHTML = `
+    <a href="/legacy/member.html?u=${encodeURIComponent(id)}">${escapeHtml(displayName)}</a>
+    <div class="smallfont">${escapeHtml(title)}</div>
+  `;
+
+  const dateTd = document.createElement("td");
+  dateTd.className = even ? "alt2" : "alt1";
+  dateTd.textContent = formatDate(data.createdAt || data.joinedAt || null);
+
+  const avatarTd = document.createElement("td");
+  avatarTd.className = even ? "alt1" : "alt2";
+  avatarTd.innerHTML = renderAvatar(data);
+
+  tr.appendChild(nameTd);
+  tr.appendChild(dateTd);
+  tr.appendChild(avatarTd);
+  return tr;
+}
+
+function renderAvatar(data) {
+  const src = data.avatar || data.photoURL || data.image || "";
+  if (!src) {
+    return "&nbsp;";
+  }
+  return `<img src="${escapeHtml(src)}" border="0" alt="avatar" hspace="4" vspace="4" />`;
+}
+
+function formatDate(value) {
+  if (!value) return "";
+  if (typeof value.toDate === "function") {
+    return value.toDate().toLocaleString();
+  }
+  if (value instanceof Date) {
+    return value.toLocaleString();
+  }
+  return "";
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}


### PR DESCRIPTION
## Summary
- centralize Firebase configuration for the legacy skin and wire the games, game, and member views to it
- add legacy equivalents for the classic site summary, member list, and player list pages with period-accurate markup
- surface navigation links (site summary, user list, player roster) so every mafia.old page has a matching legacy route

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5b2299aa0832893d799691d122802