### PR TITLE
Require authentication before loading legacy site summary

### DIFF
--- a/madia.new/public/legacy/sitesummary.html
+++ b/madia.new/public/legacy/sitesummary.html
@@ -10,9 +10,25 @@
     <div align="center">
       <div class="page" style="width:98%; text-align:left">
         <div style="padding:0px 10px 0px 10px">
-          <a href="/legacy/index.html">list of games</a>
+          <div style="margin:10px 0;">
+            <a href="/legacy/index.html">list of games</a>
+            <a
+              href="/legacy/member.html"
+              id="profileLink"
+              style="margin-left:12px; display:none;"
+              >profile</a
+            >
+            <span style="float:right" class="smallfont" id="authArea">
+              <button id="signIn" class="button">Sign in with Google</button>
+              <button id="signOut" class="button" style="display:none">
+                Sign out
+              </button>
+            </span>
+          </div>
           <div id="summaryContent" style="margin-top:12px;">
-            <div class="smallfont" style="color:#F9A906;">Loading summary...</div>
+            <div class="smallfont" style="color:#F9A906;">
+              Sign in to view site summary.
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add authentication controls to the legacy summary page header
- only load Firestore data after sign-in and show clearer permission messaging

## Testing
- not run (static files only)


------
https://chatgpt.com/codex/tasks/task_e_68d6ad009f5c83289083f2421bde895b