### PR TITLE
fix: remove nested tbody wrappers from legacy tables

### DIFF
--- a/madia.new/public/legacy/game.js
+++ b/madia.new/public/legacy/game.js
@@ -62,13 +62,11 @@ if (els.playerListLink && gameId) {
   els.playerListLink.href = `/legacy/playerlist.html?g=${encodeURIComponent(gameId)}`;
 }
 
-function wrapTbody(html) {
-  const tbody = document.createElement("tbody");
+function createMetaRow(html) {
   const tr = document.createElement("tr");
   tr.setAttribute("align", "center");
   tr.innerHTML = html;
-  tbody.appendChild(tr);
-  return tbody;
+  return tr;
 }
 
 function postRow(post, alt) {
@@ -156,7 +154,7 @@ async function loadGame() {
 
   els.gameMeta.innerHTML = "";
   els.gameMeta.appendChild(
-    wrapTbody(`
+    createMetaRow(`
       <td class="alt2">&nbsp;</td>
       <td class="alt2" nowrap="nowrap">
         <div class="smallfont" align="left"><a title="not clickable"><strong>${lastTitle}</strong></a></div>

--- a/madia.new/public/legacy/legacy.js
+++ b/madia.new/public/legacy/legacy.js
@@ -88,9 +88,7 @@ function sectionHeader(label) {
       ${label}
     </td>
   `;
-  const tbody = document.createElement("tbody");
-  tbody.appendChild(tr);
-  return tbody;
+  return tr;
 }
 
 function gameRow(game, meta) {
@@ -138,9 +136,7 @@ function gameRow(game, meta) {
     <td class="alt1">${game.day ?? 0}</td>
     <td class="alt2">${game.open ? "Yes" : "No"}</td>
   `;
-  const tbody = document.createElement("tbody");
-  tbody.appendChild(tr);
-  return tbody;
+  return tr;
 }
 
 function watchGames() {


### PR DESCRIPTION
## Summary
- update the legacy game view to append meta rows directly so the header aligns with the body
- change legacy index helpers to return table rows instead of nested `<tbody>` wrappers
- reviewed other legacy pages to confirm they already append rows directly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d69e97379c8328935ca184ec7eadd5