### PR TITLE
Add private role discussion channels to legacy game view

### DIFF
--- a/madia.new/public/legacy/game.html
+++ b/madia.new/public/legacy/game.html
@@ -145,6 +145,15 @@
                 </tr>
               </table>
             </form>
+            <div id="privateChannelsSection" style="margin-top:20px; display:none;">
+              <table class="tborder" cellpadding="4" cellspacing="1" border="0" width="100%" align="center" style="margin-bottom:6px;">
+                <tr>
+                  <td class="thead">Role Discussions</td>
+                </tr>
+              </table>
+              <div id="privateChannelsStatus" class="smallfont" style="display:none; margin:6px 2px; color:#F9A906;"></div>
+              <div id="privateChannelsContainer"></div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- surface a Role Discussions section in the legacy game view mirroring the classic private channel experience
- load eligible private channels from Firestore, render their posts, and allow permitted players or the host to reply
- provide status messaging and hide the section when no private discussions are available

## Testing
- python3 -m http.server 5000


------
https://chatgpt.com/codex/tasks/task_e_68d7258960bc83288ef7e58f03e97bda