### PR TITLE
Hide role discussions until a role is assigned

### DIFF
--- a/madia.new/public/legacy/game.js
+++ b/madia.new/public/legacy/game.js
@@ -663,6 +663,23 @@ function clearPrivateChannels() {
   setPrivateChannelsStatus("");
 }
 
+function getAssignedRoleName(player) {
+  if (!player || typeof player !== "object") {
+    return "";
+  }
+  const fields = ["role", "rolename", "roleName"];
+  for (const field of fields) {
+    const raw = player[field];
+    if (typeof raw === "string") {
+      const trimmed = raw.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+  return "";
+}
+
 function collectIdSet(source, keys = []) {
   const ids = new Set();
   if (!source || typeof source !== "object") {
@@ -787,19 +804,22 @@ async function loadPrivateChannels() {
   }
 
   const container = els.privateChannelsContainer;
-  container.innerHTML = "";
-  if (els.privateChannelsSection) {
-    els.privateChannelsSection.style.display = "block";
+  if (container) {
+    container.innerHTML = "";
   }
 
   const userId = normalizeIdentifier(user.uid);
   const ownerId = normalizeIdentifier(currentGame?.ownerUserId);
   const isOwner = ownerId && userId === ownerId;
-  if (!currentPlayer && !isOwner) {
-    setPrivateChannelsStatus("Join the game to view your role discussions.");
+  const assignedRole = getAssignedRoleName(currentPlayer);
+  if (!isOwner && !assignedRole) {
+    clearPrivateChannels();
     return;
   }
 
+  if (els.privateChannelsSection) {
+    els.privateChannelsSection.style.display = "block";
+  }
   setPrivateChannelsStatus("Loading role discussions…");
 
   const gameRef = doc(db, "games", gameId);
@@ -886,8 +906,7 @@ async function loadPrivateChannels() {
       return;
     }
 
-    container.innerHTML = "";
-    setPrivateChannelsStatus("Join the game to view your role discussions.");
+    clearPrivateChannels();
     return;
   }
 


### PR DESCRIPTION
## Summary
- add a helper to detect whether the current player has an assigned role
- hide the role discussion section for non-owners without a role so the join message is never shown prematurely

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d75bf006008328a735cc3f1e165f9f