### PR TITLE
Align player tool dropdown behavior with legacy app

### DIFF
--- a/madia.new/public/legacy/game.html
+++ b/madia.new/public/legacy/game.html
@@ -55,9 +55,15 @@
                   <input id="privateActionName" class="bginput" />
                 </label>
                 <label>
-                  Target name
-                  <input id="privateActionTarget" class="bginput" />
+                  Target
+                  <select id="privateActionTarget" class="bginput"></select>
                 </label>
+                <div id="privateActionCustomTargetRow" style="display:none;">
+                  <label>
+                    Custom target name
+                    <input id="privateActionCustomTarget" class="bginput" />
+                  </label>
+                </div>
                 <label>
                   Day
                   <input id="privateActionDay" type="number" class="bginput" min="0" />
@@ -105,6 +111,7 @@
                 </label>
                 <div><button class="button" type="submit">Save notebook entry</button></div>
               </form>
+              <div id="playerTargetNotice" class="smallfont" style="display:none; margin-top:6px; color:#F9A906;"></div>
               <div id="playerToolsStatus" style="display:none; margin-top:6px; color:#F9A906;"></div>
             </div>
             <div id="moderatorPanel" class="smallfont" style="display:none; margin-bottom:12px;">


### PR DESCRIPTION
## Summary
- add a dedicated select for private action targets with optional custom entry to mirror the legacy UI
- filter targetable players to active participants and surface a notice when no dropdown options are available
- drive player tool visibility and dropdown population from shared helpers so the new view matches the legacy behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d727b111108328a3b9c72019b691d4