### PR TITLE
feat: hard-code legacy role catalog

### DIFF
--- a/madia.new/FIREBASE.md
+++ b/madia.new/FIREBASE.md
@@ -46,6 +46,9 @@ players:
   (all strings), `email` (string), `photoURL` (optional string), and
   timestamps (`createdAt`, `lastLoginAt`). The login page looks up
   `usernameLower` to support username-based sign-in.
+- Role suggestions in the moderator tools are now drawn from a fixed
+  client-side list, so there is no need to seed a `/roles` collection in
+  Firestore.
 
 The retro login experience lives at `/legacy/login.html` and mimics the
 classic ASP form. Ensure the Firebase Authentication Email/Password

--- a/madia.new/README.md
+++ b/madia.new/README.md
@@ -153,6 +153,11 @@ service cloud.firestore {
 }
 ```
 
+The retro moderator interface now ships with a built-in catalog of role
+names, so the `/roles` collection is optional. You can keep the rule in
+place for compatibility, but no seeding or additional permissions are
+required.
+
 ## 3. Configure Firebase Storage rules
 
 Avatar uploads in the retro member profile use Cloud Storage. Until you

--- a/madia.new/public/legacy/game.js
+++ b/madia.new/public/legacy/game.js
@@ -32,6 +32,31 @@ const CUSTOM_ACTION_OPTION_VALUE = "__custom-action__";
 const CUSTOM_TARGET_OPTION_VALUE = "__custom-target__";
 const CUSTOM_REPLACEMENT_OPTION_VALUE = "__custom-replacement__";
 
+const DEFAULT_ROLE_NAMES = [
+  "Baner",
+  "Bodyguard",
+  "Bus Driver",
+  "Cultist",
+  "Doctor",
+  "Guardian Angel",
+  "Inspector",
+  "Mafia",
+  "Mason",
+  "Mayor",
+  "Miller",
+  "Necromancer",
+  "Roleblocker",
+  "Seer",
+  "Serial Killer",
+  "Spy",
+  "Tracker",
+  "Vanillager",
+  "Villager",
+  "Vigilante",
+  "Vote Manipulator",
+  "Watcher",
+];
+
 const ACTION_LIMIT_ERROR_CODE = "action-limit-exceeded";
 const ACTION_RULE_KEYS = [
   "actionRules",
@@ -125,8 +150,7 @@ let currentGame = null;
 let currentPlayer = null;
 let gamePlayers = [];
 let isOwnerView = false;
-let availableRoles = [];
-let rolesLoadPromise = null;
+let availableRoles = [...DEFAULT_ROLE_NAMES];
 let replacementCandidates = [];
 let replacementCandidateDocs = new Map();
 let replacementCandidatesPromise = null;
@@ -2436,39 +2460,8 @@ function getKnownRoleNames() {
 }
 
 async function ensureRolesLoaded() {
-  if (availableRoles.length) {
-    return availableRoles;
-  }
-  if (rolesLoadPromise) {
-    return rolesLoadPromise;
-  }
-  const loadPromise = (async () => {
-    try {
-      const rolesSnap = await getDocs(query(collection(db, "roles"), orderBy("rolename")));
-      const names = [];
-      rolesSnap.forEach((docSnap) => {
-        const data = docSnap.data() || {};
-        const name = String(data.rolename || data.name || docSnap.id || "").trim();
-        if (!name) {
-          return;
-        }
-        if (!names.includes(name)) {
-          names.push(name);
-        }
-      });
-      availableRoles = names;
-    } catch (error) {
-      console.warn("Failed to load available roles", error);
-      availableRoles = [];
-    }
-    return availableRoles;
-  })();
-  rolesLoadPromise = loadPromise;
-  try {
-    return await loadPromise;
-  } finally {
-    rolesLoadPromise = null;
-  }
+  availableRoles = [...DEFAULT_ROLE_NAMES];
+  return availableRoles;
 }
 
 function renderModeratorPanel() {


### PR DESCRIPTION
## Summary
- replace the Firestore-driven role lookup in the retro game UI with a hard-coded catalog of legacy roles
- document that role suggestions now come from the client list and no longer require seeding Firestore

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d75873dd788328ba73e9ce0b5ea070