### PR TITLE
Add moderator roster and game metadata controls

### DIFF
--- a/madia.new/public/control/index.html
+++ b/madia.new/public/control/index.html
@@ -69,6 +69,88 @@
           </table>
         </div>
       </section>
+
+      <section class="panel">
+        <div class="panel-header">
+          <div>
+            <h2>Game moderation</h2>
+            <p id="gameStatus" class="metadata status-message" role="status"></p>
+          </div>
+          <div class="panel-actions">
+            <button id="phaseToggleOpenButton" class="secondary" type="button">Toggle open</button>
+            <button id="phaseToggleActiveButton" class="secondary" type="button">Toggle active</button>
+            <button id="phaseNextDayButton" class="secondary" type="button">Advance day</button>
+          </div>
+        </div>
+
+        <form id="gameMetadataForm" class="game-metadata" autocomplete="off">
+          <label class="form-field">
+            Managed game
+            <select id="gameSelect" required>
+              <option value="">Select a game…</option>
+            </select>
+          </label>
+
+          <div class="form-grid">
+            <label class="form-field">
+              Title
+              <input id="gameNameInput" type="text" placeholder="Game title" />
+            </label>
+            <label class="form-field">
+              Day
+              <input id="gameDayInput" type="number" min="0" value="0" />
+            </label>
+            <label class="form-field">
+              Phase label
+              <input id="gamePhaseInput" type="text" placeholder="e.g. Day, Night" />
+            </label>
+          </div>
+
+          <div class="toggle-row">
+            <label class="toggle">
+              <input id="gameOpenInput" type="checkbox" />
+              <span>Open to new players</span>
+            </label>
+            <label class="toggle">
+              <input id="gameActiveInput" type="checkbox" />
+              <span>Game is active</span>
+            </label>
+            <div class="phase-shortcuts">
+              <span>Quick set:</span>
+              <button id="phaseSetDayButton" class="chip" type="button">Day</button>
+              <button id="phaseSetNightButton" class="chip" type="button">Night</button>
+            </div>
+          </div>
+
+          <div class="panel-actions">
+            <button class="primary" type="submit">Save metadata</button>
+            <button id="refreshGameButton" class="secondary" type="button">Refresh</button>
+          </div>
+        </form>
+
+        <div class="roster" aria-live="polite">
+          <div class="roster-header">
+            <h3>Roster</h3>
+            <p id="rosterStatus" class="metadata status-message" role="status"></p>
+          </div>
+          <div class="table-wrapper">
+            <table class="roster-table">
+              <thead>
+                <tr>
+                  <th scope="col">Player</th>
+                  <th scope="col">Role</th>
+                  <th scope="col">Alignment</th>
+                  <th scope="col">Status</th>
+                  <th scope="col">Posts left</th>
+                  <th scope="col">Moderator notes</th>
+                  <th scope="col" class="actions">Actions</th>
+                </tr>
+              </thead>
+              <tbody id="rosterTableBody"></tbody>
+            </table>
+          </div>
+        </div>
+      </section>
     </main>
 
     <dialog id="threadDialog">

--- a/madia.new/public/styles.css
+++ b/madia.new/public/styles.css
@@ -327,3 +327,146 @@ button:disabled {
     grid-template-columns: 1fr;
   }
 }
+
+.game-metadata {
+  display: grid;
+  gap: 1rem;
+}
+
+.game-metadata.disabled {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.form-field input,
+.form-field select {
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.toggle-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.toggle input {
+  width: auto;
+  accent-color: #38bdf8;
+}
+
+.phase-shortcuts {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.chip {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.7);
+}
+
+.roster-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.roster-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.roster-table th,
+.roster-table td {
+  padding: 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  text-align: left;
+  vertical-align: top;
+}
+
+.roster-table input,
+.roster-table textarea,
+.roster-table select {
+  width: 100%;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.roster-table textarea {
+  resize: vertical;
+  min-height: 3rem;
+}
+
+.roster-table th.actions {
+  text-align: right;
+}
+
+.roster-table tbody tr:hover {
+  background: rgba(56, 189, 248, 0.08);
+}
+
+.roster-name {
+  font-weight: 600;
+}
+
+.roster-meta {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.roster-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.roster-actions button {
+  padding-inline: 0.75rem;
+}
+
+.status-message {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.status-message.success {
+  color: #22c55e;
+}
+
+.status-message.error {
+  color: #ef4444;
+}
+
+.status-message.info {
+  color: #38bdf8;
+}


### PR DESCRIPTION
## Summary
- add a game moderation panel with metadata editing, phase shortcuts, and manual refresh support
- stream moderator roster data with save/reset actions that update player roles, notes, and status in Firestore
- extend control panel styling to cover the new management tools

## Testing
- not run (UI only)

------
https://chatgpt.com/codex/tasks/task_e_68d7f8d228d48328aef3bf0889569280