### PR TITLE
Fix vote tally permissions

### DIFF
--- a/madia.new/firestore.rules
+++ b/madia.new/firestore.rules
@@ -30,7 +30,8 @@ service cloud.firestore {
       match /actions/{actionId} {
         allow read: if request.auth != null && (
           request.auth.uid == resource.data.playerId ||
-          get(/databases/$(database)/documents/games/$(gameId)).data.ownerUserId == request.auth.uid
+          get(/databases/$(database)/documents/games/$(gameId)).data.ownerUserId == request.auth.uid ||
+          (resource.data.category == "vote" && exists(/databases/$(database)/documents/games/$(gameId)/players/$(request.auth.uid)))
         );
         allow create: if request.auth != null && request.resource.data.playerId == request.auth.uid;
         allow update: if request.auth != null && request.auth.uid == resource.data.playerId;


### PR DESCRIPTION
## Summary
- allow authenticated game participants or hosts to read vote actions for tally display

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d75bbdd2908328a41a63a2139e9672