### PR TITLE
Add quick reply public action toggles

### DIFF
--- a/madia.new/public/legacy/game.html
+++ b/madia.new/public/legacy/game.html
@@ -189,6 +189,18 @@
                       <button type="button" class="ubb-button" data-ubb-tag="u" title="Underline">U</button>
                     </div>
                     <textarea id="replyBody" class="bginput" rows="6" style="width:98%"></textarea>
+                    <div
+                      id="publicActionsContainer"
+                      class="smallfont"
+                      style="display:none; margin-top:8px;"
+                    >
+                      <div><strong>Public Actions</strong></div>
+                      <div id="publicActionsList" style="margin-top:4px;"></div>
+                      <div
+                        id="publicActionsStatus"
+                        style="display:none; margin-top:4px; color:#F9A906;"
+                      ></div>
+                    </div>
                     <div style="margin-top:8px;"><button id="postReply" class="button">Post Reply</button></div>
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- expose a public actions panel in the legacy quick reply form
- derive available public actions from game and player rules with sensible defaults
- record selected public actions alongside replies and surface status feedback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d72b0382548328ba256a9a223cf9e4