### PR TITLE
feat: share legacy header include

### DIFF
--- a/madia.new/public/legacy/game.html
+++ b/madia.new/public/legacy/game.html
@@ -10,14 +10,7 @@
     <div align="center">
       <div class="page" style="width:98%; text-align:left">
         <div style="padding:0px 10px 0px 10px">
-          <div style="margin:10px 0;">
-            <a href="/legacy/index.html">&laquo; back to games</a>
-            <span style="float:right" class="smallfont" id="authArea">
-              <span id="userName"></span>
-              <button id="signIn" class="button">Sign in</button>
-              <button id="signOut" class="button" style="display:none">Sign out</button>
-            </span>
-          </div>
+          <div id="legacyHeaderMount"></div>
 
           <table class="tborder" cellpadding="4" cellspacing="1" border="0" width="100%" align="center">
             <thead>

--- a/madia.new/public/legacy/game.js
+++ b/madia.new/public/legacy/game.js
@@ -21,6 +21,7 @@ import {
   deleteDoc,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
 import { ubbToHtml } from "/legacy/ubb.js";
+import { injectLegacyHeader } from "./header.js";
 
 function getParam(name) {
   const params = new URLSearchParams(location.search);
@@ -42,13 +43,17 @@ const auth = getAuth(app);
 const db = getFirestore(app);
 const provider = new GoogleAuthProvider();
 
+const header = injectLegacyHeader({
+  navHtml: `<a href="/legacy/index.html">&laquo; back to games</a>`,
+});
+
 const els = {
   gameTitle: document.getElementById("gameTitle"),
   gameMeta: document.getElementById("gameMeta"),
   postsContainer: document.getElementById("postsContainer"),
-  signIn: document.getElementById("signIn"),
-  signOut: document.getElementById("signOut"),
-  userName: document.getElementById("userName"),
+  signIn: header.signIn,
+  signOut: header.signOut,
+  userName: header.userName,
   replyForm: document.getElementById("replyForm"),
   replyTitle: document.getElementById("replyTitle"),
   replyBody: document.getElementById("replyBody"),
@@ -64,7 +69,9 @@ const els = {
 onAuthStateChanged(auth, (user) => {
   els.signIn.style.display = user ? "none" : "inline-block";
   els.signOut.style.display = user ? "inline-block" : "none";
-  els.userName.textContent = user ? user.displayName : "";
+  if (els.userName) {
+    els.userName.textContent = user ? user.displayName : "";
+  }
   refreshMembershipAndControls();
 });
 els.signIn.addEventListener("click", async () => signInWithPopup(auth, provider));

--- a/madia.new/public/legacy/header.js
+++ b/madia.new/public/legacy/header.js
@@ -1,0 +1,44 @@
+const templateHtml = `
+  <div class="legacy-header">
+    <div class="legacy-header-nav smallfont" data-role="nav"></div>
+    <div class="legacy-header-auth smallfont" data-role="auth">
+      <span data-role="user-name" class="legacy-header-user"></span>
+      <button class="button" data-role="sign-in">Sign in</button>
+      <button class="button" data-role="sign-out" style="display:none;">Sign out</button>
+    </div>
+  </div>
+`;
+
+export function injectLegacyHeader({ mountId = "legacyHeaderMount", navHtml = "" } = {}) {
+  const mount = document.getElementById(mountId);
+  if (!mount) {
+    throw new Error(`Legacy header mount "${mountId}" not found`);
+  }
+
+  const tpl = document.createElement("template");
+  tpl.innerHTML = templateHtml.trim();
+  const headerEl = tpl.content.firstElementChild.cloneNode(true);
+
+  mount.innerHTML = "";
+  mount.appendChild(headerEl);
+
+  const nav = headerEl.querySelector('[data-role="nav"]');
+  if (typeof navHtml === "string") {
+    nav.innerHTML = navHtml;
+  } else if (navHtml && typeof Node !== "undefined" && navHtml instanceof Node) {
+    nav.appendChild(navHtml);
+  }
+
+  const signIn = headerEl.querySelector('[data-role="sign-in"]');
+  const signOut = headerEl.querySelector('[data-role="sign-out"]');
+  const userName = headerEl.querySelector('[data-role="user-name"]');
+
+  return {
+    container: headerEl,
+    nav,
+    signIn,
+    signOut,
+    userName,
+    profileLink: nav.querySelector("#profileLink") || null,
+  };
+}

--- a/madia.new/public/legacy/index.html
+++ b/madia.new/public/legacy/index.html
@@ -11,14 +11,7 @@
     <div align="center">
       <div class="page" style="width:98%; text-align:left">
         <div style="padding:0px 10px 0px 10px">
-          <div style="margin:10px 0;">
-            <a href="#" id="siteSummaryLink">site summary</a>
-            <a href="/legacy/member.html" id="profileLink" style="margin-left:12px; display:none;">profile</a>
-            <span style="float:right" class="smallfont" id="authArea">
-              <button id="signIn" class="button">Sign in with Google</button>
-              <button id="signOut" class="button" style="display:none">Sign out</button>
-            </span>
-          </div>
+          <div id="legacyHeaderMount"></div>
 
           <!-- Games table (games.asp look) -->
           <table class="tborder" cellpadding="4" cellspacing="1" border="0" width="100%" align="center">
@@ -45,4 +38,4 @@
 
     <script type="module" src="/legacy/legacy.js"></script>
   </body>
-  </html>
+</html>

--- a/madia.new/public/legacy/legacy.js
+++ b/madia.new/public/legacy/legacy.js
@@ -19,6 +19,7 @@ import {
   onSnapshot,
   collectionGroup,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
+import { injectLegacyHeader } from "./header.js";
 
 // Reuse root config by importing from /script.js if desired. Inline here for self-containment.
 // Replace with your own project config or share via a small loader.
@@ -36,11 +37,19 @@ const auth = getAuth(app);
 const db = getFirestore(app);
 const provider = new GoogleAuthProvider();
 
+const header = injectLegacyHeader({
+  navHtml: `
+    <a href="#" id="siteSummaryLink">site summary</a>
+    <a href="/legacy/member.html" id="profileLink" style="display:none; margin-left:12px;">profile</a>
+  `,
+});
+
 const els = {
   gamesBody: document.getElementById("gamesBody"),
-  signIn: document.getElementById("signIn"),
-  signOut: document.getElementById("signOut"),
-  profileLink: document.getElementById("profileLink"),
+  signIn: header.signIn,
+  signOut: header.signOut,
+  profileLink: header.profileLink,
+  userName: header.userName,
 };
 
 let currentUser = null;
@@ -50,9 +59,14 @@ onAuthStateChanged(auth, async (user) => {
   currentUser = user;
   els.signIn.style.display = user ? "none" : "inline-block";
   els.signOut.style.display = user ? "inline-block" : "none";
-  els.profileLink.style.display = user ? "inline-block" : "none";
-  if (user) {
-    els.profileLink.href = `/legacy/member.html?u=${encodeURIComponent(user.uid)}`;
+  if (els.profileLink) {
+    els.profileLink.style.display = user ? "inline-block" : "none";
+    if (user) {
+      els.profileLink.href = `/legacy/member.html?u=${encodeURIComponent(user.uid)}`;
+    }
+  }
+  if (els.userName) {
+    els.userName.textContent = user ? `Welcome, ${user.displayName || ""}` : "";
   }
   watchGames();
 });

--- a/madia.new/public/legacy/member.html
+++ b/madia.new/public/legacy/member.html
@@ -10,6 +10,7 @@
     <div align="center">
       <div class="page" style="width:98%; text-align:left">
         <div style="padding:0px 10px 0px 10px">
+          <div id="legacyHeaderMount"></div>
           <table class="page" cellpadding="4" cellspacing="1" border="0" width="100%" align="center">
             <tr>
               <td class="page" valign="bottom" width="100%">

--- a/madia.new/public/legacy/member.js
+++ b/madia.new/public/legacy/member.js
@@ -3,6 +3,7 @@ import {
   getAuth,
   onAuthStateChanged,
   signInWithPopup,
+  signOut,
   GoogleAuthProvider,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
 import {
@@ -17,6 +18,7 @@ import {
   serverTimestamp,
   setDoc,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
+import { injectLegacyHeader } from "./header.js";
 
 function getParam(name) {
   const params = new URLSearchParams(location.search);
@@ -37,6 +39,10 @@ const auth = getAuth(app);
 const db = getFirestore(app);
 const provider = new GoogleAuthProvider();
 
+const header = injectLegacyHeader({
+  navHtml: `<a href="/legacy/index.html">&laquo; back to games</a>`,
+});
+
 const els = {
   profileInfo: document.getElementById("profileInfo"),
   gamesYouPlay: document.getElementById("gamesYouPlay"),
@@ -45,6 +51,9 @@ const els = {
   gameName: document.getElementById("gameName"),
   gameDesc: document.getElementById("gameDesc"),
   createBtn: document.getElementById("createBtn"),
+  signIn: header.signIn,
+  signOut: header.signOut,
+  userName: header.userName,
 };
 
 let currentUser = null;
@@ -52,8 +61,21 @@ const viewedUid = getParam("u");
 
 onAuthStateChanged(auth, async (user) => {
   currentUser = user;
+  els.signIn.style.display = user ? "none" : "inline-block";
+  els.signOut.style.display = user ? "inline-block" : "none";
+  if (els.userName) {
+    els.userName.textContent = user ? user.displayName || "" : "";
+  }
   renderProfileHeader();
   await loadLists();
+});
+
+els.signIn.addEventListener("click", async () => {
+  await signInWithPopup(auth, provider);
+});
+
+els.signOut.addEventListener("click", async () => {
+  await signOut(auth);
 });
 
 function renderProfileHeader() {

--- a/madia.new/public/legacy/phalla.css
+++ b/madia.new/public/legacy/phalla.css
@@ -328,3 +328,27 @@ form { display: inline; }
 label { cursor: default; }
 .normal { font-weight: normal; }
 .inlineimg { vertical-align: middle; }
+
+.legacy-header {
+  margin: 10px 0;
+  overflow: auto;
+}
+
+.legacy-header-nav {
+  float: left;
+}
+
+.legacy-header-nav a {
+  margin-right: 12px;
+}
+
+.legacy-header-auth {
+  float: right;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.legacy-header-user {
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- add a reusable legacy header module so the include content renders on every page
- update the legacy index, game, and member screens to mount the shared header and hook into Firebase auth state
- style the shared header so navigation and auth controls mirror the legacy layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5b29f81888328b41bebea261f1abf