### PR TITLE
Fix player list permissions for member profiles

### DIFF
--- a/madia.new/firestore.rules
+++ b/madia.new/firestore.rules
@@ -56,6 +56,10 @@ service cloud.firestore {
         );
     }
 
+    match /{document=**}/players/{playerId} {
+      allow read: if true;
+    }
+
     match /games/{gameId} {
       allow read: if true;
       allow create: if request.auth != null && request.resource.data.ownerUserId == request.auth.uid;


### PR DESCRIPTION
## Summary
- add a collection group rule that allows reading player documents
- ensure the member profile game lists can query Firestore without permission errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d858085a4483289562c629779b447f