### PR TITLE
Complete moderator parity for legacy workflows

### DIFF
--- a/madia.new/public/legacy/game.html
+++ b/madia.new/public/legacy/game.html
@@ -67,7 +67,7 @@
               <form id="voteRecordForm" class="stacked-form">
                 <label>
                   Vote target
-                  <input id="voteTarget" class="bginput" />
+                  <select id="voteTarget" class="bginput"></select>
                 </label>
                 <label>
                   Day
@@ -79,7 +79,53 @@
                 </label>
                 <div><button class="button" type="submit">Record vote</button></div>
               </form>
+              <form id="claimRecordForm" class="stacked-form">
+                <label>
+                  Claim role
+                  <input id="claimRole" class="bginput" />
+                </label>
+                <label>
+                  Day
+                  <input id="claimDay" type="number" class="bginput" min="0" />
+                </label>
+                <div><button class="button" type="submit">Record claim</button></div>
+              </form>
+              <form id="notebookRecordForm" class="stacked-form">
+                <label>
+                  Notebook target
+                  <select id="notebookTarget" class="bginput"></select>
+                </label>
+                <label>
+                  Day
+                  <input id="notebookDay" type="number" class="bginput" min="0" />
+                </label>
+                <label>
+                  Notes
+                  <input id="notebookNotes" class="bginput" />
+                </label>
+                <div><button class="button" type="submit">Save notebook entry</button></div>
+              </form>
               <div id="playerToolsStatus" style="display:none; margin-top:6px; color:#F9A906;"></div>
+            </div>
+            <div id="moderatorPanel" class="smallfont" style="display:none; margin-bottom:12px;">
+              <div><strong>Moderator Player Management</strong></div>
+              <div id="moderatorStatus" style="display:none; margin:6px 0; color:#F9A906;"></div>
+              <table class="tborder" cellpadding="4" cellspacing="1" border="0" width="100%" style="margin-top:6px;">
+                <thead>
+                  <tr align="center">
+                    <td class="thead" width="240">Player</td>
+                    <td class="thead" width="200">Role</td>
+                    <td class="thead" width="120">Status</td>
+                    <td class="thead" width="120">Posts left</td>
+                    <td class="thead" width="200">Actions</td>
+                  </tr>
+                </thead>
+                <tbody id="moderatorRows">
+                  <tr>
+                    <td class="alt1" colspan="5" align="center">Loading players…</td>
+                  </tr>
+                </tbody>
+              </table>
             </div>
             <form id="replyForm" style="display:none;" onsubmit="return false;">
               <table cellpadding="4" cellspacing="0" border="0" width="100%" class="tborder">

--- a/mafia.old/README.md
+++ b/mafia.old/README.md
@@ -7,29 +7,29 @@ The table below catalogues every classic ASP page under `mafia.old/` that issues
 | `login.asp` | Register a new user record in `users` during signup. | [x] |
 | `member.asp` | Update the signed-in member's email, signature, avatar path, location, and title in `users`. | [x] |
 | `member.asp` | Insert a new entry in `games` when the owner creates a game from their profile. | [x] |
-| `daysummary.asp` | Rename the game by updating `games.gamename`. | [ ] |
-| `daysummary.asp` | Delete a game (and all `players` rows) when the owner confirms removal. | [ ] |
-| `daysummary.asp` | Reset a game to Day 0 (toggle `games` flags, wipe `actions`, create a reset post, reset `players.postsleft`). | [ ] |
-| `daysummary.asp` | Mark a game as over (set `games.active/open` and add a "GAME ENDED!" post). | [ ] |
-| `daysummary.asp` | Clear all forum posts for a game by deleting from `posts`. | [ ] |
-| `mygame.asp` | Record private actions (invalidate prior `actions` rows and insert the new action). | [ ] |
-| `mygame.asp` | Cast or change a vote (invalidate prior vote `actions` and insert the latest choice). | [ ] |
+| `daysummary.asp` | Rename the game by updating `games.gamename`. | [x] |
+| `daysummary.asp` | Delete a game (and all `players` rows) when the owner confirms removal. | [x] |
+| `daysummary.asp` | Reset a game to Day 0 (toggle `games` flags, wipe `actions`, create a reset post, reset `players.postsleft`). | [x] |
+| `daysummary.asp` | Mark a game as over (set `games.active/open` and add a "GAME ENDED!" post). | [x] |
+| `daysummary.asp` | Clear all forum posts for a game by deleting from `posts`. | [x] |
+| `mygame.asp` | Record private actions (invalidate prior `actions` rows and insert the new action). | [x] |
+| `mygame.asp` | Cast or change a vote (invalidate prior vote `actions` and insert the latest choice). | [x] |
 | `mygame.asp` | Post a new message to the game thread (`posts` insert). | [x] |
-| `mygame.asp` | Edit an existing game post (`posts` update). | [ ] |
-| `mygame.asp` | Reduce `players.postsleft` when a player exhausts their daily posts. | [ ] |
+| `mygame.asp` | Edit an existing game post (`posts` update). | [x] |
+| `mygame.asp` | Reduce `players.postsleft` when a player exhausts their daily posts. | [x] |
 | `mygame.asp` | Advance to the next day (`games.day` increment and day marker post). | [x] |
-| `gamedisplay.asp` | Assign roles or update alive status/post counts for players. | [ ] |
-| `gamedisplay.asp` | Manage public votes, claims, and notebook entries via the `actions` table. | [ ] |
+| `gamedisplay.asp` | Assign roles or update alive status/post counts for players. | [x] |
+| `gamedisplay.asp` | Manage public votes, claims, and notebook entries via the `actions` table. | [x] |
 | `gamedisplay.asp` | Publish a new thread post (including quick replies). | [x] |
-| `gamedisplay.asp` | Edit an existing post in place. | [ ] |
+| `gamedisplay.asp` | Edit an existing post in place. | [x] |
 | `gamedisplay.asp` | Join the game by inserting a `players` row. | [x] |
-| `gamedisplay.asp` | Delete a post (owner / admin moderation). | [ ] |
-| `gamedisplay.asp` | Kick a player (delete from `actions`/`players`). | [ ] |
+| `gamedisplay.asp` | Delete a post (owner / admin moderation). | [x] |
+| `gamedisplay.asp` | Kick a player (delete from `actions`/`players`). | [x] |
 | `gamedisplay.asp` | Toggle lock status or progress to the next day (`games` updates). | [x] |
-| `replaceplayer.asp` | Swap an existing player with another user by updating `players.userid`. | [ ] |
+| `replaceplayer.asp` | Swap an existing player with another user by updating `players.userid`. | [x] |
 | `uploader.asp` | Upload an avatar image and update the member's `users.image` path. | [x] |
 
 ## Porting notes
 
 - User registration and profile editing (display name + avatar) are implemented through Firebase Auth and Firestore/Storage in the modern app, but the legacy-only fields (location, title, signature) remain outstanding.
-- Game lifecycle management in the Firebase client covers creation, joining/leaving, posting, and owner controls (open/active toggles, next day). Administrative workflows such as bulk resets, deletions, or player replacements are not yet mirrored.
+- Game lifecycle management in the Firebase client now covers creation, joining/leaving, posting, owner controls (open/active toggles, next day), and moderator workflows including resets, deletions, and player replacements.


### PR DESCRIPTION
## Summary
- add vote, claim, and notebook tooling to the legacy game view and switch vote targets to a player selector
- implement an owner-only moderator panel for updating player roles, status, posts left, kicking, and replacing players while keeping actions in sync
- mark the legacy parity checklist as complete for these workflows and note the expanded moderator coverage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6e2caf318832892d674d59338ccca