### PR TITLE
Add Firebase preview deploy GitHub Action

### DIFF
--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -1,0 +1,32 @@
+name: Firebase preview deploy
+
+on:
+  push:
+    paths:
+      - 'madia.new/**'
+  pull_request:
+    paths:
+      - 'madia.new/**'
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: madia.new
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install Firebase CLI
+        run: npm install --global firebase-tools
+
+      - name: Deploy preview channel
+        run: firebase hosting:channel:deploy preview --non-interactive
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/madia.new/README.md
+++ b/madia.new/README.md
@@ -160,7 +160,9 @@ These rules cover every collection the modern and legacy UIs touch (games, playe
    firebase hosting:channel:deploy preview
    ```
 
-3. When satisfied, deploy to production:
+3. GitHub Actions can automatically run the preview deploy for any pull request or push that touches `madia.new/**`. Configure a repository secret named `FIREBASE_TOKEN` (generated with `firebase login:ci`) so the workflow can authenticate, and the deploy job will output the preview channel URL.
+
+4. When satisfied, deploy to production:
 
    ```bash
    firebase deploy --only hosting
@@ -168,7 +170,7 @@ These rules cover every collection the modern and legacy UIs touch (games, playe
 
    The CLI prints the live URL (e.g., `https://<project-id>.web.app`).
 
-4. (Optional) In the Firebase console under **Build → Hosting**, connect a custom domain and follow the DNS verification steps.
+5. (Optional) In the Firebase console under **Build → Hosting**, connect a custom domain and follow the DNS verification steps.
 
 ## 5. Monitor and maintain
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that deploys the Firebase preview channel whenever `madia.new/**` changes
- document the required `FIREBASE_TOKEN` secret so the workflow can authenticate with Firebase

## Testing
- not run (CI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d69d78abf48328942ff428f4e97394