### PR TITLE
feat: add legacy header to madia pages

### DIFF
--- a/madia.new/public/legacy/game.html
+++ b/madia.new/public/legacy/game.html
@@ -7,16 +7,12 @@
     <link rel="stylesheet" href="/legacy/phalla.css" />
   </head>
   <body>
+    <div id="legacyHeader"></div>
     <div align="center">
       <div class="page" style="width:98%; text-align:left">
         <div style="padding:0px 10px 0px 10px">
           <div style="margin:10px 0;">
             <a href="/legacy/index.html">&laquo; back to games</a>
-            <span style="float:right" class="smallfont" id="authArea">
-              <span id="userName"></span>
-              <button id="signIn" class="button">Sign in</button>
-              <button id="signOut" class="button" style="display:none">Sign out</button>
-            </span>
           </div>
 
           <table class="tborder" cellpadding="4" cellspacing="1" border="0" width="100%" align="center">

--- a/madia.new/public/legacy/game.js
+++ b/madia.new/public/legacy/game.js
@@ -18,19 +18,19 @@ import {
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
 import { ubbToHtml } from "/legacy/ubb.js";
 import { auth, db, provider, missingConfig } from "./firebase.js";
+import { initLegacyHeader } from "./header.js";
 
 function getParam(name) {
   const params = new URLSearchParams(location.search);
   return params.get(name);
 }
 
+const header = initLegacyHeader();
+
 const els = {
   gameTitle: document.getElementById("gameTitle"),
   gameMeta: document.getElementById("gameMeta"),
   postsContainer: document.getElementById("postsContainer"),
-  signIn: document.getElementById("signIn"),
-  signOut: document.getElementById("signOut"),
-  userName: document.getElementById("userName"),
   replyForm: document.getElementById("replyForm"),
   replyTitle: document.getElementById("replyTitle"),
   replyBody: document.getElementById("replyBody"),
@@ -44,14 +44,23 @@ const els = {
   playerListLink: document.getElementById("playerListLink"),
 };
 
+if (header?.signInButton) {
+  header.signInButton.addEventListener("click", async () => {
+    await signInWithPopup(auth, provider);
+  });
+}
+
+if (header?.signOutLink) {
+  header.signOutLink.addEventListener("click", async (event) => {
+    event.preventDefault();
+    await signOut(auth);
+  });
+}
+
 onAuthStateChanged(auth, (user) => {
-  els.signIn.style.display = user ? "none" : "inline-block";
-  els.signOut.style.display = user ? "inline-block" : "none";
-  els.userName.textContent = user ? user.displayName : "";
+  header?.setUser(user);
   refreshMembershipAndControls();
 });
-els.signIn.addEventListener("click", async () => signInWithPopup(auth, provider));
-els.signOut.addEventListener("click", async () => signOut(auth));
 
 const gameId = getParam("g");
 if (!gameId) {

--- a/madia.new/public/legacy/header.js
+++ b/madia.new/public/legacy/header.js
@@ -1,0 +1,73 @@
+export function initLegacyHeader({ containerId = "legacyHeader" } = {}) {
+  const container = document.getElementById(containerId);
+  if (!container) {
+    return null;
+  }
+
+  container.innerHTML = `
+    <!-- logo -->
+    <a name="top"></a>
+    <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" style="background-image:url(/images/head_back.gif)">
+      <tr>
+        <td align="left" valign="top" width="90%">
+          <a href="http://www.penny-arcade.com/" style="border:none;text-decoration:none;">&nbsp;</a>
+        </td>
+        <td nowrap="nowrap" valign="top" style="padding-top:15px;padding-right:15px;">
+          <div class="smallfont">
+            <span id="legacyHeaderWelcome" style="display:none;">
+              <strong>
+                Welcome, <a href="#" id="legacyHeaderProfile"></a>.
+                (<a href="#" id="legacyHeaderLogout">Log Out</a>)
+              </strong>
+            </span>
+            <span id="legacyHeaderAnon">
+              <button id="legacyHeaderSignIn" class="button">Sign in with Google</button>
+            </span>
+          </div>
+        </td>
+      </tr>
+    </table>
+    <!-- /logo -->
+    <table width="100%" style="background-image:url(/images/nav_back.gif)" align="center" border="0" cellpadding="0" cellspacing="0">
+      <tr>
+        <td align="left" valign="top" height="48">
+          <table width="50%" align="left" border="0" cellspacing="0" cellpadding="0">
+            <tr>
+              <td align="left" valign="top" width="192" height="48">&nbsp;</td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  `;
+
+  const signInButton = container.querySelector("#legacyHeaderSignIn");
+  const signOutLink = container.querySelector("#legacyHeaderLogout");
+  const welcome = container.querySelector("#legacyHeaderWelcome");
+  const anon = container.querySelector("#legacyHeaderAnon");
+  const profileLink = container.querySelector("#legacyHeaderProfile");
+
+  function setUser(user) {
+    if (!welcome || !anon) return;
+    if (user) {
+      welcome.style.display = "block";
+      anon.style.display = "none";
+      if (profileLink) {
+        const label = user.displayName || user.email || "profile";
+        profileLink.textContent = label;
+        profileLink.href = `/legacy/member.html?u=${encodeURIComponent(user.uid)}`;
+      }
+    } else {
+      welcome.style.display = "none";
+      anon.style.display = "block";
+    }
+  }
+
+  return {
+    container,
+    signInButton,
+    signOutLink,
+    profileLink,
+    setUser,
+  };
+}

--- a/madia.new/public/legacy/index.html
+++ b/madia.new/public/legacy/index.html
@@ -7,17 +7,12 @@
     <link rel="stylesheet" href="/legacy/phalla.css" />
   </head>
   <body>
-    <!-- header/logo include equivalent -->
+    <div id="legacyHeader"></div>
     <div align="center">
       <div class="page" style="width:98%; text-align:left">
         <div style="padding:0px 10px 0px 10px">
           <div style="margin:10px 0;">
             <a href="/legacy/sitesummary.html" id="siteSummaryLink">site summary</a>
-            <a href="/legacy/member.html" id="profileLink" style="margin-left:12px; display:none;">profile</a>
-            <span style="float:right" class="smallfont" id="authArea">
-              <button id="signIn" class="button">Sign in with Google</button>
-              <button id="signOut" class="button" style="display:none">Sign out</button>
-            </span>
           </div>
 
           <!-- Games table (games.asp look) -->

--- a/madia.new/public/legacy/legacy.js
+++ b/madia.new/public/legacy/legacy.js
@@ -14,12 +14,12 @@ import {
   onSnapshot,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
 import { auth, db, provider, missingConfig } from "./firebase.js";
+import { initLegacyHeader } from "./header.js";
+
+const header = initLegacyHeader();
 
 const els = {
   gamesBody: document.getElementById("gamesBody"),
-  signIn: document.getElementById("signIn"),
-  signOut: document.getElementById("signOut"),
-  profileLink: document.getElementById("profileLink"),
 };
 
 let currentUser = null;
@@ -53,14 +53,22 @@ function stopWatchingGames({ signedOut = false } = {}) {
   }
 }
 
+if (header?.signInButton) {
+  header.signInButton.addEventListener("click", async () => {
+    await signInWithPopup(auth, provider);
+  });
+}
+
+if (header?.signOutLink) {
+  header.signOutLink.addEventListener("click", async (event) => {
+    event.preventDefault();
+    await signOut(auth);
+  });
+}
+
 onAuthStateChanged(auth, async (user) => {
   currentUser = user;
-  els.signIn.style.display = user ? "none" : "inline-block";
-  els.signOut.style.display = user ? "inline-block" : "none";
-  els.profileLink.style.display = user ? "inline-block" : "none";
-  if (user) {
-    els.profileLink.href = `/legacy/member.html?u=${encodeURIComponent(user.uid)}`;
-  }
+  header?.setUser(user);
   if (missingConfig) {
     stopWatchingGames();
     renderConfigWarning();
@@ -71,13 +79,6 @@ onAuthStateChanged(auth, async (user) => {
   } else {
     stopWatchingGames({ signedOut: true });
   }
-});
-
-els.signIn.addEventListener("click", async () => {
-  await signInWithPopup(auth, provider);
-});
-els.signOut.addEventListener("click", async () => {
-  await signOut(auth);
 });
 
 function sectionHeader(label) {

--- a/madia.new/public/legacy/member.html
+++ b/madia.new/public/legacy/member.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="/legacy/phalla.css" />
   </head>
   <body>
+    <div id="legacyHeader"></div>
     <div align="center">
       <div class="page" style="width:98%; text-align:left">
         <div style="padding:0px 10px 0px 10px">

--- a/madia.new/public/legacy/member.js
+++ b/madia.new/public/legacy/member.js
@@ -1,4 +1,8 @@
-import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
+import {
+  onAuthStateChanged,
+  signInWithPopup,
+  signOut,
+} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
 import {
   collection,
   collectionGroup,
@@ -11,7 +15,23 @@ import {
   setDoc,
   getDoc,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
-import { auth, db, missingConfig } from "./firebase.js";
+import { auth, db, missingConfig, provider } from "./firebase.js";
+import { initLegacyHeader } from "./header.js";
+
+const header = initLegacyHeader();
+
+if (header?.signInButton) {
+  header.signInButton.addEventListener("click", async () => {
+    await signInWithPopup(auth, provider);
+  });
+}
+
+if (header?.signOutLink) {
+  header.signOutLink.addEventListener("click", async (event) => {
+    event.preventDefault();
+    await signOut(auth);
+  });
+}
 
 function getParam(name) {
   const params = new URLSearchParams(location.search);
@@ -32,6 +52,7 @@ let currentUser = null;
 const viewedUid = getParam("u");
 
 onAuthStateChanged(auth, async (user) => {
+  header?.setUser(user);
   currentUser = user;
   renderProfileHeader();
   await loadLists();

--- a/madia.new/public/legacy/playerlist.html
+++ b/madia.new/public/legacy/playerlist.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="/legacy/phalla.css" />
   </head>
   <body>
+    <div id="legacyHeader"></div>
     <div align="center">
       <div class="page" style="width:98%; text-align:left">
         <div style="padding:0px 10px 0px 10px">

--- a/madia.new/public/legacy/playerlist.js
+++ b/madia.new/public/legacy/playerlist.js
@@ -1,10 +1,35 @@
 import {
+  onAuthStateChanged,
+  signInWithPopup,
+  signOut,
+} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
+import {
   collection,
   doc,
   getDoc,
   getDocs,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
-import { db, missingConfig } from "./firebase.js";
+import { auth, db, missingConfig, provider } from "./firebase.js";
+import { initLegacyHeader } from "./header.js";
+
+const header = initLegacyHeader();
+
+if (header?.signInButton) {
+  header.signInButton.addEventListener("click", async () => {
+    await signInWithPopup(auth, provider);
+  });
+}
+
+if (header?.signOutLink) {
+  header.signOutLink.addEventListener("click", async (event) => {
+    event.preventDefault();
+    await signOut(auth);
+  });
+}
+
+onAuthStateChanged(auth, (user) => {
+  header?.setUser(user);
+});
 
 const playerRows = document.getElementById("playerRows");
 const gameBreadcrumb = document.getElementById("gameBreadcrumb");

--- a/madia.new/public/legacy/sitesummary.html
+++ b/madia.new/public/legacy/sitesummary.html
@@ -7,23 +7,12 @@
     <link rel="stylesheet" href="/legacy/phalla.css" />
   </head>
   <body>
+    <div id="legacyHeader"></div>
     <div align="center">
       <div class="page" style="width:98%; text-align:left">
         <div style="padding:0px 10px 0px 10px">
           <div style="margin:10px 0;">
             <a href="/legacy/index.html">list of games</a>
-            <a
-              href="/legacy/member.html"
-              id="profileLink"
-              style="margin-left:12px; display:none;"
-              >profile</a
-            >
-            <span style="float:right" class="smallfont" id="authArea">
-              <button id="signIn" class="button">Sign in with Google</button>
-              <button id="signOut" class="button" style="display:none">
-                Sign out
-              </button>
-            </span>
           </div>
           <div id="summaryContent" style="margin-top:12px;">
             <div class="smallfont" style="color:#F9A906;">

--- a/madia.new/public/legacy/sitesummary.js
+++ b/madia.new/public/legacy/sitesummary.js
@@ -14,11 +14,10 @@ import {
   query,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
 import { auth, db, provider, missingConfig } from "./firebase.js";
+import { initLegacyHeader } from "./header.js";
 
 const summaryContent = document.getElementById("summaryContent");
-const signInButton = document.getElementById("signIn");
-const signOutButton = document.getElementById("signOut");
-const profileLink = document.getElementById("profileLink");
+const header = initLegacyHeader();
 
 if (missingConfig) {
   renderConfigWarning();
@@ -26,23 +25,21 @@ if (missingConfig) {
   renderInfo("Sign in to view site summary.");
 }
 
-signInButton?.addEventListener("click", async () => {
-  await signInWithPopup(auth, provider);
-});
+if (header?.signInButton) {
+  header.signInButton.addEventListener("click", async () => {
+    await signInWithPopup(auth, provider);
+  });
+}
 
-signOutButton?.addEventListener("click", async () => {
-  await signOut(auth);
-});
+if (header?.signOutLink) {
+  header.signOutLink.addEventListener("click", async (event) => {
+    event.preventDefault();
+    await signOut(auth);
+  });
+}
 
 onAuthStateChanged(auth, async (user) => {
-  if (signInButton) signInButton.style.display = user ? "none" : "inline-block";
-  if (signOutButton) signOutButton.style.display = user ? "inline-block" : "none";
-  if (profileLink) {
-    profileLink.style.display = user ? "inline-block" : "none";
-    if (user) {
-      profileLink.href = `/legacy/member.html?u=${encodeURIComponent(user.uid)}`;
-    }
-  }
+  header?.setUser(user);
 
   if (missingConfig) {
     return;

--- a/madia.new/public/legacy/userlist.html
+++ b/madia.new/public/legacy/userlist.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="/legacy/phalla.css" />
   </head>
   <body>
+    <div id="legacyHeader"></div>
     <div align="center">
       <div class="page" style="width:98%; text-align:left">
         <div style="padding:0px 10px 0px 10px">

--- a/madia.new/public/legacy/userlist.js
+++ b/madia.new/public/legacy/userlist.js
@@ -1,5 +1,30 @@
+import {
+  onAuthStateChanged,
+  signInWithPopup,
+  signOut,
+} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
 import { collection, getDocs } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
-import { db, missingConfig } from "./firebase.js";
+import { auth, db, missingConfig, provider } from "./firebase.js";
+import { initLegacyHeader } from "./header.js";
+
+const header = initLegacyHeader();
+
+if (header?.signInButton) {
+  header.signInButton.addEventListener("click", async () => {
+    await signInWithPopup(auth, provider);
+  });
+}
+
+if (header?.signOutLink) {
+  header.signOutLink.addEventListener("click", async (event) => {
+    event.preventDefault();
+    await signOut(auth);
+  });
+}
+
+onAuthStateChanged(auth, (user) => {
+  header?.setUser(user);
+});
 
 const userRows = document.getElementById("userRows");
 


### PR DESCRIPTION
## Summary
- add a shared legacy header module that mirrors the original mafia.old/logo.asp markup and auth controls
- embed the header on every legacy HTML page and wire Firebase auth listeners through it across page modules

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6b09321c88328981883ca7a54145c