### PR TITLE
fix: hide legacy role tags

### DIFF
--- a/madia.new/public/legacy/roles-guide.js
+++ b/madia.new/public/legacy/roles-guide.js
@@ -63,13 +63,6 @@ function createRoleCard(role) {
 
   headCell.appendChild(heading);
 
-  if (Array.isArray(role.tags) && role.tags.length) {
-    const tags = document.createElement("div");
-    tags.className = "role-card__tags smallfont";
-    tags.textContent = `Tags: ${role.tags.join(", ")}`;
-    headCell.appendChild(tags);
-  }
-
   headRow.appendChild(headCell);
   thead.appendChild(headRow);
   table.appendChild(thead);
@@ -230,10 +223,6 @@ function renderActions(actions, emptyMessage) {
     if (action.notes) {
       details.push(`Notes: ${action.notes}`);
     }
-    if (Array.isArray(action.tags) && action.tags.length) {
-      details.push(`Tags: ${action.tags.join(", ")}`);
-    }
-
     if (details.length) {
       const meta = document.createElement("div");
       meta.className = "smallfont role-card__action-meta";


### PR DESCRIPTION
## Summary
- stop rendering tag metadata in the legacy role guide header
- omit action-level tag strings so the redundant "legacy" label no longer appears

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d857c0433083288a2cada50b8e14bf