### PR TITLE
feat: render dead player icon on legacy player list

### DIFF
--- a/madia.new/public/legacy/playerlist.html
+++ b/madia.new/public/legacy/playerlist.html
@@ -22,10 +22,10 @@
 
           <table class="tborder" cellpadding="4" cellspacing="1" border="0" width="100%" align="center">
             <tr>
-              <td class="tcat" colspan="2">Players</td>
+              <td class="tcat" colspan="3">Players</td>
             </tr>
             <tbody id="playerRows">
-              <tr><td class="alt1" colspan="2" align="center">Loading players...</td></tr>
+              <tr><td class="alt1" colspan="3" align="center">Loading players...</td></tr>
             </tbody>
           </table>
         </div>

--- a/madia.new/public/legacy/playerlist.js
+++ b/madia.new/public/legacy/playerlist.js
@@ -13,7 +13,7 @@ const params = new URLSearchParams(location.search);
 const gameId = params.get("g");
 
 if (!gameId) {
-  playerRows.innerHTML = '<tr><td class="alt1" colspan="2" align="center">Missing game id.</td></tr>';
+  playerRows.innerHTML = '<tr><td class="alt1" colspan="3" align="center">Missing game id.</td></tr>';
 } else if (missingConfig) {
   renderConfigWarning();
 } else {
@@ -22,13 +22,13 @@ if (!gameId) {
 
 function renderConfigWarning() {
   playerRows.innerHTML = `
-    <tr><td class="alt1" colspan="2" align="center" style="color:#F9A906;">Configure Firebase to load players.</td></tr>
+    <tr><td class="alt1" colspan="3" align="center" style="color:#F9A906;">Configure Firebase to load players.</td></tr>
   `;
 }
 
 function renderError(message) {
   playerRows.innerHTML = `
-    <tr><td class="alt1" colspan="2" align="center" style="color:#F9A906;">Failed to load players: ${message}</td></tr>
+    <tr><td class="alt1" colspan="3" align="center" style="color:#F9A906;">Failed to load players: ${message}</td></tr>
   `;
 }
 
@@ -43,7 +43,7 @@ async function loadPlayers() {
 
   const playersSnap = await getDocs(collection(gameRef, "players"));
   if (playersSnap.empty) {
-    playerRows.innerHTML = '<tr><td class="alt1" colspan="2" align="center"><i>No players joined.</i></td></tr>';
+    playerRows.innerHTML = '<tr><td class="alt1" colspan="3" align="center"><i>No players joined.</i></td></tr>';
     return;
   }
 
@@ -62,17 +62,28 @@ async function loadPlayers() {
 
 function renderRow(entry, even) {
   const tr = document.createElement("tr");
-  tr.setAttribute("align", "left");
+  tr.setAttribute("align", "center");
+
+  const alive = playerIsAlive(entry.data);
+  const iconTd = document.createElement("td");
+  iconTd.className = "alt2";
+  iconTd.setAttribute("align", "center");
+  const icon = alive ? "phalla" : "dead_phalla";
+  const iconAlt = alive ? "Active player" : "Eliminated player";
+  iconTd.innerHTML = `<img src="/images/${icon}.gif" alt="${iconAlt}" border="0" />`;
 
   const nameTd = document.createElement("td");
   nameTd.className = even ? "alt1Active" : "alt1";
-  nameTd.innerHTML = `${escapeHtml(entry.data.name || entry.data.username || entry.id)} <span class="smallfont" style="color:#888;">${entry.data.active === false ? "(inactive)" : ""}</span>`;
+  nameTd.setAttribute("align", "left");
+  nameTd.innerHTML = `${escapeHtml(entry.data.name || entry.data.username || entry.id)} <span class="smallfont" style="color:#888;">${alive ? "" : "(inactive)"}</span>`;
 
   const roleTd = document.createElement("td");
   roleTd.className = even ? "alt2" : "alt1";
+  roleTd.setAttribute("align", "left");
   const role = entry.data.role || entry.data.rolename || "";
   roleTd.innerHTML = role ? escapeHtml(role) : "&nbsp;";
 
+  tr.appendChild(iconTd);
   tr.appendChild(nameTd);
   tr.appendChild(roleTd);
   return tr;
@@ -85,4 +96,49 @@ function escapeHtml(value) {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#39;");
+}
+
+// Legacy Access stored the player status in the players.active column, so we
+// prefer that field to mirror mafia.old/gamedisplay.asp behaviour and only fall
+// back to any newer alive flags if it is missing.
+function playerIsAlive(data = {}) {
+  if (Object.prototype.hasOwnProperty.call(data, "active")) {
+    const value = data.active;
+    if (typeof value === "string") {
+      const normalized = value.trim().toLowerCase();
+      if (["no", "dead", "false", "0"].includes(normalized)) {
+        return false;
+      }
+      if (["yes", "alive", "true", "1"].includes(normalized)) {
+        return true;
+      }
+    }
+    if (typeof value === "number") {
+      return value !== 0;
+    }
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(data, "alive")) {
+    const value = data.alive;
+    if (typeof value === "string") {
+      const normalized = value.trim().toLowerCase();
+      if (["no", "dead", "false", "0"].includes(normalized)) {
+        return false;
+      }
+      if (["yes", "alive", "true", "1"].includes(normalized)) {
+        return true;
+      }
+    }
+    if (typeof value === "number") {
+      return value !== 0;
+    }
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+
+  return true;
 }


### PR DESCRIPTION
## Summary
- add the player status icon column so the legacy player list can show phalla vs dead_phalla
- detect inactive players using the legacy players.active semantics before composing each row to pick the correct image and label
- update empty-state messaging to span the new column count

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6b232803c8328b49db01595d1bff7