### PR TITLE
feat: switch private actions to dropdowns

### DIFF
--- a/madia.new/public/legacy/game.html
+++ b/madia.new/public/legacy/game.html
@@ -52,11 +52,23 @@
               <form id="privateActionForm" class="stacked-form">
                 <label>
                   Action name
-                  <input id="privateActionName" class="bginput" />
+                  <select id="privateActionName" class="bginput"></select>
+                  <input
+                    id="privateActionNameCustom"
+                    class="bginput"
+                    style="display:none; margin-top:6px;"
+                    placeholder="Enter action name"
+                  />
                 </label>
                 <label>
                   Target name
-                  <input id="privateActionTarget" class="bginput" />
+                  <select id="privateActionTarget" class="bginput"></select>
+                  <input
+                    id="privateActionTargetCustom"
+                    class="bginput"
+                    style="display:none; margin-top:6px;"
+                    placeholder="Enter target name"
+                  />
                 </label>
                 <label>
                   Day


### PR DESCRIPTION
## Summary
- replace the private action text inputs with dropdown selectors and optional custom entry fields
- populate the action list from known rules and reuse the player roster for target selection, keeping custom targeting available

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d724fad9bc8328895d25233ac90320