### PR TITLE
Fix site summary to show latest new players

### DIFF
--- a/madia.new/public/legacy/game.js
+++ b/madia.new/public/legacy/game.js
@@ -1783,7 +1783,15 @@ els.joinButton?.addEventListener("click", async () => {
     header?.openAuthPanel("login");
     return;
   }
-  await setDoc(doc(db, "games", gameId, "players", user.uid), { uid: user.uid, name: user.displayName || "" });
+  await setDoc(
+    doc(db, "games", gameId, "players", user.uid),
+    {
+      uid: user.uid,
+      name: user.displayName || "",
+      joinedAt: serverTimestamp(),
+    },
+    { merge: true }
+  );
   await refreshMembershipAndControls();
   await loadGame();
 });
@@ -4041,12 +4049,15 @@ async function executeModeratorReplacement(playerId, userDoc) {
       delete baseData.userId;
       delete baseData.username;
       delete baseData.id;
+      delete baseData.joinedAt;
+      delete baseData.createdAt;
       transaction.set(newRef, {
         ...baseData,
         uid: newUserId,
         name: newName,
         username: newName,
         replacedFrom: playerId,
+        joinedAt: serverTimestamp(),
         updatedAt: serverTimestamp(),
       });
       transaction.delete(oldRef);

--- a/madia.new/public/legacy/member.js
+++ b/madia.new/public/legacy/member.js
@@ -588,7 +588,15 @@ els.createBtn.addEventListener("click", async () => {
     createdAt: serverTimestamp(),
   });
   // Auto-join owner
-  await setDoc(doc(db, "games", newDoc.id, "players", currentUser.uid), { uid: currentUser.uid, name: currentUser.displayName || "" });
+  await setDoc(
+    doc(db, "games", newDoc.id, "players", currentUser.uid),
+    {
+      uid: currentUser.uid,
+      name: currentUser.displayName || "",
+      joinedAt: serverTimestamp(),
+    },
+    { merge: true }
+  );
   location.href = `/legacy/game.html?g=${newDoc.id}`;
 });
 

--- a/madia.new/public/legacy/sitesummary.js
+++ b/madia.new/public/legacy/sitesummary.js
@@ -240,11 +240,21 @@ async function fetchLatestPlayers() {
       }
 
       snap.forEach((playerDoc) => {
+        const data = playerDoc.data() || {};
+        const joinedAt =
+          data.joinedAt ||
+          data.createdAt ||
+          data.updatedAt ||
+          playerDoc.createTime ||
+          playerDoc.updateTime ||
+          null;
+        const normalizedData =
+          joinedAt && !data.joinedAt ? { ...data, joinedAt } : data;
         players.push({
           id: playerDoc.id,
           gameId: gameDoc.id,
           gameName,
-          data: playerDoc.data(),
+          data: normalizedData,
         });
       });
     })


### PR DESCRIPTION
## Summary
- normalize player timestamps when aggregating site summary data so the latest section is populated
- capture join timestamps when players join or are replaced to feed the summary view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7fb5522f883289cf8fb6f6deb3735