### PR TITLE
Restrict Firebase preview deploy to main

### DIFF
--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   deploy-preview:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary
- ensure the Firebase preview workflow only runs when the main branch is the current ref

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f986d9088328a43c85663bb881f0