### PR TITLE
Add UBB formatting buttons to reply editor

### DIFF
--- a/madia.new/public/legacy/game.html
+++ b/madia.new/public/legacy/game.html
@@ -53,6 +53,11 @@
                     <div class="smallfont">Title</div>
                     <input id="replyTitle" class="bginput" style="width:98%" />
                     <div class="smallfont" style="margin-top:6px;">Message (UBB)</div>
+                    <div class="ubb-toolbar">
+                      <button type="button" class="ubb-button" data-ubb-tag="b" title="Bold">B</button>
+                      <button type="button" class="ubb-button" data-ubb-tag="i" title="Italic">I</button>
+                      <button type="button" class="ubb-button" data-ubb-tag="u" title="Underline">U</button>
+                    </div>
                     <textarea id="replyBody" class="bginput" rows="6" style="width:98%"></textarea>
                     <div style="margin-top:8px;"><button id="postReply" class="button">Post Reply</button></div>
                   </td>

--- a/madia.new/public/legacy/game.js
+++ b/madia.new/public/legacy/game.js
@@ -43,6 +43,7 @@ const els = {
   nextDay: document.getElementById("nextDay"),
   playerListLink: document.getElementById("playerListLink"),
 };
+els.ubbButtons = document.querySelectorAll(".ubb-button[data-ubb-tag]");
 
 if (header?.signInButton) {
   header.signInButton.addEventListener("click", async () => {
@@ -69,6 +70,12 @@ if (!gameId) {
 
 if (els.playerListLink && gameId) {
   els.playerListLink.href = `/legacy/playerlist.html?g=${encodeURIComponent(gameId)}`;
+}
+
+if (els.ubbButtons?.length) {
+  els.ubbButtons.forEach((button) => {
+    button.addEventListener("click", () => applyUbbTag(button.dataset.ubbTag));
+  });
 }
 
 function createMetaRow(html) {
@@ -271,4 +278,31 @@ async function ownerUpdate(action) {
   if (action.nextDay) patch.day = (g.day || 0) + 1;
   await updateDoc(ref, patch);
   await loadGame();
+}
+
+function applyUbbTag(tag) {
+  if (!tag || !els.replyBody) {
+    return;
+  }
+
+  const textarea = els.replyBody;
+  const value = textarea.value || "";
+  const start = textarea.selectionStart ?? 0;
+  const end = textarea.selectionEnd ?? 0;
+  const openTag = `[${tag}]`;
+  const closeTag = `[/${tag}]`;
+  const before = value.slice(0, start);
+  const selected = value.slice(start, end);
+  const after = value.slice(end);
+  const scrollTop = textarea.scrollTop;
+
+  textarea.value = `${before}${openTag}${selected}${closeTag}${after}`;
+  textarea.focus();
+
+  const newSelectionStart = start + openTag.length;
+  const selectionLength = selected.length;
+  const newSelectionEnd = selectionLength ? newSelectionStart + selectionLength : newSelectionStart;
+
+  textarea.setSelectionRange(newSelectionStart, newSelectionEnd);
+  textarea.scrollTop = scrollTop;
 }

--- a/madia.new/public/legacy/phalla.css
+++ b/madia.new/public/legacy/phalla.css
@@ -328,3 +328,21 @@ form { display: inline; }
 label { cursor: default; }
 .normal { font-weight: normal; }
 .inlineimg { vertical-align: middle; }
+.ubb-toolbar {
+        margin: 4px 0px;
+        display: flex;
+        gap: 4px;
+}
+.ubb-button {
+        background: #2f3d66;
+        color: #ffffff;
+        font: bold 10px verdana, geneva, lucida, 'lucida grande', arial, helvetica, sans-serif;
+        border: 1px solid #6C78AB;
+        padding: 1px 5px;
+        line-height: 1.2;
+        cursor: pointer;
+        text-transform: uppercase;
+}
+.ubb-button:hover {
+        background: #3d4d7d;
+}


### PR DESCRIPTION
## Summary
- add a compact UBB toolbar above the quick reply textarea in the legacy game view
- style the new B/I/U controls to match the original forum aesthetic
- hook the buttons up so they wrap the selected text with the appropriate tags

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d6b392f67083289b3f42a29080dfd3