### PR TITLE
fix: remove legacy control center link

### DIFF
--- a/madia.new/public/legacy/index.html
+++ b/madia.new/public/legacy/index.html
@@ -13,7 +13,6 @@
         <div style="padding:0px 10px 0px 10px">
           <div style="margin:10px 0; display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
             <a href="/legacy/sitesummary.html" id="siteSummaryLink">site summary</a>
-            <a href="/control/" class="button legacy-control-link">control center</a>
           </div>
 
           <!-- Games table (games.asp look) -->


### PR DESCRIPTION
## Summary
- remove the legacy Control Center shortcut from the legacy home page toolbar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f67e2a048328bbf7298111e24ec4