### PR TITLE
docs: outline firestore setup for legacy actions

### DIFF
--- a/madia.new/FIREBASE.md
+++ b/madia.new/FIREBASE.md
@@ -26,11 +26,22 @@ players:
 
 - `games/{gameId}` documents: `gamename` (string), `description`
   (string), `ownerUserId` (string), `ownerName` (string), `active`
-  (bool), `open` (bool), `day` (number).
-- `games/{gameId}/players/{uid}` documents for each participant.
+  (bool), `open` (bool), `day` (number), `updatedAt` (timestamp).
+- `games/{gameId}/players/{uid}` documents for each participant. The
+  retro moderator tools expect `postsLeft` (number) and `active`
+  (boolean) fields when you reset a game, but they default to `-1` and
+  `true` respectively if you omit them.
 - `games/{gameId}/posts/{postId}` documents: `title` (string), `body`
   (UBB), `authorId` (string), `authorName` (string), `avatar` (string,
-  optional), `sig` (string, optional), `createdAt` (timestamp).
+  optional), `sig` (string, optional), `createdAt` (timestamp),
+  `updatedAt` (timestamp, optional), `editedBy` (string, optional),
+  `editedByName` (string, optional).
+- `games/{gameId}/actions/{actionId}` documents capture private
+  actions and vote history recorded from the legacy UI. Each entry
+  stores `playerId` (string), `username` (string), `actionName`
+  (string), `targetName` (string), `notes` (string), `category`
+  (string, either `private` or `vote`), `day` (number), `valid`
+  (boolean), plus `createdAt`/`updatedAt` timestamps.
 - `users/{uid}` documents: `displayName`, `username`, `usernameLower`
   (all strings), `email` (string), `photoURL` (optional string), and
   timestamps (`createdAt`, `lastLoginAt`). The login page looks up

--- a/madia.new/README.md
+++ b/madia.new/README.md
@@ -94,12 +94,33 @@ service cloud.firestore {
       match /players/{playerId} {
         allow read: if true;
         allow create, delete: if request.auth != null && request.auth.uid == playerId;
+        allow update: if request.auth != null && (
+          request.auth.uid == playerId ||
+          get(/databases/$(database)/documents/games/$(gameId)).data.ownerUserId == request.auth.uid
+        );
       }
 
       match /posts/{postId} {
         allow read: if true;
         allow create: if request.auth != null
           && exists(/databases/$(database)/documents/games/$(gameId)/players/$(request.auth.uid));
+        allow update: if request.auth != null && (
+          request.auth.uid == resource.data.authorId ||
+          get(/databases/$(database)/documents/games/$(gameId)).data.ownerUserId == request.auth.uid
+        );
+        allow delete: if request.auth != null
+          && get(/databases/$(database)/documents/games/$(gameId)).data.ownerUserId == request.auth.uid;
+      }
+
+      match /actions/{actionId} {
+        allow read: if request.auth != null && (
+          request.auth.uid == resource.data.playerId ||
+          get(/databases/$(database)/documents/games/$(gameId)).data.ownerUserId == request.auth.uid
+        );
+        allow create: if request.auth != null && request.resource.data.playerId == request.auth.uid;
+        allow update: if request.auth != null && request.auth.uid == resource.data.playerId;
+        allow delete: if request.auth != null
+          && get(/databases/$(database)/documents/games/$(gameId)).data.ownerUserId == request.auth.uid;
       }
     }
 


### PR DESCRIPTION
## Summary
- expand the documented Firestore rules so moderators can edit posts, reset player quotas, and manage recorded actions from the retro UI
- describe the expected schema for the new `actions` subcollection along with additional player/post metadata fields used by the legacy tools

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d6e3e9fae08328bdce5c86021a4a82