### PR TITLE
fix: guard realtime listeners behind auth

### DIFF
--- a/madia.new/public/styles.css
+++ b/madia.new/public/styles.css
@@ -90,6 +90,24 @@ main {
   font-size: 1rem;
 }
 
+.list .empty-message,
+.posts .empty-message {
+  list-style: none;
+  text-align: center;
+  padding: 1.5rem 1rem;
+  border: 1px dashed var(--panel-border);
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.5);
+  color: var(--muted);
+  cursor: default;
+}
+
+.table-empty td {
+  text-align: center;
+  padding: 1rem;
+  color: var(--muted);
+}
+
 .panel-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- defer thread, post, and vote listeners until a user is authenticated to avoid Firestore permission errors
- add friendly loading, empty, and error states for threads, posts, votes, and legacy games tables
- style the new empty states for list and table placeholders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5c09ac84c8328b10ed076ef39f7ab