### PR TITLE
Add vote tallies and action history to legacy game view

### DIFF
--- a/docs/mafia-old-logic.md
+++ b/docs/mafia-old-logic.md
@@ -13,12 +13,12 @@ This document summarizes the custom server-side logic implemented in each `mafia
 | `default.asp` | Redirects visitors to the games list. | ✅ | Meta refresh redirect in `public/index.html`. |
 | `daysummary.asp` | GM-only day summary, renaming, reset/close/delete controls. | ✅ | `legacy/daysummary.html` + `daysummary.js` owner tools and action log. |
 | `editpost.asp` | Loads a post for editing when a user is signed in. | ✅ | Inline edit buttons in `legacy/game.js`. |
-| `gamedisplay.asp` | Core thread view: posting, role/admin controls, vote + action handling. | ⚠️ | `legacy/game.html` + `game.js` cover posting, moderation, and actions but lack the legacy auto vote tally table. |
+| `gamedisplay.asp` | Core thread view: posting, role/admin controls, vote + action handling. | ✅ | `legacy/game.html` + `game.js` cover posting, moderation, actions, and render the inline day vote tally table. |
 | `games.asp` | Lists games grouped by status with last-post metadata. | ✅ | `legacy/index.html` + `legacy.js` live game list. |
 | `helloworld.asp` | Test page opening a DB connection and printing "hello world". | ❌ | No equivalent debug page in `madia.new`. |
 | `login.asp` | Handles username/password sign-in, cookie persistence, and registration. | ✅ | Firebase auth flows in `legacy/login.html` + `login.js` and the shared header. |
 | `member.asp` | Profile view/edit, avatar field, and create-game workflow. | ✅ | `legacy/member.html` + `member.js` profile editor and game creation. |
-| `mygame.asp` | Player private view: submit private/vote/claim/notebook actions and review outcomes. | ⚠️ | `legacy/game.js` exposes action forms but does not yet reproduce the per-day action result table. |
+| `mygame.asp` | Player private view: submit private/vote/claim/notebook actions and review outcomes. | ✅ | `legacy/game.js` now adds a per-day action history table summarizing recorded actions and statuses. |
 | `newplayercomment.asp` | Notebook comment modal tied to action type 17. | ✅ | Notebook form embedded in `legacy/game.html` handled by `game.js`. |
 | `playerlist.asp` | Dumps game roster with hidden roles. | ✅ | `legacy/playerlist.html` + `playerlist.js` roster view. |
 | `replaceplayer.asp` | Owner flow to swap a player slot to a different user. | ✅ | Moderator panel replace workflow in `legacy/game.js`. |

--- a/madia.new/public/legacy/game.html
+++ b/madia.new/public/legacy/game.html
@@ -34,6 +34,36 @@
 
           <div id="postsContainer" style="margin-top:10px;"></div>
 
+          <div
+            id="voteTalliesSection"
+            class="smallfont"
+            style="display:none; margin-top:12px;"
+          >
+            <div id="voteTalliesStatus" style="margin-bottom:4px;"></div>
+            <table
+              class="tborder"
+              cellpadding="4"
+              cellspacing="1"
+              border="0"
+              width="100%"
+              align="center"
+            >
+              <thead>
+                <tr align="center">
+                  <td class="thead" width="45%" align="left">Player</td>
+                  <td class="thead" width="120">Alive</td>
+                  <td class="thead" width="80">Votes</td>
+                  <td class="thead" align="left">Voters</td>
+                </tr>
+              </thead>
+              <tbody id="voteTalliesBody">
+                <tr>
+                  <td class="alt1" colspan="4" align="center">Loading votes…</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
           <!-- Quick reply / actions -->
           <div style="margin-top:12px;">
             <div id="ownerControls" class="smallfont" style="display:none; margin-bottom:8px;">
@@ -106,6 +136,13 @@
                 <div><button class="button" type="submit">Save notebook entry</button></div>
               </form>
               <div id="playerToolsStatus" style="display:none; margin-top:6px; color:#F9A906;"></div>
+              <div
+                id="actionHistorySection"
+                style="display:none; margin-top:12px;"
+              >
+                <div><strong>Action History</strong></div>
+                <div id="actionHistoryContent" style="margin-top:6px;"></div>
+              </div>
             </div>
             <div id="moderatorPanel" class="smallfont" style="display:none; margin-bottom:12px;">
               <div><strong>Moderator Player Management</strong></div>

--- a/madia.new/public/legacy/game.js
+++ b/madia.new/public/legacy/game.js
@@ -63,6 +63,9 @@ const els = {
   daySummary: document.getElementById("daySummary"),
   playerTools: document.getElementById("playerTools"),
   playerToolsStatus: document.getElementById("playerToolsStatus"),
+  voteTalliesSection: document.getElementById("voteTalliesSection"),
+  voteTalliesStatus: document.getElementById("voteTalliesStatus"),
+  voteTalliesBody: document.getElementById("voteTalliesBody"),
   privateActionForm: document.getElementById("privateActionForm"),
   privateActionName: document.getElementById("privateActionName"),
   privateActionTarget: document.getElementById("privateActionTarget"),
@@ -82,6 +85,8 @@ const els = {
   moderatorStatus: document.getElementById("moderatorStatus"),
   moderatorRows: document.getElementById("moderatorRows"),
   playerListLink: document.getElementById("playerListLink"),
+  actionHistorySection: document.getElementById("actionHistorySection"),
+  actionHistoryContent: document.getElementById("actionHistoryContent"),
 };
 els.ubbButtons = document.querySelectorAll(".ubb-button[data-ubb-tag]");
 
@@ -280,6 +285,7 @@ async function loadGame() {
   await ensureRolesLoaded();
   populatePlayerSelects();
   renderModeratorPanel();
+  await renderVoteTallies();
 
   let lastPost = null;
   try {
@@ -394,6 +400,9 @@ async function refreshMembershipAndControls() {
     setDisplay(els.leaveButton, "none");
     setDisplay(els.playerTools, "none");
     setPlayerToolsStatus("");
+    if (els.actionHistorySection) {
+      els.actionHistorySection.style.display = "none";
+    }
     currentPlayer = null;
     return;
   }
@@ -407,6 +416,7 @@ async function refreshMembershipAndControls() {
     const ownerView = currentGame && currentGame.ownerUserId === user.uid;
     setDisplay(els.playerTools, joined || ownerView ? "block" : "none");
   } catch {}
+  await renderActionHistory();
 }
 
 els.joinButton?.addEventListener("click", async () => {
@@ -507,6 +517,7 @@ els.privateActionForm?.addEventListener("submit", async (event) => {
     if (els.privateActionTarget) {
       els.privateActionTarget.value = "";
     }
+    await renderActionHistory();
   } catch (error) {
     if (error?.code === ACTION_LIMIT_ERROR_CODE) {
       const limit = typeof error.limit === "number" ? error.limit : null;
@@ -555,6 +566,8 @@ els.voteRecordForm?.addEventListener("submit", async (event) => {
     if (els.voteNotes) {
       els.voteNotes.value = "";
     }
+    await renderVoteTallies();
+    await renderActionHistory();
   } catch (error) {
     console.error("Failed to record vote", error);
     setPlayerToolsStatus("Unable to record vote.", "error");
@@ -584,6 +597,7 @@ els.claimRecordForm?.addEventListener("submit", async (event) => {
     if (els.claimRole) {
       els.claimRole.value = "";
     }
+    await renderActionHistory();
   } catch (error) {
     console.error("Failed to record claim", error);
     setPlayerToolsStatus("Unable to record claim.", "error");
@@ -618,6 +632,7 @@ els.notebookRecordForm?.addEventListener("submit", async (event) => {
     if (els.notebookNotes) {
       els.notebookNotes.value = "";
     }
+    await renderActionHistory();
   } catch (error) {
     console.error("Failed to record notebook entry", error);
     setPlayerToolsStatus("Unable to record notebook entry.", "error");
@@ -1045,6 +1060,11 @@ function findPlayerByName(name) {
   );
 }
 
+function getPlayerDisplayName(playerId) {
+  const match = findPlayerById(playerId);
+  return match?.name || "";
+}
+
 function populatePlayerSelects() {
   const selects = [
     { element: els.voteTarget, placeholder: "-- select player --" },
@@ -1276,6 +1296,362 @@ function renderModeratorPanel() {
     tr.appendChild(actionsTd);
     rows.appendChild(tr);
   });
+}
+
+async function renderVoteTallies() {
+  const section = els.voteTalliesSection;
+  const body = els.voteTalliesBody;
+  const status = els.voteTalliesStatus;
+  if (!section || !body) {
+    return;
+  }
+  if (!currentGame || missingConfig) {
+    section.style.display = "none";
+    body.innerHTML = "";
+    if (status) {
+      status.textContent = "";
+    }
+    return;
+  }
+  section.style.display = "block";
+  body.innerHTML = "";
+  const day = currentGame.day ?? 0;
+  if (status) {
+    status.textContent = `Vote tally · Day ${day}`;
+  }
+  if (!gamePlayers.length) {
+    const row = document.createElement("tr");
+    const td = document.createElement("td");
+    td.colSpan = 4;
+    td.className = "alt1";
+    td.style.textAlign = "center";
+    td.textContent = "No players joined yet.";
+    row.appendChild(td);
+    body.appendChild(row);
+    return;
+  }
+  let snapshot;
+  try {
+    const gameRef = doc(db, "games", gameId);
+    snapshot = await getDocs(query(collection(gameRef, "actions"), where("category", "==", "vote")));
+  } catch (error) {
+    console.warn("Failed to load vote tallies", error);
+    const row = document.createElement("tr");
+    const td = document.createElement("td");
+    td.colSpan = 4;
+    td.className = "alt1";
+    td.style.textAlign = "center";
+    td.textContent = "Unable to load votes.";
+    row.appendChild(td);
+    body.appendChild(row);
+    return;
+  }
+  const tallies = new Map();
+  gamePlayers.forEach((player) => {
+    tallies.set(player.id, {
+      id: player.id,
+      name: player.name,
+      alive: playerIsAlive(player.data),
+      voters: new Map(),
+    });
+  });
+  const extraTargets = new Map();
+  snapshot.forEach((docSnap) => {
+    const data = docSnap.data() || {};
+    if ((data.day ?? 0) !== day) {
+      return;
+    }
+    if (data.valid === false) {
+      return;
+    }
+    const targetId = normalizeIdentifier(data.targetPlayerId);
+    const fallbackName = data.targetName || getPlayerDisplayName(targetId) || "";
+    let entry;
+    if (targetId && tallies.has(targetId)) {
+      entry = tallies.get(targetId);
+    } else {
+      const keyBase = normalizeActionName(fallbackName) || targetId || "unknown";
+      const key = targetId ? `id:${targetId}` : `name:${keyBase}`;
+      if (!extraTargets.has(key)) {
+        extraTargets.set(key, {
+          id: targetId || keyBase,
+          name: fallbackName || targetId || "(no target)",
+          alive: null,
+          voters: new Map(),
+        });
+      }
+      entry = extraTargets.get(key);
+    }
+    if (!entry) {
+      return;
+    }
+    const voterId = normalizeIdentifier(data.playerId);
+    const voterName =
+      data.username ||
+      data.playerName ||
+      getPlayerDisplayName(voterId) ||
+      (typeof data.playerDisplayName === "string" ? data.playerDisplayName : "");
+    const voterKey =
+      voterId ||
+      (voterName ? `name:${normalizeActionName(voterName)}` : `doc:${docSnap.id}`);
+    if (!entry.voters.has(voterKey)) {
+      entry.voters.set(voterKey, voterName || "Unknown");
+    }
+  });
+  const combined = [
+    ...tallies.values(),
+    ...Array.from(extraTargets.values()).filter((entry) => entry.voters.size > 0),
+  ];
+  if (!combined.length) {
+    const row = document.createElement("tr");
+    const td = document.createElement("td");
+    td.colSpan = 4;
+    td.className = "alt1";
+    td.style.textAlign = "center";
+    td.textContent = "No votes recorded yet.";
+    row.appendChild(td);
+    body.appendChild(row);
+    return;
+  }
+  const formatted = combined.map((entry) => ({
+    ...entry,
+    voters: Array.from(entry.voters.values()).sort((a, b) =>
+      a.localeCompare(b, undefined, { sensitivity: "base" })
+    ),
+  }));
+  formatted.sort((a, b) => {
+    if (b.voters.length !== a.voters.length) {
+      return b.voters.length - a.voters.length;
+    }
+    return (a.name || "").localeCompare(b.name || "", undefined, { sensitivity: "base" });
+  });
+  let alt = false;
+  formatted.forEach((entry) => {
+    alt = !alt;
+    const row = document.createElement("tr");
+    row.setAttribute("align", "center");
+    const primary = alt ? "alt1" : "alt2";
+    const secondary = alt ? "alt2" : "alt1";
+    const nameCell = document.createElement("td");
+    nameCell.className = primary;
+    nameCell.setAttribute("align", "left");
+    nameCell.innerHTML = `<strong>${escapeHtml(entry.name || "Unknown")}</strong>`;
+    const aliveCell = document.createElement("td");
+    aliveCell.className = secondary;
+    aliveCell.textContent =
+      entry.alive === null || entry.alive === undefined ? "—" : entry.alive ? "Yes" : "No";
+    const countCell = document.createElement("td");
+    countCell.className = primary;
+    countCell.textContent = String(entry.voters.length);
+    const votersCell = document.createElement("td");
+    votersCell.className = secondary;
+    votersCell.setAttribute("align", "left");
+    votersCell.textContent = entry.voters.length ? entry.voters.join(", ") : "—";
+    row.append(nameCell, aliveCell, countCell, votersCell);
+    body.appendChild(row);
+  });
+}
+
+function extractFirstStringValue(source, keys = []) {
+  if (!source) {
+    return "";
+  }
+  for (const key of keys) {
+    if (!key) continue;
+    const value = source[key];
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+  return "";
+}
+
+function describeActionStatus(action = {}) {
+  const explicit = extractFirstStringValue(action, [
+    "statusText",
+    "status",
+    "resultText",
+    "result",
+    "outcome",
+    "resolution",
+    "resolutionText",
+  ]);
+  if (explicit) {
+    return explicit;
+  }
+  if (action.valid === false) {
+    return "Invalidated";
+  }
+  if (action.pending === true) {
+    return "Pending";
+  }
+  if (typeof action.success === "boolean") {
+    return action.success ? "Success" : "Failed";
+  }
+  const category = normalizeActionName(action.category);
+  const day = action.day ?? 0;
+  const currentDay = currentGame?.day ?? 0;
+  if (category === "vote") {
+    return day === currentDay ? "Pending" : "Counted";
+  }
+  if (category === "claim") {
+    return day === currentDay ? "Pending" : "Recorded";
+  }
+  if (category === "notebook") {
+    return "Saved";
+  }
+  if (isTrustAction(action.actionName) && day === currentDay) {
+    return "Trusted";
+  }
+  if (day === currentDay) {
+    return "Pending";
+  }
+  return "Recorded";
+}
+
+function timestampToMillis(value) {
+  if (!value) {
+    return 0;
+  }
+  if (typeof value.toMillis === "function") {
+    try {
+      return value.toMillis();
+    } catch {}
+  }
+  if (typeof value.toDate === "function") {
+    const date = value.toDate();
+    if (date instanceof Date) {
+      return date.getTime();
+    }
+  }
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function formatActionTarget(action = {}) {
+  const pieces = [];
+  const primary =
+    action.targetName ||
+    getPlayerDisplayName(action.targetPlayerId) ||
+    (action.targetPlayerId ? String(action.targetPlayerId) : "");
+  if (primary) {
+    pieces.push(`<div>${escapeHtml(primary)}</div>`);
+  } else {
+    pieces.push("<div>—</div>");
+  }
+  const note = extractFirstStringValue(action, ["notes", "detail", "details", "extraNotes"]);
+  if (note) {
+    pieces.push(`<div class="smallfont">${escapeHtml(note)}</div>`);
+  }
+  return pieces.join("");
+}
+
+async function renderActionHistory() {
+  const section = els.actionHistorySection;
+  const content = els.actionHistoryContent;
+  if (!section || !content) {
+    return;
+  }
+  if (!currentUser || !currentPlayer || missingConfig) {
+    section.style.display = "none";
+    content.innerHTML = "";
+    return;
+  }
+  let snapshot;
+  try {
+    const actionsRef = collection(db, "games", gameId, "actions");
+    snapshot = await getDocs(query(actionsRef, where("playerId", "==", currentUser.uid)));
+  } catch (error) {
+    console.warn("Failed to load action history", error);
+    section.style.display = "block";
+    content.innerHTML =
+      '<div class="smallfont" style="text-align:center;color:#ff7676;">Unable to load actions.</div>';
+    return;
+  }
+  const actions = snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+  if (!actions.length) {
+    section.style.display = "block";
+    content.innerHTML =
+      '<div class="smallfont" style="text-align:center;">No recorded actions yet.</div>';
+    return;
+  }
+  actions.sort((a, b) => {
+    const dayDiff = (b.day ?? 0) - (a.day ?? 0);
+    if (dayDiff !== 0) {
+      return dayDiff;
+    }
+    return timestampToMillis(b.updatedAt || b.createdAt) - timestampToMillis(a.updatedAt || a.createdAt);
+  });
+  const grouped = new Map();
+  actions.forEach((action) => {
+    const dayValue = action.day ?? 0;
+    if (!grouped.has(dayValue)) {
+      grouped.set(dayValue, []);
+    }
+    grouped.get(dayValue).push(action);
+  });
+  const fragment = document.createDocumentFragment();
+  const days = Array.from(grouped.keys()).sort((a, b) => b - a);
+  days.forEach((dayValue) => {
+    const table = document.createElement("table");
+    table.className = "tborder";
+    table.setAttribute("cellpadding", "4");
+    table.setAttribute("cellspacing", "1");
+    table.setAttribute("border", "0");
+    table.style.marginTop = "6px";
+    table.style.width = "100%";
+    const thead = document.createElement("thead");
+    thead.innerHTML = `
+      <tr align="center">
+        <td class="thead" colspan="4" align="left">Day ${dayValue}</td>
+      </tr>
+      <tr align="center">
+        <td class="thead" width="180">Action</td>
+        <td class="thead" width="220">Target</td>
+        <td class="thead" width="140">Status</td>
+        <td class="thead" align="left">Updated</td>
+      </tr>
+    `;
+    table.appendChild(thead);
+    const tbody = document.createElement("tbody");
+    const dayActions = grouped.get(dayValue) || [];
+    let alt = false;
+    dayActions.forEach((action) => {
+      alt = !alt;
+      const row = document.createElement("tr");
+      row.setAttribute("align", "center");
+      const primary = alt ? "alt1" : "alt2";
+      const secondary = alt ? "alt2" : "alt1";
+      const actionCell = document.createElement("td");
+      actionCell.className = primary;
+      actionCell.setAttribute("align", "left");
+      actionCell.innerHTML = `<strong>${escapeHtml(action.actionName || action.category || "Action")}</strong>`;
+      const targetCell = document.createElement("td");
+      targetCell.className = secondary;
+      targetCell.setAttribute("align", "left");
+      targetCell.innerHTML = formatActionTarget(action);
+      const statusCell = document.createElement("td");
+      statusCell.className = primary;
+      statusCell.textContent = describeActionStatus(action);
+      const updatedCell = document.createElement("td");
+      updatedCell.className = secondary;
+      updatedCell.setAttribute("align", "left");
+      updatedCell.textContent = formatDate(action.updatedAt || action.createdAt) || "—";
+      row.append(actionCell, targetCell, statusCell, updatedCell);
+      tbody.appendChild(row);
+    });
+    table.appendChild(tbody);
+    fragment.appendChild(table);
+  });
+  section.style.display = "block";
+  content.innerHTML = "";
+  content.appendChild(fragment);
 }
 
 function setModeratorStatus(message, type = "info") {


### PR DESCRIPTION
## Summary
- render the legacy day vote tally table in the retro game view
- add a per-day action history log so players can review recorded actions
- update the parity tracking doc to mark the workflows as complete

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d725f0fb348328a3eec644ef085dd1