### PR TITLE
Restrict Firebase preview workflow to main branch

### DIFF
--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -2,9 +2,13 @@ name: Firebase preview deploy
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'madia.new/**'
   pull_request:
+    branches:
+      - main
     paths:
       - 'madia.new/**'
 


### PR DESCRIPTION
## Summary
- restrict the Firebase preview deploy workflow to run only when targeting the main branch for push and pull request events

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7f1ab71c0832899e5a1c6030be252