### PR TITLE
fix: lock vote day to current day

### DIFF
--- a/madia.new/public/legacy/game.html
+++ b/madia.new/public/legacy/game.html
@@ -113,7 +113,15 @@
                 </label>
                 <label>
                   Day
-                  <input id="voteDay" type="number" class="bginput" min="0" />
+                  <input
+                    id="voteDay"
+                    type="number"
+                    class="bginput"
+                    min="0"
+                    disabled
+                    aria-readonly="true"
+                    title="Votes are recorded for the current day"
+                  />
                 </label>
                 <label>
                   Notes

--- a/madia.new/public/legacy/game.js
+++ b/madia.new/public/legacy/game.js
@@ -452,6 +452,8 @@ async function loadGame() {
   }
   if (els.voteDay) {
     els.voteDay.value = g.day ?? 0;
+    els.voteDay.disabled = true;
+    els.voteDay.title = "Votes are recorded for the current day.";
   }
   if (els.claimDay) {
     els.claimDay.value = g.day ?? 0;
@@ -1322,7 +1324,7 @@ els.voteRecordForm?.addEventListener("submit", async (event) => {
   const target = targetId ? findPlayerById(targetId) : null;
   const targetName = target?.name || "";
   const notes = (els.voteNotes?.value || "").trim();
-  const day = parseDayInput(els.voteDay);
+  const day = currentGame?.day ?? parseDayInput(els.voteDay);
   if (!targetId) {
     setPlayerToolsStatus("Enter a vote target first.", "error");
     return;


### PR DESCRIPTION
## Summary
- disable the vote day selector in the legacy control center so votes are always tied to the active day
- ensure vote submissions use the game record's current day regardless of client input

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d75855ee688328bbaca63c6dbf16a8