### PR TITLE
Add legacy email/password sign-in flow

### DIFF
--- a/madia.new/FIREBASE.md
+++ b/madia.new/FIREBASE.md
@@ -10,7 +10,8 @@ experience.
 ## Configure retro client SDKs
 
 - After registering your Firebase Web app, paste the configuration
-  snippet into `public/legacy/legacy.js` and `public/legacy/game.js`.
+  snippet into `public/legacy/legacy.js`, `public/legacy/game.js`, and
+  `public/legacy/login.js`.
 - Keep the values in sync with `public/script.js` so both experiences
   point at the same project.
 - When running emulators, call `connectAuthEmulator` and
@@ -30,6 +31,15 @@ players:
 - `games/{gameId}/posts/{postId}` documents: `title` (string), `body`
   (UBB), `authorId` (string), `authorName` (string), `avatar` (string,
   optional), `sig` (string, optional), `createdAt` (timestamp).
+- `users/{uid}` documents: `displayName`, `username`, `usernameLower`
+  (all strings), `email` (string), `photoURL` (optional string), and
+  timestamps (`createdAt`, `lastLoginAt`). The login page looks up
+  `usernameLower` to support username-based sign-in.
+
+The retro login experience lives at `/legacy/login.html` and mimics the
+classic ASP form. Ensure the Firebase Authentication Email/Password
+provider is enabled so the form can create and authenticate local
+accounts alongside Google sign-in.
 
 ## Required indexes
 

--- a/madia.new/README.md
+++ b/madia.new/README.md
@@ -11,8 +11,8 @@ players comfortable.
 - **Threaded discussion board** with real-time updates backed by Cloud
   Firestore.
 - **Integrated Mafia game dashboard** to track player votes and notes.
-- **Google sign-in** via Firebase Authentication with guards around
-  write operations.
+- **Google and email/password sign-in** via Firebase Authentication with
+  guards around write operations and legacy-inspired forms.
 - **Firebase Hosting configuration** that deploys the static assets in
   `public/`.
 - **Emulator Suite support** for local development with Auth,
@@ -47,14 +47,21 @@ madia.new/
 1. Navigate to the [Firebase console](https://console.firebase.google.com/) and click **Add project**.
 2. Choose (or create) a Google Cloud project name, enable Google Analytics if desired, and finish the wizard.
 3. In the project dashboard:
-   - Go to **Build → Authentication → Sign-in method** and enable **Google**. Configure an authorized domain if you plan to use a custom domain.
+   - Go to **Build → Authentication → Sign-in method** and enable both **Google** *and* **Email/Password** providers. The retro login page mirrors the classic ASP form and relies on the Email/Password provider for site-specific credentials.
+   - Still within the Authentication section, review the **Authorized domains** list and add any custom domains you intend to serve from Firebase Hosting.
    - Go to **Build → Firestore Database** and create a database in production mode. Choose a region close to your players.
    - (Optional) Under **Build → Storage**, create a Cloud Storage bucket if you plan to add media uploads later.
 4. Create a **Web app** registration (`</>` icon) to obtain the Firebase configuration snippet. Copy the settings (apiKey, authDomain, etc.).
 5. Update all client entry points with the copied configuration values:
    - `public/script.js` for the modern single-page app.
    - `public/legacy/legacy.js` and `public/legacy/game.js` for the retro UI.
+   - `public/legacy/login.js` for the legacy-styled authentication flow.
 6. Update `.firebaserc` to set the default project ID: replace `YOUR_FIREBASE_PROJECT_ID` with the project ID shown in the Firebase console.
+7. (Optional) Customize the password reset and verification emails under **Authentication → Templates** if you plan to support account recovery for the Email/Password provider.
+
+### Username-backed sign-in
+
+The legacy login page (served at `/legacy/login.html`) allows players to sign in with either their email address or their site-specific username. Email/Password accounts are stored in Firebase Authentication, while profile metadata (display name, username, and lowercase username) lives in Firestore under `users/{uid}`. When migrating existing data, ensure each document includes a `usernameLower` field so the login form can resolve usernames to email addresses. The helper logic in `public/legacy/login.js` will maintain these fields automatically for new and returning users.
 
 ## 2. Recommended Firestore security rules
 

--- a/madia.new/public/legacy/firebase.js
+++ b/madia.new/public/legacy/firebase.js
@@ -3,7 +3,13 @@ import {
   getAuth,
   GoogleAuthProvider,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
-import { getFirestore } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
+import {
+  doc,
+  getDoc,
+  getFirestore,
+  serverTimestamp,
+  setDoc,
+} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
 
 const firebaseConfig = {
   apiKey: "AIzaSyDLVQ_ncruYo7Xd0tCzh8RIvlmzhrQYt_8",
@@ -24,4 +30,57 @@ const auth = getAuth(app);
 const db = getFirestore(app);
 const provider = new GoogleAuthProvider();
 
-export { app, auth, db, provider, firebaseConfig, missingConfig };
+async function ensureUserDocument(user, overrides = {}) {
+  if (!user || missingConfig) {
+    return;
+  }
+
+  const userRef = doc(db, "users", user.uid);
+  const snapshot = await getDoc(userRef).catch(() => null);
+
+  const displayName =
+    overrides.displayName ?? overrides.username ?? user.displayName ?? "";
+  const username = overrides.username ?? displayName;
+  const email = overrides.email ?? user.email ?? "";
+
+  const profile = {
+    lastLoginAt: serverTimestamp(),
+  };
+
+  if (displayName) {
+    profile.displayName = displayName;
+  }
+  if (email) {
+    profile.email = email;
+  }
+  if (user.photoURL) {
+    profile.photoURL = user.photoURL;
+  }
+  if (username) {
+    profile.username = username;
+    profile.usernameLower = username.toLowerCase();
+  }
+
+  if (!snapshot || !snapshot.exists()) {
+    await setDoc(
+      userRef,
+      {
+        ...profile,
+        createdAt: serverTimestamp(),
+      }
+    );
+    return;
+  }
+
+  await setDoc(userRef, profile, { merge: true });
+}
+
+export {
+  app,
+  auth,
+  db,
+  provider,
+  firebaseConfig,
+  missingConfig,
+  ensureUserDocument,
+};

--- a/madia.new/public/legacy/game.html
+++ b/madia.new/public/legacy/game.html
@@ -16,6 +16,12 @@
               <span id="userName"></span>
               <button id="signIn" class="button">Sign in</button>
               <button id="signOut" class="button" style="display:none">Sign out</button>
+              <a
+                id="signUpLink"
+                href="#signup"
+                style="margin-left:8px; display:none;"
+                >sign up!</a
+              >
             </span>
           </div>
 

--- a/madia.new/public/legacy/index.html
+++ b/madia.new/public/legacy/index.html
@@ -15,8 +15,14 @@
             <a href="/legacy/sitesummary.html" id="siteSummaryLink">site summary</a>
             <a href="/legacy/member.html" id="profileLink" style="margin-left:12px; display:none;">profile</a>
             <span style="float:right" class="smallfont" id="authArea">
-              <button id="signIn" class="button">Sign in with Google</button>
+              <button id="signIn" class="button">Sign in</button>
               <button id="signOut" class="button" style="display:none">Sign out</button>
+              <a
+                id="signUpLink"
+                href="#signup"
+                style="margin-left:8px; display:none;"
+                >sign up!</a
+              >
             </span>
           </div>
 

--- a/madia.new/public/legacy/legacy.js
+++ b/madia.new/public/legacy/legacy.js
@@ -1,6 +1,5 @@
 import {
   onAuthStateChanged,
-  signInWithPopup,
   signOut,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
 import {
@@ -13,13 +12,14 @@ import {
   limit,
   onSnapshot,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
-import { auth, db, provider, missingConfig } from "./firebase.js";
+import { auth, db, ensureUserDocument, missingConfig } from "./firebase.js";
 
 const els = {
   gamesBody: document.getElementById("gamesBody"),
   signIn: document.getElementById("signIn"),
   signOut: document.getElementById("signOut"),
   profileLink: document.getElementById("profileLink"),
+  signUpLink: document.getElementById("signUpLink"),
 };
 
 let currentUser = null;
@@ -58,8 +58,12 @@ onAuthStateChanged(auth, async (user) => {
   els.signIn.style.display = user ? "none" : "inline-block";
   els.signOut.style.display = user ? "inline-block" : "none";
   els.profileLink.style.display = user ? "inline-block" : "none";
+  if (els.signUpLink) {
+    els.signUpLink.style.display = user ? "none" : "inline";
+  }
   if (user) {
     els.profileLink.href = `/legacy/member.html?u=${encodeURIComponent(user.uid)}`;
+    await ensureUserDocument(user);
   }
   if (missingConfig) {
     stopWatchingGames();
@@ -73,9 +77,21 @@ onAuthStateChanged(auth, async (user) => {
   }
 });
 
-els.signIn.addEventListener("click", async () => {
-  await signInWithPopup(auth, provider);
+els.signIn.addEventListener("click", () => {
+  const redirect = encodeURIComponent(
+    `${location.pathname}${location.search}${location.hash}`
+  );
+  location.href = `/legacy/login.html?redirect=${redirect}`;
 });
+if (els.signUpLink) {
+  els.signUpLink.addEventListener("click", (event) => {
+    event.preventDefault();
+    const redirect = encodeURIComponent(
+      `${location.pathname}${location.search}${location.hash}`
+    );
+    location.href = `/legacy/login.html?redirect=${redirect}#signup`;
+  });
+}
 els.signOut.addEventListener("click", async () => {
   await signOut(auth);
 });

--- a/madia.new/public/legacy/login.html
+++ b/madia.new/public/legacy/login.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Login</title>
+    <link rel="stylesheet" href="/legacy/phalla.css" />
+  </head>
+  <body>
+    <div align="center">
+      <div class="page" style="width:98%; text-align:left">
+        <div style="padding:0px 10px 0px 10px">
+          <div style="margin:10px 0;">
+            <a href="/legacy/index.html">&laquo; back to games</a>
+          </div>
+
+          <div
+            id="configWarning"
+            class="smallfont"
+            style="color:#F9A906; display:none; margin-bottom:12px;"
+          ></div>
+
+          <div
+            id="signedInNotice"
+            class="smallfont"
+            style="display:none; margin-bottom:18px;"
+          >
+            <div style="margin-bottom:6px;">
+              You are currently signed in as <span id="signedInName"></span>.
+            </div>
+            <div>
+              <button id="continueButton" class="button">Continue</button>
+              <button id="signOutButton" class="button">Sign out</button>
+            </div>
+          </div>
+
+          <div id="loginSection" style="margin-bottom:24px;">
+            <div
+              id="loginError"
+              class="smallfont"
+              style="color:#F9A906; margin-bottom:6px; display:none;"
+            ></div>
+            <form id="loginForm" method="post">
+              <table cellpadding="0" cellspacing="3" border="0">
+                <tr>
+                  <td class="smallfont">
+                    <label for="loginUsername">Login:</label>
+                  </td>
+                  <td>
+                    <input
+                      type="text"
+                      class="bginput"
+                      style="font-size: 11px"
+                      name="loginUsername"
+                      id="loginUsername"
+                      size="20"
+                      autocomplete="username"
+                    />
+                  </td>
+                  <td class="smallfont" colspan="2" nowrap="nowrap">
+                    <label for="loginRemember">
+                      <input
+                        type="checkbox"
+                        name="loginRemember"
+                        id="loginRemember"
+                        value="y"
+                        checked
+                      />
+                      remember
+                    </label>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="smallfont">
+                    <label for="loginPassword">Password:</label>
+                  </td>
+                  <td>
+                    <input
+                      type="password"
+                      class="bginput"
+                      style="font-size: 11px"
+                      name="loginPassword"
+                      id="loginPassword"
+                      size="20"
+                      autocomplete="current-password"
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="2" align="left">
+                    <input
+                      type="submit"
+                      class="button"
+                      value="Log in"
+                      id="loginSubmit"
+                    />
+                  </td>
+                </tr>
+              </table>
+            </form>
+            <div class="smallfont" style="margin-top:8px;">
+              Tip: you can enter either your username or email address.
+            </div>
+            <div style="margin-top:12px;">
+              <button id="googleSignIn" class="button">
+                Sign in with Google
+              </button>
+            </div>
+          </div>
+
+          <a id="signup"></a>
+          <div id="signupSection">
+            <div
+              id="signupError"
+              class="smallfont"
+              style="color:#F9A906; margin-bottom:6px; display:none;"
+            ></div>
+            <form id="signupForm" method="post">
+              <input type="hidden" name="newaccount" value="y" />
+              <table cellpadding="0" cellspacing="3" border="0">
+                <tr>
+                  <td class="smallfont">
+                    <label for="signupUsername">Username:</label>
+                  </td>
+                  <td>
+                    <input
+                      type="text"
+                      class="bginput"
+                      style="font-size: 11px"
+                      name="signupUsername"
+                      id="signupUsername"
+                      size="20"
+                      autocomplete="nickname"
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td class="smallfont">
+                    <label for="signupPassword">Password:</label>
+                  </td>
+                  <td>
+                    <input
+                      type="password"
+                      class="bginput"
+                      style="font-size: 11px"
+                      name="signupPassword"
+                      id="signupPassword"
+                      size="20"
+                      autocomplete="new-password"
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td class="smallfont">
+                    <label for="signupConfirmPassword">Retype Password:</label>
+                  </td>
+                  <td>
+                    <input
+                      type="password"
+                      class="bginput"
+                      style="font-size: 11px"
+                      name="signupConfirmPassword"
+                      id="signupConfirmPassword"
+                      size="20"
+                      autocomplete="new-password"
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td class="smallfont">
+                    <label for="signupEmail">Email Address:</label>
+                  </td>
+                  <td>
+                    <input
+                      type="email"
+                      class="bginput"
+                      style="font-size: 11px"
+                      name="signupEmail"
+                      id="signupEmail"
+                      size="20"
+                      autocomplete="email"
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="2">
+                    <div class="smallfont" style="margin:6px 0;">
+                      Email is required for account recovery and multi-login support.
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <input
+                      type="submit"
+                      class="button"
+                      value="Sign Up!"
+                      id="signupSubmit"
+                    />
+                  </td>
+                </tr>
+              </table>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script type="module" src="/legacy/login.js"></script>
+  </body>
+</html>

--- a/madia.new/public/legacy/login.js
+++ b/madia.new/public/legacy/login.js
@@ -1,0 +1,350 @@
+import {
+  browserLocalPersistence,
+  browserSessionPersistence,
+  createUserWithEmailAndPassword,
+  onAuthStateChanged,
+  setPersistence,
+  signInWithEmailAndPassword,
+  signInWithPopup,
+  signOut,
+  updateProfile,
+} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
+import {
+  collection,
+  getDocs,
+  limit,
+  query,
+  where,
+} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
+import {
+  auth,
+  db,
+  ensureUserDocument,
+  missingConfig,
+  provider,
+} from "./firebase.js";
+
+const els = {
+  configWarning: document.getElementById("configWarning"),
+  loginSection: document.getElementById("loginSection"),
+  loginForm: document.getElementById("loginForm"),
+  loginUsername: document.getElementById("loginUsername"),
+  loginPassword: document.getElementById("loginPassword"),
+  loginRemember: document.getElementById("loginRemember"),
+  loginError: document.getElementById("loginError"),
+  loginSubmit: document.getElementById("loginSubmit"),
+  googleSignIn: document.getElementById("googleSignIn"),
+  signupSection: document.getElementById("signupSection"),
+  signupForm: document.getElementById("signupForm"),
+  signupUsername: document.getElementById("signupUsername"),
+  signupPassword: document.getElementById("signupPassword"),
+  signupConfirmPassword: document.getElementById("signupConfirmPassword"),
+  signupEmail: document.getElementById("signupEmail"),
+  signupError: document.getElementById("signupError"),
+  signupSubmit: document.getElementById("signupSubmit"),
+  signedInNotice: document.getElementById("signedInNotice"),
+  signedInName: document.getElementById("signedInName"),
+  continueButton: document.getElementById("continueButton"),
+  signOutButton: document.getElementById("signOutButton"),
+};
+
+const params = new URLSearchParams(location.search);
+const redirectTarget = sanitizeRedirect(params.get("redirect"));
+const wantsSignup = location.hash.toLowerCase() === "#signup";
+let focusApplied = false;
+
+if (els.continueButton) {
+  els.continueButton.addEventListener("click", (event) => {
+    event.preventDefault();
+    location.href = redirectTarget;
+  });
+}
+
+if (els.signOutButton) {
+  els.signOutButton.addEventListener("click", async (event) => {
+    event.preventDefault();
+    await signOut(auth);
+  });
+}
+
+if (missingConfig) {
+  showConfigWarning(
+    "Firebase configuration required. Update public/legacy/firebase.js before using authentication."
+  );
+  disableSection(els.loginSection);
+  disableSection(els.signupSection);
+  if (els.googleSignIn) els.googleSignIn.disabled = true;
+} else {
+  hide(els.configWarning);
+}
+
+onAuthStateChanged(auth, async (user) => {
+  if (user) {
+    await ensureUserDocument(user);
+    if (els.signedInName) {
+      els.signedInName.textContent = user.displayName || user.email || user.uid;
+    }
+    show(els.signedInNotice);
+    hide(els.loginSection);
+    hide(els.signupSection);
+    focusApplied = false;
+  } else {
+    hide(els.signedInNotice);
+    if (!missingConfig) {
+      show(els.loginSection);
+      show(els.signupSection);
+      if (!focusApplied) {
+        focusApplied = true;
+        if (wantsSignup) {
+          els.signupSection?.scrollIntoView({ behavior: "smooth", block: "start" });
+          els.signupUsername?.focus();
+        } else {
+          els.loginUsername?.focus();
+        }
+      }
+    }
+  }
+});
+
+if (els.loginForm) {
+  els.loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (missingConfig) return;
+
+    const identifier = (els.loginUsername?.value || "").trim();
+    const password = els.loginPassword?.value || "";
+    const remember = Boolean(els.loginRemember?.checked);
+
+    setError(els.loginError, "");
+    setSubmitting(els.loginForm, els.loginSubmit, true, "Logging in...");
+
+    try {
+      if (!identifier || !password) {
+        throw new Error("Enter your username or email and password.");
+      }
+
+      await applyPersistence(remember);
+      const email = await resolveIdentifier(identifier);
+      const credential = await signInWithEmailAndPassword(auth, email, password);
+      await ensureUserDocument(credential.user);
+      location.href = redirectTarget;
+    } catch (error) {
+      setError(els.loginError, describeAuthError(error));
+    } finally {
+      setSubmitting(els.loginForm, els.loginSubmit, false, "Log in");
+    }
+  });
+}
+
+if (els.googleSignIn) {
+  els.googleSignIn.addEventListener("click", async (event) => {
+    event.preventDefault();
+    if (missingConfig) return;
+
+    setError(els.loginError, "");
+    setButtonLoading(els.googleSignIn, true, "Signing in...");
+    try {
+      await setPersistence(auth, browserLocalPersistence);
+      const credential = await signInWithPopup(auth, provider);
+      await ensureUserDocument(credential.user);
+      location.href = redirectTarget;
+    } catch (error) {
+      setError(els.loginError, describeAuthError(error));
+    } finally {
+      setButtonLoading(els.googleSignIn, false, "Sign in with Google");
+    }
+  });
+}
+
+if (els.signupForm) {
+  els.signupForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (missingConfig) return;
+
+    const username = (els.signupUsername?.value || "").trim();
+    const email = (els.signupEmail?.value || "").trim();
+    const password = els.signupPassword?.value || "";
+    const confirm = els.signupConfirmPassword?.value || "";
+
+    setError(els.signupError, "");
+    setSubmitting(els.signupForm, els.signupSubmit, true, "Signing up...");
+
+    try {
+      validateSignup({ username, email, password, confirm });
+      await ensureUsernameAvailable(username);
+
+      const credential = await createUserWithEmailAndPassword(auth, email, password);
+      await updateProfile(credential.user, { displayName: username });
+      await ensureUserDocument(credential.user, {
+        username,
+        email,
+        displayName: username,
+      });
+      location.href = redirectTarget;
+    } catch (error) {
+      setError(els.signupError, describeAuthError(error));
+    } finally {
+      setSubmitting(els.signupForm, els.signupSubmit, false, "Sign Up!");
+    }
+  });
+}
+
+function sanitizeRedirect(value) {
+  if (!value) return "/legacy/index.html";
+  try {
+    const url = new URL(value, location.origin);
+    if (url.origin !== location.origin) {
+      return "/legacy/index.html";
+    }
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return "/legacy/index.html";
+  }
+}
+
+async function resolveIdentifier(identifier) {
+  if (identifier.includes("@")) {
+    return identifier.toLowerCase();
+  }
+  const usernameLower = identifier.toLowerCase();
+  const q = query(
+    collection(db, "users"),
+    where("usernameLower", "==", usernameLower),
+    limit(1)
+  );
+  const snapshot = await getDocs(q);
+  if (snapshot.empty) {
+    throw new Error("No account matches that username.");
+  }
+  const data = snapshot.docs[0].data();
+  if (!data.email) {
+    throw new Error("This account does not have an email on file. Use email to sign in.");
+  }
+  return data.email;
+}
+
+async function ensureUsernameAvailable(username) {
+  const q = query(
+    collection(db, "users"),
+    where("usernameLower", "==", username.toLowerCase()),
+    limit(1)
+  );
+  const snapshot = await getDocs(q);
+  if (!snapshot.empty) {
+    throw new Error("Username already in use.");
+  }
+}
+
+function validateSignup({ username, email, password, confirm }) {
+  if (!username) {
+    throw new Error("Choose a username.");
+  }
+  if (!email) {
+    throw new Error("Enter an email address.");
+  }
+  if (!password) {
+    throw new Error("Enter a password.");
+  }
+  if (password.length < 6) {
+    throw new Error("Choose a password with at least 6 characters.");
+  }
+  if (password !== confirm) {
+    throw new Error("Passwords do not match.");
+  }
+}
+
+async function applyPersistence(remember) {
+  const persistence = remember
+    ? browserLocalPersistence
+    : browserSessionPersistence;
+  await setPersistence(auth, persistence);
+}
+
+function setError(element, message) {
+  if (!element) return;
+  if (message) {
+    element.textContent = message;
+    element.style.display = "block";
+  } else {
+    element.textContent = "";
+    element.style.display = "none";
+  }
+}
+
+function setSubmitting(form, submitEl, submitting, label) {
+  if (submitEl) {
+    submitEl.value = label;
+    submitEl.disabled = submitting;
+  }
+  if (form) {
+    Array.from(form.elements).forEach((el) => {
+      if (el !== submitEl) {
+        el.disabled = submitting;
+      }
+    });
+  }
+}
+
+function setButtonLoading(button, loading, label) {
+  if (!button) return;
+  button.textContent = label;
+  button.disabled = loading;
+}
+
+function showConfigWarning(message) {
+  if (!els.configWarning) return;
+  els.configWarning.textContent = message;
+  els.configWarning.style.display = "block";
+}
+
+function disableSection(section) {
+  if (!section) return;
+  section.style.opacity = "0.5";
+  const controls = section.querySelectorAll("input, button");
+  controls.forEach((el) => {
+    el.disabled = true;
+  });
+}
+
+function show(element) {
+  if (!element) return;
+  element.style.display = "block";
+}
+
+function hide(element) {
+  if (!element) return;
+  element.style.display = "none";
+}
+
+function describeAuthError(error) {
+  if (!error) {
+    return "An unknown error occurred.";
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  switch (error.code) {
+    case "auth/user-not-found":
+      return "No account found with that email.";
+    case "auth/wrong-password":
+      return "Incorrect password.";
+    case "auth/invalid-email":
+      return "Enter a valid email address.";
+    case "auth/email-already-in-use":
+      return "That email address is already in use.";
+    case "auth/weak-password":
+      return "Choose a stronger password (6+ characters).";
+    case "auth/account-exists-with-different-credential":
+      return "That email is linked to another sign-in method.";
+    case "auth/credential-already-in-use":
+      return "That credential is already linked to another account.";
+    case "auth/popup-closed-by-user":
+      return "Google sign-in was cancelled.";
+    case "auth/popup-blocked":
+      return "Allow popups to sign in with Google.";
+    case "auth/too-many-requests":
+      return "Too many attempts. Try again later.";
+    default:
+      return error.message || "An unknown error occurred.";
+  }
+}

--- a/madia.new/public/legacy/member.js
+++ b/madia.new/public/legacy/member.js
@@ -11,7 +11,7 @@ import {
   setDoc,
   getDoc,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
-import { auth, db, missingConfig } from "./firebase.js";
+import { auth, db, ensureUserDocument, missingConfig } from "./firebase.js";
 
 function getParam(name) {
   const params = new URLSearchParams(location.search);
@@ -33,6 +33,9 @@ const viewedUid = getParam("u");
 
 onAuthStateChanged(auth, async (user) => {
   currentUser = user;
+  if (user) {
+    await ensureUserDocument(user);
+  }
   renderProfileHeader();
   await loadLists();
 });

--- a/madia.new/public/legacy/sitesummary.html
+++ b/madia.new/public/legacy/sitesummary.html
@@ -19,10 +19,16 @@
               >profile</a
             >
             <span style="float:right" class="smallfont" id="authArea">
-              <button id="signIn" class="button">Sign in with Google</button>
+              <button id="signIn" class="button">Sign in</button>
               <button id="signOut" class="button" style="display:none">
                 Sign out
               </button>
+              <a
+                id="signUpLink"
+                href="#signup"
+                style="margin-left:8px; display:none;"
+                >sign up!</a
+              >
             </span>
           </div>
           <div id="summaryContent" style="margin-top:12px;">

--- a/madia.new/public/legacy/sitesummary.js
+++ b/madia.new/public/legacy/sitesummary.js
@@ -1,6 +1,5 @@
 import {
   onAuthStateChanged,
-  signInWithPopup,
   signOut,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
 import {
@@ -13,12 +12,13 @@ import {
   orderBy,
   query,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
-import { auth, db, provider, missingConfig } from "./firebase.js";
+import { auth, db, ensureUserDocument, missingConfig } from "./firebase.js";
 
 const summaryContent = document.getElementById("summaryContent");
 const signInButton = document.getElementById("signIn");
 const signOutButton = document.getElementById("signOut");
 const profileLink = document.getElementById("profileLink");
+const signUpLink = document.getElementById("signUpLink");
 
 if (missingConfig) {
   renderConfigWarning();
@@ -26,8 +26,19 @@ if (missingConfig) {
   renderInfo("Sign in to view site summary.");
 }
 
-signInButton?.addEventListener("click", async () => {
-  await signInWithPopup(auth, provider);
+signInButton?.addEventListener("click", () => {
+  const redirect = encodeURIComponent(
+    `${location.pathname}${location.search}${location.hash}`
+  );
+  location.href = `/legacy/login.html?redirect=${redirect}`;
+});
+
+signUpLink?.addEventListener("click", (event) => {
+  event.preventDefault();
+  const redirect = encodeURIComponent(
+    `${location.pathname}${location.search}${location.hash}`
+  );
+  location.href = `/legacy/login.html?redirect=${redirect}#signup`;
 });
 
 signOutButton?.addEventListener("click", async () => {
@@ -41,7 +52,11 @@ onAuthStateChanged(auth, async (user) => {
     profileLink.style.display = user ? "inline-block" : "none";
     if (user) {
       profileLink.href = `/legacy/member.html?u=${encodeURIComponent(user.uid)}`;
+      await ensureUserDocument(user);
     }
+  }
+  if (signUpLink) {
+    signUpLink.style.display = user ? "none" : "inline";
   }
 
   if (missingConfig) {


### PR DESCRIPTION
## Summary
- add a legacy-styled login and signup page backed by Firebase email/password authentication
- ensure user documents capture username metadata so username sign-in works and expose sign-up links across the legacy UI
- document the new authentication provider requirements in the Firebase setup guides

## Testing
- not run (static assets only)

------
https://chatgpt.com/codex/tasks/task_e_68d6b06ba56c83289f03195cfb946bdc