### PR TITLE
Fix user profile sync with auth changes

### DIFF
--- a/madia.new/public/script.js
+++ b/madia.new/public/script.js
@@ -202,14 +202,23 @@ async function ensurePlayerRecord(user) {
 
   const data = snapshot.data() || {};
   const updates = {};
-  if (!data.displayName && user.displayName) {
-    updates.displayName = user.displayName;
+
+  const existingDisplayName = (data.displayName || "").trim();
+  const authDisplayName = (user.displayName || "").trim();
+  if (existingDisplayName !== authDisplayName) {
+    updates.displayName = authDisplayName;
   }
-  if (!data.photoURL && user.photoURL) {
-    updates.photoURL = user.photoURL;
+
+  const existingPhotoURL = (data.photoURL || "").trim();
+  const authPhotoURL = (user.photoURL || "").trim();
+  if (existingPhotoURL !== authPhotoURL) {
+    updates.photoURL = authPhotoURL;
   }
-  if (!data.email && user.email) {
-    updates.email = user.email;
+
+  const existingEmail = (data.email || "").trim();
+  const authEmail = (user.email || "").trim();
+  if (existingEmail !== authEmail) {
+    updates.email = authEmail;
   }
 
   if (Object.keys(updates).length) {


### PR DESCRIPTION
## Summary
- update player record sync to refresh display name, email, and photo URL when auth values change

## Testing
- not run (emulator not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7fbee15d083289c9557a4558646c9