### PR TITLE
Fix private channel loading for non-members

### DIFF
--- a/madia.new/public/legacy/game.js
+++ b/madia.new/public/legacy/game.js
@@ -767,6 +767,15 @@ async function loadPrivateChannels() {
   if (els.privateChannelsSection) {
     els.privateChannelsSection.style.display = "block";
   }
+
+  const userId = normalizeIdentifier(user.uid);
+  const ownerId = normalizeIdentifier(currentGame?.ownerUserId);
+  const isOwner = ownerId && userId === ownerId;
+  if (!currentPlayer && !isOwner) {
+    setPrivateChannelsStatus("Join the game to view your role discussions.");
+    return;
+  }
+
   setPrivateChannelsStatus("Loading role discussions…");
 
   const gameRef = doc(db, "games", gameId);
@@ -783,9 +792,6 @@ async function loadPrivateChannels() {
     container.innerHTML = "";
     return;
   }
-
-  const userId = normalizeIdentifier(user.uid);
-  const ownerId = normalizeIdentifier(currentGame?.ownerUserId);
 
   const accessibleChannels = [];
   channelSnapshot.forEach((docSnap) => {


### PR DESCRIPTION
## Summary
- stop attempting to query private channels when the signed-in user has not joined the game and is not the owner
- surface an informational status message instead of triggering a Firestore permission error for non-members

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d757ed79d08328a3699614731fce5a