### PR TITLE
Allow unauthenticated vote tally reads

### DIFF
--- a/madia.new/firestore.rules
+++ b/madia.new/firestore.rules
@@ -28,11 +28,11 @@ service cloud.firestore {
       }
 
       match /actions/{actionId} {
-        allow read: if request.auth != null && (
+        allow read: if resource.data.category == "vote" || (request.auth != null && (
           request.auth.uid == resource.data.playerId ||
           get(/databases/$(database)/documents/games/$(gameId)).data.ownerUserId == request.auth.uid ||
           (resource.data.category == "vote" && exists(/databases/$(database)/documents/games/$(gameId)/players/$(request.auth.uid)))
-        );
+        ));
         allow create: if request.auth != null && request.resource.data.playerId == request.auth.uid;
         allow update: if request.auth != null && request.auth.uid == resource.data.playerId;
         allow delete: if request.auth != null


### PR DESCRIPTION
## Summary
- allow vote action documents to be read without authentication so public vote tallies can load
- retain existing protections for non-vote actions while keeping access for hosts and individual players

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f0941b30832884370c9b321a8af8