### PR TITLE
Fix escapeHtml redeclaration in legacy game view

### DIFF
--- a/madia.new/public/legacy/game.js
+++ b/madia.new/public/legacy/game.js
@@ -15,7 +15,7 @@ import {
   deleteField,
   runTransaction,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
-import { ubbToHtml } from "/legacy/ubb.js";
+import { escapeHtml as baseEscapeHtml, ubbToHtml } from "/legacy/ubb.js";
 import { auth, db, ensureUserDocument, missingConfig } from "./firebase.js";
 import { initLegacyHeader } from "./header.js";
 
@@ -673,12 +673,7 @@ function escapeHtml(value) {
   if (value === null || value === undefined) {
     return "";
   }
-  return String(value)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
+  return baseEscapeHtml(value);
 }
 
 function renderPrivateChannel(channel, posts, options = {}) {
@@ -3224,15 +3219,6 @@ function playerIsAlive(data = {}) {
     }
   }
   return true;
-}
-
-function escapeHtml(value) {
-  return String(value)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
 }
 
 async function handleEditPost(postId, post) {


### PR DESCRIPTION
## Summary
- import the shared escapeHtml helper from the legacy UBB module
- remove the duplicate escapeHtml declaration to prevent runtime redeclaration errors

## Testing
- not run (static change)

------
https://chatgpt.com/codex/tasks/task_e_68d75660d86c832894a33e0cc0f4801b