### PR TITLE
feat: convert private action inputs to dropdowns

### DIFF
--- a/madia.new/public/legacy/game.html
+++ b/madia.new/public/legacy/game.html
@@ -52,11 +52,15 @@
               <form id="privateActionForm" class="stacked-form">
                 <label>
                   Action name
-                  <input id="privateActionName" class="bginput" />
+                  <select id="privateActionName" class="bginput"></select>
+                </label>
+                <label id="privateActionNameCustomLabel" style="display:none;">
+                  Custom action name
+                  <input id="privateActionNameCustom" class="bginput" />
                 </label>
                 <label>
                   Target name
-                  <input id="privateActionTarget" class="bginput" />
+                  <select id="privateActionTarget" class="bginput"></select>
                 </label>
                 <label>
                   Day


### PR DESCRIPTION
## Summary
- replace the private action name and target text inputs with dropdowns that mirror the roster
- load optional private action definitions from Firestore and derive options from game/player metadata with a custom fallback
- enforce target requirements and reset the new selectors after recording a private action

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d7014404c48328b7661cf8c3440fd1