### PR TITLE
feat: add profile avatar upload and display name editing

### DIFF
--- a/madia.new/public/legacy/firebase.js
+++ b/madia.new/public/legacy/firebase.js
@@ -10,6 +10,7 @@ import {
   serverTimestamp,
   setDoc,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
+import { getStorage } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-storage.js";
 
 const firebaseConfig = {
   apiKey: "AIzaSyDLVQ_ncruYo7Xd0tCzh8RIvlmzhrQYt_8",
@@ -29,6 +30,7 @@ const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const db = getFirestore(app);
 const provider = new GoogleAuthProvider();
+const storage = getStorage(app);
 
 async function ensureUserDocument(user, overrides = {}) {
   if (!user || missingConfig) {
@@ -83,4 +85,5 @@ export {
   firebaseConfig,
   missingConfig,
   ensureUserDocument,
+  storage,
 };

--- a/madia.new/public/legacy/member.html
+++ b/madia.new/public/legacy/member.html
@@ -28,6 +28,45 @@
 
           <table width="100%" cellpadding="4" cellspacing="10" border="0">
             <tr>
+              <td colspan="2" class="panelsurround">
+                <div class="panel">
+                  <div style="font-weight:bold; margin-bottom:6px;">Profile Summary</div>
+                  <div class="profile-card">
+                    <img
+                      id="profileAvatar"
+                      class="profile-avatar"
+                      alt="Member avatar"
+                      src="/images/avatars/001.jpg"
+                    />
+                    <div>
+                      <div id="profileDisplayName" class="profile-display-name"></div>
+                      <div id="profileEmail" class="profile-email"></div>
+                    </div>
+                  </div>
+                  <form id="profileForm" class="profile-form" onsubmit="return false;">
+                    <table cellpadding="3" cellspacing="0" border="0">
+                      <tr>
+                        <td class="smallfont" style="white-space:nowrap;">Display Name:</td>
+                        <td><input class="bginput" id="displayNameInput" maxlength="40" /></td>
+                      </tr>
+                      <tr>
+                        <td class="smallfont" style="white-space:nowrap;">Thumbnail:</td>
+                        <td>
+                          <input id="avatarInput" type="file" accept="image/*" />
+                          <div class="smallfont">Images are resized to 64&times;64 automatically.</div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td></td>
+                        <td><button class="button" id="profileSaveBtn">Update Display Name</button></td>
+                      </tr>
+                    </table>
+                  </form>
+                  <div class="smallfont profile-status" id="profileStatus"></div>
+                </div>
+              </td>
+            </tr>
+            <tr>
               <td class="panelsurround" valign="top" width="50%">
                 <div class="panel">
                   <div style="font-weight:bold; margin-bottom:6px;">Games You Play</div>

--- a/madia.new/public/legacy/member.js
+++ b/madia.new/public/legacy/member.js
@@ -1,4 +1,7 @@
-import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
+import {
+  onAuthStateChanged,
+  updateProfile,
+} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
 import {
   collection,
   collectionGroup,
@@ -11,7 +14,18 @@ import {
   setDoc,
   getDoc,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
-import { auth, db, ensureUserDocument, missingConfig } from "./firebase.js";
+import {
+  auth,
+  db,
+  ensureUserDocument,
+  missingConfig,
+  storage,
+} from "./firebase.js";
+import {
+  getDownloadURL,
+  ref as storageRef,
+  uploadBytes,
+} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-storage.js";
 import { initLegacyHeader } from "./header.js";
 
 const header = initLegacyHeader();
@@ -23,6 +37,13 @@ function getParam(name) {
 
 const els = {
   profileInfo: document.getElementById("profileInfo"),
+  profileAvatar: document.getElementById("profileAvatar"),
+  profileDisplayName: document.getElementById("profileDisplayName"),
+  profileEmail: document.getElementById("profileEmail"),
+  profileForm: document.getElementById("profileForm"),
+  displayNameInput: document.getElementById("displayNameInput"),
+  avatarInput: document.getElementById("avatarInput"),
+  profileStatus: document.getElementById("profileStatus"),
   gamesYouPlay: document.getElementById("gamesYouPlay"),
   gamesYouOwn: document.getElementById("gamesYouOwn"),
   createForm: document.getElementById("createGameForm"),
@@ -31,8 +52,13 @@ const els = {
   createBtn: document.getElementById("createBtn"),
 };
 
+const defaultAvatar = "/images/avatars/001.jpg";
+const MAX_AVATAR_SIZE = 5 * 1024 * 1024;
+
 let currentUser = null;
 const viewedUid = getParam("u");
+const profileDocRef = viewedUid ? doc(db, "users", viewedUid) : null;
+let profileData = null;
 
 onAuthStateChanged(auth, async (user) => {
   header?.setUser(user);
@@ -40,21 +66,393 @@ onAuthStateChanged(auth, async (user) => {
   if (user) {
     await ensureUserDocument(user);
   }
-  renderProfileHeader();
+  await loadProfile();
   await loadLists();
 });
 
-function renderProfileHeader() {
-  if (!viewedUid) {
-    els.profileInfo.textContent = "Missing member id";
-    els.createForm.style.display = "none";
+async function loadProfile() {
+  setProfileStatus("");
+
+  const mine = currentUser && currentUser.uid === viewedUid;
+
+  if (!viewedUid || !profileDocRef) {
+    profileData = null;
+    renderProfileHeader();
+    renderProfileCard();
     return;
   }
+
+  if (missingConfig) {
+    if (mine && currentUser) {
+      profileData = {
+        displayName: currentUser.displayName || "",
+        email: currentUser.email || "",
+        photoURL: currentUser.photoURL || "",
+      };
+      setProfileStatus("Configure Firebase to edit your profile.", "info");
+    } else {
+      profileData = {};
+    }
+    renderProfileHeader();
+    renderProfileCard();
+    return;
+  }
+
+  try {
+    const snapshot = await getDoc(profileDocRef);
+    profileData = snapshot.exists() ? snapshot.data() : {};
+  } catch (error) {
+    console.error("Failed to load user profile", error);
+    profileData = profileData || {};
+    if (mine) {
+      setProfileStatus("We couldn't load your profile right now.", "error");
+    }
+  }
+
+  if (mine && currentUser) {
+    profileData = {
+      ...profileData,
+      displayName: profileData.displayName || currentUser.displayName || "",
+      email: profileData.email || currentUser.email || "",
+      photoURL: profileData.photoURL || currentUser.photoURL || "",
+    };
+  }
+
+  renderProfileHeader();
+  renderProfileCard();
+}
+
+function renderProfileHeader() {
+  if (!els.profileInfo) {
+    return;
+  }
+
+  if (!viewedUid) {
+    els.profileInfo.textContent = "Missing member id";
+    if (els.createForm) {
+      els.createForm.style.display = "none";
+    }
+    if (els.profileForm) {
+      els.profileForm.style.display = "none";
+    }
+    return;
+  }
+
   const mine = currentUser && currentUser.uid === viewedUid;
+  const name =
+    profileData?.displayName ||
+    (mine ? currentUser?.displayName : "") ||
+    "";
+  const label = name || viewedUid;
+
   els.profileInfo.innerHTML = mine
-    ? `<b>${currentUser?.displayName || "You"}</b> (you)`
-    : `Member: <b>${viewedUid}</b>`;
-  els.createForm.style.display = mine ? "block" : "none";
+    ? `<b>${label || "You"}</b> (you)`
+    : `Member: <b>${label}</b>`;
+
+  if (els.createForm) {
+    els.createForm.style.display = mine && !missingConfig ? "block" : "none";
+  }
+}
+
+function renderProfileCard() {
+  if (!els.profileAvatar) {
+    return;
+  }
+
+  const mine = currentUser && currentUser.uid === viewedUid;
+  const name =
+    profileData?.displayName ||
+    (mine ? currentUser?.displayName : "") ||
+    "";
+  const email =
+    profileData?.email ||
+    (mine ? currentUser?.email : "") ||
+    "";
+  const photo =
+    profileData?.photoURL ||
+    (mine ? currentUser?.photoURL : "") ||
+    defaultAvatar;
+
+  els.profileAvatar.src = photo;
+
+  if (els.profileDisplayName) {
+    const hasName = Boolean(name);
+    els.profileDisplayName.textContent = hasName
+      ? name
+      : mine
+      ? "(no display name yet)"
+      : "(no display name)";
+    els.profileDisplayName.classList.toggle("empty", !hasName);
+  }
+
+  if (els.profileEmail) {
+    if (email) {
+      els.profileEmail.textContent = email;
+      els.profileEmail.style.display = "block";
+    } else {
+      els.profileEmail.textContent = "";
+      els.profileEmail.style.display = "none";
+    }
+  }
+
+  if (els.profileForm) {
+    els.profileForm.style.display = mine && !missingConfig ? "block" : "none";
+  }
+
+  if (
+    mine &&
+    els.displayNameInput &&
+    document.activeElement !== els.displayNameInput
+  ) {
+    els.displayNameInput.value = name || "";
+  }
+
+  if (!mine && els.profileStatus) {
+    els.profileStatus.textContent = "";
+    els.profileStatus.style.display = "none";
+  }
+}
+
+function setProfileStatus(message, tone = "info") {
+  if (!els.profileStatus) {
+    return;
+  }
+
+  const mine = currentUser && currentUser.uid === viewedUid;
+  if (!mine) {
+    els.profileStatus.textContent = "";
+    els.profileStatus.style.display = "none";
+    return;
+  }
+
+  if (!message) {
+    els.profileStatus.textContent = "";
+    els.profileStatus.style.display = "none";
+    return;
+  }
+
+  const colors = {
+    success: "#8ddf8d",
+    error: "#ffb3a9",
+    info: "#F9A906",
+  };
+
+  els.profileStatus.textContent = message;
+  els.profileStatus.style.display = "block";
+  els.profileStatus.style.color = colors[tone] || colors.info;
+}
+
+function resizeImageTo64(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => {
+        const canvas = document.createElement("canvas");
+        canvas.width = 64;
+        canvas.height = 64;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) {
+          reject(new Error("Unable to process image"));
+          return;
+        }
+        const size = Math.min(img.width, img.height);
+        const sx = (img.width - size) / 2;
+        const sy = (img.height - size) / 2;
+        ctx.imageSmoothingEnabled = true;
+        ctx.imageSmoothingQuality = "high";
+        ctx.clearRect(0, 0, 64, 64);
+        ctx.drawImage(img, sx, sy, size, size, 0, 0, 64, 64);
+        canvas.toBlob((blob) => {
+          if (blob) {
+            resolve(blob);
+          } else {
+            reject(new Error("Unable to resize image"));
+          }
+        }, "image/png");
+      };
+      img.onerror = () => reject(new Error("Unable to load image"));
+      img.src = reader.result;
+    };
+    reader.onerror = () => reject(new Error("Unable to read image"));
+    reader.readAsDataURL(file);
+  });
+}
+
+if (els.profileForm) {
+  els.profileForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const mine = currentUser && currentUser.uid === viewedUid;
+    if (!mine || missingConfig || !profileDocRef) {
+      return;
+    }
+
+    const newName = (els.displayNameInput?.value || "").trim();
+    if (!newName) {
+      setProfileStatus("Display name cannot be empty.", "error");
+      return;
+    }
+    if (newName.length > 40) {
+      setProfileStatus("Display name must be 40 characters or fewer.", "error");
+      return;
+    }
+    if (profileData?.displayName === newName) {
+      setProfileStatus("That display name is already saved.", "info");
+      return;
+    }
+
+    setProfileStatus("Saving display name...", "info");
+
+    let authUpdateFailed = false;
+    if (currentUser) {
+      try {
+        await updateProfile(currentUser, { displayName: newName });
+      } catch (error) {
+        authUpdateFailed = true;
+        console.warn("Failed to update auth display name", error);
+      }
+    }
+
+    try {
+      await setDoc(
+        profileDocRef,
+        {
+          displayName: newName,
+          username: newName,
+          usernameLower: newName.toLowerCase(),
+          updatedAt: serverTimestamp(),
+        },
+        { merge: true }
+      );
+
+      profileData = {
+        ...profileData,
+        displayName: newName,
+        username: newName,
+        usernameLower: newName.toLowerCase(),
+      };
+
+      if (currentUser) {
+        currentUser = auth.currentUser;
+        header?.setUser(auth.currentUser);
+      }
+
+      renderProfileHeader();
+      renderProfileCard();
+
+      if (authUpdateFailed) {
+        setProfileStatus(
+          "Display name saved. Sign out and back in to refresh everywhere.",
+          "info"
+        );
+      } else {
+        setProfileStatus("Display name updated.", "success");
+      }
+    } catch (error) {
+      console.error("Failed to update display name", error);
+      setProfileStatus("Failed to update display name. Try again later.", "error");
+    }
+  });
+}
+
+if (els.avatarInput) {
+  els.avatarInput.addEventListener("change", async (event) => {
+    const input = event.target;
+    const file = input.files && input.files[0];
+    if (!file) {
+      return;
+    }
+
+    const mine = currentUser && currentUser.uid === viewedUid;
+    if (!mine || missingConfig || !profileDocRef) {
+      input.value = "";
+      return;
+    }
+
+    if (file.size > MAX_AVATAR_SIZE) {
+      setProfileStatus("Please choose an image smaller than 5 MB.", "error");
+      input.value = "";
+      return;
+    }
+
+    if (!file.type.startsWith("image/")) {
+      setProfileStatus("Please choose an image file.", "error");
+      input.value = "";
+      return;
+    }
+
+    setProfileStatus("Uploading thumbnail...", "info");
+
+    const previousPhoto = els.profileAvatar?.src || "";
+    let previewUrl = "";
+    let authUpdateFailed = false;
+
+    try {
+      const resized = await resizeImageTo64(file);
+      previewUrl = URL.createObjectURL(resized);
+      if (els.profileAvatar) {
+        els.profileAvatar.src = previewUrl;
+      }
+
+      const avatarRef = storageRef(
+        storage,
+        `thumbnails/${viewedUid}-${Date.now()}.png`
+      );
+      await uploadBytes(avatarRef, resized, { contentType: "image/png" });
+      const downloadUrl = await getDownloadURL(avatarRef);
+
+      if (currentUser) {
+        try {
+          await updateProfile(currentUser, { photoURL: downloadUrl });
+        } catch (error) {
+          authUpdateFailed = true;
+          console.warn("Failed to update auth thumbnail", error);
+        }
+      }
+
+      await setDoc(
+        profileDocRef,
+        { photoURL: downloadUrl, updatedAt: serverTimestamp() },
+        { merge: true }
+      );
+
+      profileData = {
+        ...profileData,
+        photoURL: downloadUrl,
+      };
+
+      if (currentUser) {
+        currentUser = auth.currentUser;
+        header?.setUser(auth.currentUser);
+      }
+
+      renderProfileCard();
+
+      if (authUpdateFailed) {
+        setProfileStatus(
+          "Thumbnail saved. Sign out and back in to refresh everywhere.",
+          "info"
+        );
+      } else {
+        setProfileStatus("Thumbnail updated.", "success");
+      }
+    } catch (error) {
+      console.error("Failed to update thumbnail", error);
+      setProfileStatus(
+        "Couldn't update thumbnail. Please try a different image.",
+        "error"
+      );
+      if (previousPhoto && els.profileAvatar) {
+        els.profileAvatar.src = previousPhoto;
+      }
+    } finally {
+      if (previewUrl) {
+        setTimeout(() => URL.revokeObjectURL(previewUrl), 4000);
+      }
+      input.value = "";
+    }
+  });
 }
 
 async function loadLists() {

--- a/madia.new/public/legacy/phalla.css
+++ b/madia.new/public/legacy/phalla.css
@@ -404,6 +404,56 @@ td.thead, div.thead { padding: 0px 4px; }
   gap: 4px;
 }
 
+.profile-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.profile-avatar {
+  width: 64px;
+  height: 64px;
+  border: 1px solid #6C78AB;
+  background: #1b2647;
+  object-fit: cover;
+}
+
+.profile-display-name {
+  font-size: 14px;
+  font-weight: bold;
+  color: #F9A906;
+}
+
+.profile-display-name.empty {
+  color: #DEE2F2;
+  font-weight: normal;
+  font-style: italic;
+}
+
+.profile-email {
+  font-size: 11px;
+  color: #DEE2F2;
+  margin-top: 2px;
+}
+
+.profile-form {
+  margin-top: 4px;
+}
+
+.profile-form table {
+  font-size: 11px;
+}
+
+.profile-form .bginput {
+  width: 200px;
+}
+
+.profile-status {
+  margin-top: 6px;
+  display: none;
+}
+
 /* ***** define margin and font-size for elements inside panels ***** */
 .fieldset { margin-bottom: 6px; }
 .fieldset, .fieldset td, .fieldset p, .fieldset li { font-size: 11px; }


### PR DESCRIPTION
## Summary
- add a profile summary panel so members can edit display names and upload 64×64 thumbnails
- resize uploads client-side, save them to Firebase Storage, and merge the new data into the user document
- refresh legacy styling to showcase the avatar, metadata, and status messaging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6bc4ce9c88328838a6ad33d1e9df5