### PR TITLE
feat: expose control center via legacy link

### DIFF
--- a/madia.new/public/control/index.html
+++ b/madia.new/public/control/index.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Phalla Control Center</title>
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Phalla Control Center</h1>
+      <p id="authStatus" class="subtitle">Checking sign-in status…</p>
+      <div class="auth-controls">
+        <button id="signInButton" class="primary" type="button">Sign in with Google</button>
+        <button id="signOutButton" class="secondary" type="button" hidden>Sign out</button>
+      </div>
+    </header>
+
+    <main>
+      <section class="panel">
+        <div class="panel-header">
+          <h2>Threads</h2>
+          <div class="panel-actions">
+            <button id="newThreadButton" class="primary" type="button">New thread</button>
+          </div>
+        </div>
+        <ul id="threadsList" class="list" aria-live="polite"></ul>
+      </section>
+
+      <section class="panel">
+        <div class="panel-header">
+          <div>
+            <h2 id="threadTitle">Select a thread</h2>
+            <p id="threadMetadata" class="metadata"></p>
+          </div>
+          <div class="panel-actions">
+            <button id="refreshThread" class="secondary" type="button">Refresh</button>
+            <button id="deleteThread" class="secondary" type="button" hidden>Delete</button>
+          </div>
+        </div>
+        <ul id="postsList" class="list posts" aria-live="polite"></ul>
+        <form id="replyForm" class="reply-form" hidden>
+          <label for="replyBody">Post reply</label>
+          <textarea id="replyBody" rows="5" placeholder="Share an update with the village" required></textarea>
+          <div class="panel-actions">
+            <button class="secondary" type="button" id="cancelReplyButton">Cancel</button>
+            <button class="primary" type="submit">Submit reply</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="panel">
+        <div class="panel-header">
+          <h2>Vote tracker</h2>
+          <div class="panel-actions">
+            <button id="recordVoteButton" class="primary" type="button">Record vote</button>
+          </div>
+        </div>
+        <div class="table-wrapper">
+          <table id="voteTable" class="vote-table">
+            <thead>
+              <tr>
+                <th scope="col">Player</th>
+                <th scope="col">Votes</th>
+                <th scope="col">Notes</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <dialog id="threadDialog">
+      <form method="dialog" id="threadForm" class="dialog-form">
+        <h2>Create a new thread</h2>
+        <label for="threadTitleInput">Title</label>
+        <input id="threadTitleInput" type="text" name="title" required />
+        <label for="threadBodyInput">Opening post</label>
+        <textarea
+          id="threadBodyInput"
+          name="body"
+          rows="6"
+          placeholder="Welcome players, describe the game, or log the next phase update"
+          required
+        ></textarea>
+        <menu class="dialog-actions">
+          <button value="cancel" type="reset" class="secondary">Cancel</button>
+          <button value="default" class="primary">Create thread</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <dialog id="voteDialog">
+      <form method="dialog" id="voteForm" class="dialog-form">
+        <h2>Record a vote</h2>
+        <label for="votePlayerInput">Player</label>
+        <input id="votePlayerInput" type="text" name="player" required />
+        <label for="voteCountInput">Vote count</label>
+        <input id="voteCountInput" type="number" name="votes" min="0" value="1" required />
+        <label for="voteNotesInput">Notes</label>
+        <textarea
+          id="voteNotesInput"
+          name="notes"
+          rows="4"
+          placeholder="Include context like vote source or tie-breakers"
+        ></textarea>
+        <menu class="dialog-actions">
+          <button value="cancel" type="reset" class="secondary">Cancel</button>
+          <button value="default" class="primary">Save vote</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <script type="module" src="../script.js"></script>
+  </body>
+</html>

--- a/madia.new/public/legacy/index.html
+++ b/madia.new/public/legacy/index.html
@@ -11,8 +11,9 @@
     <div align="center">
       <div class="page" style="width:98%; text-align:left">
         <div style="padding:0px 10px 0px 10px">
-          <div style="margin:10px 0;">
+          <div style="margin:10px 0; display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
             <a href="/legacy/sitesummary.html" id="siteSummaryLink">site summary</a>
+            <a href="/control/" class="button legacy-control-link">control center</a>
           </div>
 
           <!-- Games table (games.asp look) -->

--- a/madia.new/public/legacy/phalla.css
+++ b/madia.new/public/legacy/phalla.css
@@ -161,6 +161,20 @@ textarea, .bginput
         font: 11px verdana, geneva, lucida, 'lucida grande', arial, helvetica, sans-serif;
         border-width:1px; border-right: 1px solid #FAB60C; border-bottom: 1px solid #FAB60C;
 }
+a.button {
+        display: inline-block;
+        padding: 2px 8px;
+        text-decoration: none;
+        color: #ffffff;
+}
+a.button:hover,
+a.button:focus {
+        color: #ffffff;
+        text-decoration: none;
+}
+.legacy-control-link {
+        text-transform: none;
+}
 .action-badges
 {
         display: flex;

--- a/madia.new/public/script.js
+++ b/madia.new/public/script.js
@@ -67,6 +67,7 @@ const els = {
   postsList: document.getElementById("postsList"),
   replyForm: document.getElementById("replyForm"),
   replyBody: document.getElementById("replyBody"),
+  cancelReplyButton: document.getElementById("cancelReplyButton"),
   deleteThread: document.getElementById("deleteThread"),
   refreshThread: document.getElementById("refreshThread"),
   recordVoteButton: document.getElementById("recordVoteButton"),
@@ -265,6 +266,12 @@ function resetThreadSelection(message, postsMessage = "Select a thread to view p
   els.threadTitle.textContent = message;
   els.threadMetadata.textContent = "";
   showPostsMessage(postsMessage);
+  if (els.replyBody) {
+    els.replyBody.value = "";
+  }
+  if (els.replyForm) {
+    els.replyForm.hidden = true;
+  }
 }
 
 function stopRealtimeSubscriptions({ showSignedOutState = false } = {}) {
@@ -536,20 +543,30 @@ if (!missingConfig) {
   els.newThreadButton.addEventListener("click", requireAuth(() => {
     els.threadDialog.showModal();
   }));
-  els.threadForm.addEventListener("close", () => {
-    if (els.threadForm.returnValue === "default") {
-      const title = els.threadTitleInput.value.trim();
-      const body = els.threadBodyInput.value.trim();
-      if (title && body) {
-        createThread(title, body).catch((error) => {
-          console.error(error);
-          alert("Unable to create thread.");
-        });
+  if (els.threadDialog) {
+    els.threadDialog.addEventListener("close", () => {
+      if (els.threadDialog.returnValue === "default") {
+        const title = els.threadTitleInput.value.trim();
+        const body = els.threadBodyInput.value.trim();
+        if (title && body) {
+          createThread(title, body).catch((error) => {
+            console.error(error);
+            alert("Unable to create thread.");
+          });
+        }
       }
-    }
-    els.threadTitleInput.value = "";
-    els.threadBodyInput.value = "";
-  });
+      if (els.threadForm) {
+        els.threadForm.reset();
+      } else {
+        if (els.threadTitleInput) {
+          els.threadTitleInput.value = "";
+        }
+        if (els.threadBodyInput) {
+          els.threadBodyInput.value = "";
+        }
+      }
+    });
+  }
   els.deleteThread.addEventListener("click", requireAuth(deleteCurrentThread));
   els.replyForm.addEventListener("submit", requireAuth(submitReply));
   els.refreshThread.addEventListener("click", () => {
@@ -560,22 +577,41 @@ if (!missingConfig) {
   els.recordVoteButton.addEventListener("click", requireAuth(() => {
     els.voteDialog.showModal();
   }));
-  els.voteForm.addEventListener("close", () => {
-    if (els.voteForm.returnValue === "default") {
-      const player = els.votePlayerInput.value.trim();
-      const votes = parseInt(els.voteCountInput.value, 10) || 0;
-      const notes = els.voteNotesInput.value.trim();
-      if (player) {
-        recordVote(player, votes, notes).catch((error) => {
-          console.error(error);
-          alert("Unable to record vote.");
-        });
+  if (els.voteDialog) {
+    els.voteDialog.addEventListener("close", () => {
+      if (els.voteDialog.returnValue === "default") {
+        const player = els.votePlayerInput.value.trim();
+        const votes = parseInt(els.voteCountInput.value, 10) || 0;
+        const notes = els.voteNotesInput.value.trim();
+        if (player) {
+          recordVote(player, votes, notes).catch((error) => {
+            console.error(error);
+            alert("Unable to record vote.");
+          });
+        }
       }
-    }
-    els.votePlayerInput.value = "";
-    els.voteCountInput.value = "1";
-    els.voteNotesInput.value = "";
-  });
+      if (els.voteForm) {
+        els.voteForm.reset();
+      } else {
+        if (els.votePlayerInput) {
+          els.votePlayerInput.value = "";
+        }
+        if (els.voteCountInput) {
+          els.voteCountInput.value = "1";
+        }
+        if (els.voteNotesInput) {
+          els.voteNotesInput.value = "";
+        }
+      }
+    });
+  }
+
+  if (els.cancelReplyButton && els.replyBody) {
+    els.cancelReplyButton.addEventListener("click", () => {
+      els.replyBody.value = "";
+      els.replyBody.blur();
+    });
+  }
 
   onAuthStateChanged(auth, async (user) => {
     currentUser = user;

--- a/madia.new/public/styles.css
+++ b/madia.new/public/styles.css
@@ -198,6 +198,80 @@ button.secondary {
   border-color: rgba(148, 163, 184, 0.2);
 }
 
+.reply-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.reply-form label {
+  font-weight: 600;
+}
+
+.reply-form .panel-actions {
+  justify-content: flex-end;
+}
+
+.table-wrapper {
+  max-height: 360px;
+  overflow-y: auto;
+  border: 1px solid var(--panel-border);
+  border-radius: 0.75rem;
+}
+
+.vote-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.vote-table th,
+.vote-table td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+  text-align: left;
+}
+
+.vote-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+dialog {
+  border: 1px solid var(--panel-border);
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.95);
+  color: inherit;
+  padding: 0;
+  width: min(480px, 90vw);
+}
+
+dialog::backdrop {
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.dialog-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.5rem;
+}
+
+.dialog-form label {
+  font-weight: 600;
+}
+
+.dialog-form textarea {
+  resize: vertical;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
 button.danger {
   background: linear-gradient(135deg, #ef4444, #f97316);
   box-shadow: 0 10px 25px -10px rgba(239, 68, 68, 0.8);


### PR DESCRIPTION
## Summary
- restore the root redirect to the legacy experience while moving the modern control center into /control/
- add a control center link to the legacy landing page so the modern tools are easy to reach
- teach the legacy skin how to style anchor buttons to match the existing chrome

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7536789b48328bf77738f2ac51e76