### PR TITLE
feat: consolidate auth flow into legacy header

### DIFF
--- a/madia.new/public/legacy/auth-helpers.js
+++ b/madia.new/public/legacy/auth-helpers.js
@@ -1,0 +1,168 @@
+import {
+  browserLocalPersistence,
+  browserSessionPersistence,
+  setPersistence,
+} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
+import {
+  collection,
+  getDocs,
+  limit,
+  query,
+  where,
+} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
+
+export function sanitizeRedirect(value, { fallback = "/legacy/index.html" } = {}) {
+  if (!value) return fallback;
+  try {
+    const url = new URL(value, location.origin);
+    if (url.origin !== location.origin) {
+      return fallback;
+    }
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return fallback;
+  }
+}
+
+export async function resolveIdentifier(db, identifier) {
+  if (!identifier) {
+    throw new Error("Enter your username or email and password.");
+  }
+  if (identifier.includes("@")) {
+    return identifier.toLowerCase();
+  }
+  const usernameLower = identifier.toLowerCase();
+  const q = query(
+    collection(db, "users"),
+    where("usernameLower", "==", usernameLower),
+    limit(1)
+  );
+  const snapshot = await getDocs(q);
+  if (snapshot.empty) {
+    throw new Error("No account matches that username.");
+  }
+  const data = snapshot.docs[0].data();
+  if (!data.email) {
+    throw new Error("This account does not have an email on file. Use email to sign in.");
+  }
+  return data.email;
+}
+
+export async function ensureUsernameAvailable(db, username) {
+  const q = query(
+    collection(db, "users"),
+    where("usernameLower", "==", username.toLowerCase()),
+    limit(1)
+  );
+  const snapshot = await getDocs(q);
+  if (!snapshot.empty) {
+    throw new Error("Username already in use.");
+  }
+}
+
+export function validateSignup({ username, email, password, confirm }) {
+  if (!username) {
+    throw new Error("Choose a username.");
+  }
+  if (!email) {
+    throw new Error("Enter an email address.");
+  }
+  if (!password) {
+    throw new Error("Enter a password.");
+  }
+  if (password.length < 6) {
+    throw new Error("Choose a password with at least 6 characters.");
+  }
+  if (password !== confirm) {
+    throw new Error("Passwords do not match.");
+  }
+}
+
+export async function applyPersistence(auth, remember) {
+  const persistence = remember
+    ? browserLocalPersistence
+    : browserSessionPersistence;
+  await setPersistence(auth, persistence);
+}
+
+export function setError(element, message) {
+  if (!element) return;
+  if (message) {
+    element.textContent = message;
+    element.style.display = "block";
+  } else {
+    element.textContent = "";
+    element.style.display = "none";
+  }
+}
+
+export function setSubmitting(form, submitEl, submitting, label) {
+  if (submitEl) {
+    if (submitEl.tagName === "BUTTON") {
+      submitEl.textContent = label;
+    } else {
+      submitEl.value = label;
+    }
+    submitEl.disabled = submitting;
+  }
+  if (form) {
+    Array.from(form.elements).forEach((el) => {
+      if (el !== submitEl) {
+        el.disabled = submitting;
+      }
+    });
+  }
+}
+
+export function setButtonLoading(button, loading, label) {
+  if (!button) return;
+  if (button.tagName === "BUTTON") {
+    button.textContent = label;
+  } else {
+    button.value = label;
+  }
+  button.disabled = loading;
+}
+
+export function show(element) {
+  if (!element) return;
+  element.style.display = "block";
+}
+
+export function hide(element) {
+  if (!element) return;
+  element.style.display = "none";
+}
+
+export function describeAuthError(error) {
+  if (!error) {
+    return "An unknown error occurred.";
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  switch (error.code) {
+    case "auth/user-not-found":
+      return "No account found with that email.";
+    case "auth/wrong-password":
+      return "Incorrect password.";
+    case "auth/invalid-email":
+      return "Enter a valid email address.";
+    case "auth/email-already-in-use":
+      return "That email address is already in use.";
+    case "auth/weak-password":
+      return "Choose a stronger password (6+ characters).";
+    case "auth/account-exists-with-different-credential":
+      return "That email is linked to another sign-in method.";
+    case "auth/credential-already-in-use":
+      return "That credential is already linked to another account.";
+    case "auth/popup-closed-by-user":
+      return "Google sign-in was cancelled.";
+    case "auth/popup-blocked":
+      return "Allow popups to sign in with Google.";
+    case "auth/too-many-requests":
+      return "Too many attempts. Try again later.";
+    default:
+      return error.message || "An unknown error occurred.";
+  }
+}

--- a/madia.new/public/legacy/game.html
+++ b/madia.new/public/legacy/game.html
@@ -13,17 +13,6 @@
         <div style="padding:0px 10px 0px 10px">
           <div style="margin:10px 0;">
             <a href="/legacy/index.html">&laquo; back to games</a>
-            <span style="float:right" class="smallfont" id="authArea">
-              <span id="userName"></span>
-              <button id="signIn" class="button">Sign in</button>
-              <button id="signOut" class="button" style="display:none">Sign out</button>
-              <a
-                id="signUpLink"
-                href="#signup"
-                style="margin-left:8px; display:none;"
-                >sign up!</a
-              >
-            </span>
           </div>
 
           <table class="tborder" cellpadding="4" cellspacing="1" border="0" width="100%" align="center">

--- a/madia.new/public/legacy/game.js
+++ b/madia.new/public/legacy/game.js
@@ -1,7 +1,4 @@
-import {
-  onAuthStateChanged,
-  signOut,
-} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
+import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
 import {
   doc,
   getDoc,
@@ -30,10 +27,6 @@ const els = {
   gameTitle: document.getElementById("gameTitle"),
   gameMeta: document.getElementById("gameMeta"),
   postsContainer: document.getElementById("postsContainer"),
-  signIn: document.getElementById("signIn"),
-  signOut: document.getElementById("signOut"),
-  userName: document.getElementById("userName"),
-  signUpLink: document.getElementById("signUpLink"),
   replyForm: document.getElementById("replyForm"),
   replyTitle: document.getElementById("replyTitle"),
   replyBody: document.getElementById("replyBody"),
@@ -48,49 +41,10 @@ const els = {
 };
 
 onAuthStateChanged(auth, async (user) => {
-  els.signIn.style.display = user ? "none" : "inline-block";
-  els.signOut.style.display = user ? "inline-block" : "none";
-  els.userName.textContent = user ? user.displayName : "";
+  header?.setUser(user);
   if (user) {
     await ensureUserDocument(user);
   }
-  if (els.signUpLink) {
-    els.signUpLink.style.display = user ? "none" : "inline";
-  }
-  refreshMembershipAndControls();
-});
-els.signIn.addEventListener("click", () => {
-  const redirect = encodeURIComponent(
-    `${location.pathname}${location.search}${location.hash}`
-  );
-  location.href = `/legacy/login.html?redirect=${redirect}`;
-});
-els.signOut.addEventListener("click", async () => signOut(auth));
-if (els.signUpLink) {
-  els.signUpLink.addEventListener("click", (event) => {
-    event.preventDefault();
-    const redirect = encodeURIComponent(
-      `${location.pathname}${location.search}${location.hash}`
-    );
-    location.href = `/legacy/login.html?redirect=${redirect}#signup`;
-  });
-}
-
-if (header?.signInButton) {
-  header.signInButton.addEventListener("click", async () => {
-    await signInWithPopup(auth, provider);
-  });
-}
-
-if (header?.signOutLink) {
-  header.signOutLink.addEventListener("click", async (event) => {
-    event.preventDefault();
-    await signOut(auth);
-  });
-}
-
-onAuthStateChanged(auth, (user) => {
-  header?.setUser(user);
   refreshMembershipAndControls();
 });
 
@@ -253,14 +207,20 @@ async function refreshMembershipAndControls() {
 
 els.joinButton.addEventListener("click", async () => {
   const user = auth.currentUser;
-  if (!user) return;
+  if (!user) {
+    header?.openAuthPanel("login");
+    return;
+  }
   await setDoc(doc(db, "games", gameId, "players", user.uid), { uid: user.uid, name: user.displayName || "" });
   await refreshMembershipAndControls();
 });
 
 els.leaveButton.addEventListener("click", async () => {
   const user = auth.currentUser;
-  if (!user) return;
+  if (!user) {
+    header?.openAuthPanel("login");
+    return;
+  }
   // Delete player doc keyed by uid
   await deleteDoc(doc(db, "games", gameId, "players", user.uid));
   await refreshMembershipAndControls();
@@ -268,7 +228,10 @@ els.leaveButton.addEventListener("click", async () => {
 
 els.postReply.addEventListener("click", async () => {
   const user = auth.currentUser;
-  if (!user) return;
+  if (!user) {
+    header?.openAuthPanel("login");
+    return;
+  }
   const title = (els.replyTitle.value || "").trim();
   const body = (els.replyBody.value || "").trim();
   if (!body) return;
@@ -291,7 +254,10 @@ els.nextDay.addEventListener("click", async () => ownerUpdate({ nextDay: true })
 
 async function ownerUpdate(action) {
   const user = auth.currentUser;
-  if (!user) return;
+  if (!user) {
+    header?.openAuthPanel("login");
+    return;
+  }
   const ref = doc(db, "games", gameId);
   const snap = await getDoc(ref);
   if (!snap.exists()) return;

--- a/madia.new/public/legacy/header.js
+++ b/madia.new/public/legacy/header.js
@@ -1,3 +1,25 @@
+import {
+  createUserWithEmailAndPassword,
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  signInWithPopup,
+  signOut,
+  updateProfile,
+} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
+import { auth, db, ensureUserDocument, missingConfig, provider } from "./firebase.js";
+import {
+  applyPersistence,
+  describeAuthError,
+  ensureUsernameAvailable,
+  hide,
+  resolveIdentifier,
+  setButtonLoading,
+  setError,
+  setSubmitting,
+  show,
+  validateSignup,
+} from "./auth-helpers.js";
+
 export function initLegacyHeader({ containerId = "legacyHeader" } = {}) {
   const container = document.getElementById(containerId);
   if (!container) {
@@ -7,12 +29,23 @@ export function initLegacyHeader({ containerId = "legacyHeader" } = {}) {
   container.innerHTML = `
     <!-- logo -->
     <a name="top"></a>
-    <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" style="background-image:url(/images/head_back.gif)">
+    <table
+      border="0"
+      width="100%"
+      cellpadding="0"
+      cellspacing="0"
+      align="center"
+      style="background-image:url(/images/head_back.gif)"
+    >
       <tr>
         <td align="left" valign="top" width="90%">
           <a href="http://www.penny-arcade.com/" style="border:none;text-decoration:none;">&nbsp;</a>
         </td>
-        <td nowrap="nowrap" valign="top" style="padding-top:15px;padding-right:15px;">
+        <td
+          nowrap="nowrap"
+          valign="top"
+          style="padding-top:15px;padding-right:15px;position:relative;"
+        >
           <div class="smallfont">
             <span id="legacyHeaderWelcome" style="display:none;">
               <strong>
@@ -21,14 +54,130 @@ export function initLegacyHeader({ containerId = "legacyHeader" } = {}) {
               </strong>
             </span>
             <span id="legacyHeaderAnon">
-              <button id="legacyHeaderSignIn" class="button">Sign in with Google</button>
+              <button id="legacyHeaderTrigger" class="button">Sign in / Sign up</button>
             </span>
+          </div>
+          <div id="legacyHeaderAuthPanel" class="legacy-auth-panel" style="display:none;">
+            <button
+              type="button"
+              id="legacyHeaderClosePanel"
+              class="legacy-auth-close"
+              aria-label="Close sign-in form"
+            >
+              &times;
+            </button>
+            <div
+              id="legacyHeaderConfigWarning"
+              class="smallfont legacy-auth-warning"
+              style="display:none;"
+            ></div>
+            <div class="legacy-auth-tabs smallfont">
+              <button type="button" id="legacyHeaderShowLogin" class="legacy-auth-tab active">
+                Log in
+              </button>
+              <button type="button" id="legacyHeaderShowSignup" class="legacy-auth-tab">
+                Sign up
+              </button>
+            </div>
+            <div id="legacyHeaderLoginSection" class="legacy-auth-section">
+              <div
+                id="legacyHeaderLoginError"
+                class="smallfont legacy-auth-error"
+                style="display:none;"
+              ></div>
+              <form id="legacyHeaderLoginForm">
+                <label class="smallfont" for="legacyHeaderLoginUsername">Username or Email</label>
+                <input
+                  type="text"
+                  id="legacyHeaderLoginUsername"
+                  class="bginput"
+                  autocomplete="username"
+                />
+                <label class="smallfont" for="legacyHeaderLoginPassword">Password</label>
+                <input
+                  type="password"
+                  id="legacyHeaderLoginPassword"
+                  class="bginput"
+                  autocomplete="current-password"
+                />
+                <label class="smallfont legacy-auth-remember">
+                  <input type="checkbox" id="legacyHeaderLoginRemember" checked />
+                  remember me
+                </label>
+                <input
+                  type="submit"
+                  id="legacyHeaderLoginSubmit"
+                  class="button"
+                  value="Log in"
+                />
+              </form>
+              <button id="legacyHeaderGoogleButton" class="button legacy-auth-google">
+                Sign in with Google
+              </button>
+            </div>
+            <div
+              id="legacyHeaderSignupSection"
+              class="legacy-auth-section"
+              style="display:none;"
+            >
+              <div
+                id="legacyHeaderSignupError"
+                class="smallfont legacy-auth-error"
+                style="display:none;"
+              ></div>
+              <form id="legacyHeaderSignupForm">
+                <label class="smallfont" for="legacyHeaderSignupUsername">Username</label>
+                <input
+                  type="text"
+                  id="legacyHeaderSignupUsername"
+                  class="bginput"
+                  autocomplete="nickname"
+                />
+                <label class="smallfont" for="legacyHeaderSignupEmail">Email address</label>
+                <input
+                  type="email"
+                  id="legacyHeaderSignupEmail"
+                  class="bginput"
+                  autocomplete="email"
+                />
+                <label class="smallfont" for="legacyHeaderSignupPassword">Password</label>
+                <input
+                  type="password"
+                  id="legacyHeaderSignupPassword"
+                  class="bginput"
+                  autocomplete="new-password"
+                />
+                <label class="smallfont" for="legacyHeaderSignupConfirm">Confirm password</label>
+                <input
+                  type="password"
+                  id="legacyHeaderSignupConfirm"
+                  class="bginput"
+                  autocomplete="new-password"
+                />
+                <div class="smallfont" style="margin:6px 0;">
+                  Email is required for account recovery and multi-login support.
+                </div>
+                <input
+                  type="submit"
+                  id="legacyHeaderSignupSubmit"
+                  class="button"
+                  value="Sign up"
+                />
+              </form>
+            </div>
           </div>
         </td>
       </tr>
     </table>
     <!-- /logo -->
-    <table width="100%" style="background-image:url(/images/nav_back.gif)" align="center" border="0" cellpadding="0" cellspacing="0">
+    <table
+      width="100%"
+      style="background-image:url(/images/nav_back.gif)"
+      align="center"
+      border="0"
+      cellpadding="0"
+      cellspacing="0"
+    >
       <tr>
         <td align="left" valign="top" height="48">
           <table width="50%" align="left" border="0" cellspacing="0" cellpadding="0">
@@ -41,33 +190,240 @@ export function initLegacyHeader({ containerId = "legacyHeader" } = {}) {
     </table>
   `;
 
-  const signInButton = container.querySelector("#legacyHeaderSignIn");
-  const signOutLink = container.querySelector("#legacyHeaderLogout");
-  const welcome = container.querySelector("#legacyHeaderWelcome");
-  const anon = container.querySelector("#legacyHeaderAnon");
-  const profileLink = container.querySelector("#legacyHeaderProfile");
+  const els = {
+    welcome: container.querySelector("#legacyHeaderWelcome"),
+    anon: container.querySelector("#legacyHeaderAnon"),
+    profileLink: container.querySelector("#legacyHeaderProfile"),
+    signOutLink: container.querySelector("#legacyHeaderLogout"),
+    trigger: container.querySelector("#legacyHeaderTrigger"),
+    panel: container.querySelector("#legacyHeaderAuthPanel"),
+    closePanel: container.querySelector("#legacyHeaderClosePanel"),
+    configWarning: container.querySelector("#legacyHeaderConfigWarning"),
+    loginSection: container.querySelector("#legacyHeaderLoginSection"),
+    loginForm: container.querySelector("#legacyHeaderLoginForm"),
+    loginError: container.querySelector("#legacyHeaderLoginError"),
+    loginUsername: container.querySelector("#legacyHeaderLoginUsername"),
+    loginPassword: container.querySelector("#legacyHeaderLoginPassword"),
+    loginRemember: container.querySelector("#legacyHeaderLoginRemember"),
+    loginSubmit: container.querySelector("#legacyHeaderLoginSubmit"),
+    googleButton: container.querySelector("#legacyHeaderGoogleButton"),
+    signupSection: container.querySelector("#legacyHeaderSignupSection"),
+    signupForm: container.querySelector("#legacyHeaderSignupForm"),
+    signupError: container.querySelector("#legacyHeaderSignupError"),
+    signupUsername: container.querySelector("#legacyHeaderSignupUsername"),
+    signupEmail: container.querySelector("#legacyHeaderSignupEmail"),
+    signupPassword: container.querySelector("#legacyHeaderSignupPassword"),
+    signupConfirm: container.querySelector("#legacyHeaderSignupConfirm"),
+    signupSubmit: container.querySelector("#legacyHeaderSignupSubmit"),
+    showLogin: container.querySelector("#legacyHeaderShowLogin"),
+    showSignup: container.querySelector("#legacyHeaderShowSignup"),
+  };
 
-  function setUser(user) {
-    if (!welcome || !anon) return;
+  let currentMode = "login";
+  let panelVisible = false;
+
+  function updateUser(user) {
     if (user) {
-      welcome.style.display = "block";
-      anon.style.display = "none";
-      if (profileLink) {
+      show(els.welcome);
+      hide(els.anon);
+      if (els.profileLink) {
         const label = user.displayName || user.email || "profile";
-        profileLink.textContent = label;
-        profileLink.href = `/legacy/member.html?u=${encodeURIComponent(user.uid)}`;
+        els.profileLink.textContent = label;
+        els.profileLink.href = `/legacy/member.html?u=${encodeURIComponent(user.uid)}`;
       }
+      closePanel();
     } else {
-      welcome.style.display = "none";
-      anon.style.display = "block";
+      hide(els.welcome);
+      show(els.anon);
     }
+  }
+
+  function setMode(mode) {
+    currentMode = mode;
+    if (mode === "signup") {
+      hide(els.loginSection);
+      show(els.signupSection);
+      els.showSignup?.classList.add("active");
+      els.showLogin?.classList.remove("active");
+    } else {
+      show(els.loginSection);
+      hide(els.signupSection);
+      els.showLogin?.classList.add("active");
+      els.showSignup?.classList.remove("active");
+    }
+  }
+
+  function openPanel(mode = currentMode) {
+    setMode(mode);
+    if (!panelVisible) {
+      els.panel?.setAttribute("aria-hidden", "false");
+      show(els.panel);
+      panelVisible = true;
+      const focusTarget =
+        mode === "signup" ? els.signupUsername : els.loginUsername;
+      focusTarget?.focus();
+    }
+  }
+
+  function closePanel() {
+    if (!panelVisible) return;
+    hide(els.panel);
+    els.panel?.setAttribute("aria-hidden", "true");
+    panelVisible = false;
+  }
+
+  function togglePanel(event, mode) {
+    event?.preventDefault();
+    event?.stopPropagation();
+    if (panelVisible && mode === currentMode) {
+      closePanel();
+    } else {
+      openPanel(mode);
+    }
+  }
+
+  function outsideClickListener(event) {
+    if (!panelVisible) return;
+    if (!els.panel?.contains(event.target) && event.target !== els.trigger) {
+      closePanel();
+    }
+  }
+
+  document.addEventListener("click", outsideClickListener);
+
+  els.trigger?.addEventListener("click", (event) => togglePanel(event, currentMode));
+  els.closePanel?.addEventListener("click", (event) => {
+    event.preventDefault();
+    closePanel();
+  });
+  els.showLogin?.addEventListener("click", (event) => {
+    event.preventDefault();
+    openPanel("login");
+  });
+  els.showSignup?.addEventListener("click", (event) => {
+    event.preventDefault();
+    openPanel("signup");
+  });
+
+  if (els.signOutLink) {
+    els.signOutLink.addEventListener("click", async (event) => {
+      event.preventDefault();
+      await signOut(auth);
+    });
+  }
+
+  if (els.loginForm) {
+    els.loginForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      if (missingConfig) return;
+
+      const identifier = (els.loginUsername?.value || "").trim();
+      const password = els.loginPassword?.value || "";
+      const remember = Boolean(els.loginRemember?.checked);
+
+      setError(els.loginError, "");
+      setSubmitting(els.loginForm, els.loginSubmit, true, "Logging in...");
+
+      try {
+        await applyPersistence(auth, remember);
+        const email = await resolveIdentifier(db, identifier);
+        const credential = await signInWithEmailAndPassword(auth, email, password);
+        await ensureUserDocument(credential.user);
+        closePanel();
+      } catch (error) {
+        setError(els.loginError, describeAuthError(error));
+      } finally {
+        setSubmitting(els.loginForm, els.loginSubmit, false, "Log in");
+      }
+    });
+  }
+
+  if (els.googleButton) {
+    els.googleButton.addEventListener("click", async (event) => {
+      event.preventDefault();
+      if (missingConfig) return;
+
+      setError(els.loginError, "");
+      setButtonLoading(els.googleButton, true, "Signing in...");
+      try {
+        await applyPersistence(auth, true);
+        const credential = await signInWithPopup(auth, provider);
+        await ensureUserDocument(credential.user);
+        closePanel();
+      } catch (error) {
+        setError(els.loginError, describeAuthError(error));
+      } finally {
+        setButtonLoading(els.googleButton, false, "Sign in with Google");
+      }
+    });
+  }
+
+  if (els.signupForm) {
+    els.signupForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      if (missingConfig) return;
+
+      const username = (els.signupUsername?.value || "").trim();
+      const email = (els.signupEmail?.value || "").trim();
+      const password = els.signupPassword?.value || "";
+      const confirm = els.signupConfirm?.value || "";
+
+      setError(els.signupError, "");
+      setSubmitting(els.signupForm, els.signupSubmit, true, "Signing up...");
+
+      try {
+        validateSignup({ username, email, password, confirm });
+        await ensureUsernameAvailable(db, username);
+        const credential = await createUserWithEmailAndPassword(auth, email, password);
+        await updateProfile(credential.user, { displayName: username });
+        await ensureUserDocument(credential.user, {
+          username,
+          email,
+          displayName: username,
+        });
+        closePanel();
+      } catch (error) {
+        setError(els.signupError, describeAuthError(error));
+      } finally {
+        setSubmitting(els.signupForm, els.signupSubmit, false, "Sign up");
+      }
+    });
+  }
+
+  if (missingConfig) {
+    show(els.configWarning);
+    els.configWarning.textContent =
+      "Firebase configuration required. Update public/legacy/firebase.js before signing in.";
+    disableSection(els.loginSection);
+    disableSection(els.signupSection);
+    if (els.googleButton) {
+      els.googleButton.disabled = true;
+    }
+  }
+
+  onAuthStateChanged(auth, (user) => {
+    updateUser(user);
+  });
+
+  function disableSection(section) {
+    if (!section) return;
+    section.style.opacity = "0.5";
+    const controls = section.querySelectorAll("input, button");
+    controls.forEach((control) => {
+      control.disabled = true;
+    });
+  }
+
+  function destroy() {
+    document.removeEventListener("click", outsideClickListener);
   }
 
   return {
     container,
-    signInButton,
-    signOutLink,
-    profileLink,
-    setUser,
+    openAuthPanel: openPanel,
+    closeAuthPanel: closePanel,
+    profileLink: els.profileLink,
+    setUser: updateUser,
+    destroy,
   };
 }

--- a/madia.new/public/legacy/index.html
+++ b/madia.new/public/legacy/index.html
@@ -13,17 +13,6 @@
         <div style="padding:0px 10px 0px 10px">
           <div style="margin:10px 0;">
             <a href="/legacy/sitesummary.html" id="siteSummaryLink">site summary</a>
-            <a href="/legacy/member.html" id="profileLink" style="margin-left:12px; display:none;">profile</a>
-            <span style="float:right" class="smallfont" id="authArea">
-              <button id="signIn" class="button">Sign in</button>
-              <button id="signOut" class="button" style="display:none">Sign out</button>
-              <a
-                id="signUpLink"
-                href="#signup"
-                style="margin-left:8px; display:none;"
-                >sign up!</a
-              >
-            </span>
           </div>
 
           <!-- Games table (games.asp look) -->

--- a/madia.new/public/legacy/legacy.js
+++ b/madia.new/public/legacy/legacy.js
@@ -1,7 +1,4 @@
-import {
-  onAuthStateChanged,
-  signOut,
-} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
+import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
 import {
   collection,
   doc,
@@ -12,16 +9,12 @@ import {
   limit,
   onSnapshot,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
-import { auth, db, provider, ensureUserDocument, missingConfig } from "./firebase.js";
+import { auth, db, ensureUserDocument, missingConfig } from "./firebase.js";
 import { initLegacyHeader } from "./header.js";
 
 const header = initLegacyHeader();
 const els = {
   gamesBody: document.getElementById("gamesBody"),
-  signIn: document.getElementById("signIn"),
-  signOut: document.getElementById("signOut"),
-  profileLink: document.getElementById("profileLink"),
-  signUpLink: document.getElementById("signUpLink"),
 };
 
 let currentUser = null;
@@ -55,30 +48,10 @@ function stopWatchingGames({ signedOut = false } = {}) {
   }
 }
 
-if (header?.signInButton) {
-  header.signInButton.addEventListener("click", async () => {
-    await signInWithPopup(auth, provider);
-  });
-}
-
-if (header?.signOutLink) {
-  header.signOutLink.addEventListener("click", async (event) => {
-    event.preventDefault();
-    await signOut(auth);
-  });
-}
-
 onAuthStateChanged(auth, async (user) => {
   currentUser = user;
   header?.setUser(user);
-  els.signIn.style.display = user ? "none" : "inline-block";
-  els.signOut.style.display = user ? "inline-block" : "none";
-  els.profileLink.style.display = user ? "inline-block" : "none";
-  if (els.signUpLink) {
-    els.signUpLink.style.display = user ? "none" : "inline";
-  }
   if (user) {
-    els.profileLink.href = `/legacy/member.html?u=${encodeURIComponent(user.uid)}`;
     await ensureUserDocument(user);
   }
   if (missingConfig) {
@@ -91,25 +64,6 @@ onAuthStateChanged(auth, async (user) => {
   } else {
     stopWatchingGames({ signedOut: true });
   }
-});
-
-els.signIn.addEventListener("click", () => {
-  const redirect = encodeURIComponent(
-    `${location.pathname}${location.search}${location.hash}`
-  );
-  location.href = `/legacy/login.html?redirect=${redirect}`;
-});
-if (els.signUpLink) {
-  els.signUpLink.addEventListener("click", (event) => {
-    event.preventDefault();
-    const redirect = encodeURIComponent(
-      `${location.pathname}${location.search}${location.hash}`
-    );
-    location.href = `/legacy/login.html?redirect=${redirect}#signup`;
-  });
-}
-els.signOut.addEventListener("click", async () => {
-  await signOut(auth);
 });
 
 function sectionHeader(label) {

--- a/madia.new/public/legacy/member.js
+++ b/madia.new/public/legacy/member.js
@@ -1,8 +1,4 @@
-import {
-  onAuthStateChanged,
-  signInWithPopup,
-  signOut,
-} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
+import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
 import {
   collection,
   collectionGroup,
@@ -15,23 +11,10 @@ import {
   setDoc,
   getDoc,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
-import { auth, db, ensureUserDocument, missingConfig, provider } from "./firebase.js";
+import { auth, db, ensureUserDocument, missingConfig } from "./firebase.js";
 import { initLegacyHeader } from "./header.js";
 
 const header = initLegacyHeader();
-
-if (header?.signInButton) {
-  header.signInButton.addEventListener("click", async () => {
-    await signInWithPopup(auth, provider);
-  });
-}
-
-if (header?.signOutLink) {
-  header.signOutLink.addEventListener("click", async (event) => {
-    event.preventDefault();
-    await signOut(auth);
-  });
-}
 
 function getParam(name) {
   const params = new URLSearchParams(location.search);

--- a/madia.new/public/legacy/phalla.css
+++ b/madia.new/public/legacy/phalla.css
@@ -319,6 +319,91 @@ td.thead, div.thead { padding: 0px 4px; }
 .pagenav a { text-decoration: none; }
 .pagenav td { padding: 2px 4px 2px 4px; }
 
+.legacy-auth-panel {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  width: 260px;
+  margin-top: 8px;
+  padding: 12px 14px 16px 14px;
+  background: rgba(9, 38, 85, 0.96);
+  border: 1px solid #32435d;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.45);
+  z-index: 1000;
+  border-radius: 4px;
+}
+
+.legacy-auth-close {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  background: transparent;
+  border: none;
+  color: #f9a906;
+  font-size: 20px;
+  cursor: pointer;
+}
+
+.legacy-auth-tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 10px;
+}
+
+.legacy-auth-tab {
+  flex: 1;
+  background: #1f2a44;
+  border: 1px solid #32435d;
+  color: #dee2f2;
+  padding: 4px 0;
+  cursor: pointer;
+}
+
+.legacy-auth-tab.active {
+  background: #324580;
+  color: #ffffff;
+}
+
+.legacy-auth-section {
+  margin-bottom: 16px;
+}
+
+.legacy-auth-section form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.legacy-auth-section input.bginput {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.legacy-auth-section .button {
+  width: 100%;
+}
+
+.legacy-auth-google {
+  margin-top: 8px;
+  width: 100%;
+}
+
+.legacy-auth-error {
+  color: #f9a906;
+  margin-bottom: 6px;
+}
+
+.legacy-auth-warning {
+  color: #f9a906;
+  margin-bottom: 8px;
+}
+
+.legacy-auth-remember {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 /* ***** define margin and font-size for elements inside panels ***** */
 .fieldset { margin-bottom: 6px; }
 .fieldset, .fieldset td, .fieldset p, .fieldset li { font-size: 11px; }

--- a/madia.new/public/legacy/playerlist.js
+++ b/madia.new/public/legacy/playerlist.js
@@ -1,31 +1,14 @@
-import {
-  onAuthStateChanged,
-  signInWithPopup,
-  signOut,
-} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
+import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
 import {
   collection,
   doc,
   getDoc,
   getDocs,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
-import { auth, db, missingConfig, provider } from "./firebase.js";
+import { auth, db, missingConfig } from "./firebase.js";
 import { initLegacyHeader } from "./header.js";
 
 const header = initLegacyHeader();
-
-if (header?.signInButton) {
-  header.signInButton.addEventListener("click", async () => {
-    await signInWithPopup(auth, provider);
-  });
-}
-
-if (header?.signOutLink) {
-  header.signOutLink.addEventListener("click", async (event) => {
-    event.preventDefault();
-    await signOut(auth);
-  });
-}
 
 onAuthStateChanged(auth, (user) => {
   header?.setUser(user);

--- a/madia.new/public/legacy/sitesummary.html
+++ b/madia.new/public/legacy/sitesummary.html
@@ -13,24 +13,6 @@
         <div style="padding:0px 10px 0px 10px">
           <div style="margin:10px 0;">
             <a href="/legacy/index.html">list of games</a>
-            <a
-              href="/legacy/member.html"
-              id="profileLink"
-              style="margin-left:12px; display:none;"
-              >profile</a
-            >
-            <span style="float:right" class="smallfont" id="authArea">
-              <button id="signIn" class="button">Sign in</button>
-              <button id="signOut" class="button" style="display:none">
-                Sign out
-              </button>
-              <a
-                id="signUpLink"
-                href="#signup"
-                style="margin-left:8px; display:none;"
-                >sign up!</a
-              >
-            </span>
           </div>
           <div id="summaryContent" style="margin-top:12px;">
             <div class="smallfont" style="color:#F9A906;">

--- a/madia.new/public/legacy/sitesummary.js
+++ b/madia.new/public/legacy/sitesummary.js
@@ -1,7 +1,4 @@
-import {
-  onAuthStateChanged,
-  signOut,
-} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
+import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
 import {
   collection,
   getDocs,
@@ -13,10 +10,6 @@ import { auth, db, ensureUserDocument, missingConfig } from "./firebase.js";
 import { initLegacyHeader } from "./header.js";
 
 const summaryContent = document.getElementById("summaryContent");
-const signInButton = document.getElementById("signIn");
-const signOutButton = document.getElementById("signOut");
-const profileLink = document.getElementById("profileLink");
-const signUpLink = document.getElementById("signUpLink");
 const header = initLegacyHeader();
 
 if (missingConfig) {
@@ -25,51 +18,7 @@ if (missingConfig) {
   renderInfo("Sign in to view site summary.");
 }
 
-signInButton?.addEventListener("click", () => {
-  const redirect = encodeURIComponent(
-    `${location.pathname}${location.search}${location.hash}`
-  );
-  location.href = `/legacy/login.html?redirect=${redirect}`;
-});
-
-signUpLink?.addEventListener("click", (event) => {
-  event.preventDefault();
-  const redirect = encodeURIComponent(
-    `${location.pathname}${location.search}${location.hash}`
-  );
-  location.href = `/legacy/login.html?redirect=${redirect}#signup`;
-});
-
-// This listener is for the sign-out button within the main content
-signOutButton?.addEventListener("click", async (event) => {
-    event.preventDefault();
-    await signOut(auth);
-});
-
-// This listener is for the sign-out link in the refactored header
-if (header?.signOutLink) {
-  header.signOutLink.addEventListener("click", async (event) => {
-    event.preventDefault();
-    await signOut(auth);
-  });
-}
-
 onAuthStateChanged(auth, async (user) => {
-  // Update UI elements from the codex branch
-  if (signInButton) signInButton.style.display = user ? "none" : "inline-block";
-  if (signOutButton) signOutButton.style.display = user ? "inline-block" : "none";
-  if (profileLink) {
-    profileLink.style.display = user ? "inline-block" : "none";
-    if (user) {
-      profileLink.href = `/legacy/member.html?u=${encodeURIComponent(user.uid)}`;
-      await ensureUserDocument(user);
-    }
-  }
-  if (signUpLink) {
-    signUpLink.style.display = user ? "none" : "inline";
-  }
-  
-  // Also update the header component from the main branch
   header?.setUser(user);
 
   if (missingConfig) {
@@ -82,6 +31,7 @@ onAuthStateChanged(auth, async (user) => {
   }
 
   try {
+    await ensureUserDocument(user);
     renderInfo("Loading summary...");
     await loadSummary();
   } catch (error) {

--- a/madia.new/public/legacy/userlist.js
+++ b/madia.new/public/legacy/userlist.js
@@ -1,26 +1,9 @@
-import {
-  onAuthStateChanged,
-  signInWithPopup,
-  signOut,
-} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
+import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
 import { collection, getDocs } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
-import { auth, db, missingConfig, provider } from "./firebase.js";
+import { auth, db, missingConfig } from "./firebase.js";
 import { initLegacyHeader } from "./header.js";
 
 const header = initLegacyHeader();
-
-if (header?.signInButton) {
-  header.signInButton.addEventListener("click", async () => {
-    await signInWithPopup(auth, provider);
-  });
-}
-
-if (header?.signOutLink) {
-  header.signOutLink.addEventListener("click", async (event) => {
-    event.preventDefault();
-    await signOut(auth);
-  });
-}
 
 onAuthStateChanged(auth, (user) => {
   header?.setUser(user);


### PR DESCRIPTION
## Summary
- add a shared auth helper module that centralizes form and validation utilities
- embed email/password and Google sign-in/sign-up forms directly into the legacy header dropdown
- remove scattered auth controls from legacy pages and update styles/scripts to rely on the shared header

## Testing
- manual: served public site via `python -m http.server 5000` and exercised header auth UI

------
https://chatgpt.com/codex/tasks/task_e_68d6b79892088328abad4986e000a439