### PR TITLE
Prevent game owners from appearing as players

### DIFF
--- a/madia.new/public/legacy/daysummary.js
+++ b/madia.new/public/legacy/daysummary.js
@@ -247,12 +247,15 @@ els.resetForm?.addEventListener("submit", async (event) => {
     });
     await deleteCollectionDocs(collection(gameRef, "actions"));
     const players = await getDocs(collection(gameRef, "players"));
+    const ownerId = currentGame?.ownerUserId || "";
     await Promise.all(
-      players.docs.map((docSnap) =>
-        updateDoc(docSnap.ref, { postsLeft: -1, active: true }).catch((error) => {
-          console.warn("Failed to reset player", docSnap.id, error);
-        })
-      )
+      players.docs
+        .filter((docSnap) => !ownerId || docSnap.id !== ownerId)
+        .map((docSnap) =>
+          updateDoc(docSnap.ref, { postsLeft: -1, active: true }).catch((error) => {
+            console.warn("Failed to reset player", docSnap.id, error);
+          })
+        )
     );
     await createSystemPost("Day 0 (game reset!)");
     setStatus("Game reset to Day 0.", "success");

--- a/madia.new/public/legacy/legacy.js
+++ b/madia.new/public/legacy/legacy.js
@@ -196,10 +196,11 @@ function watchGames() {
 
 async function decorateRow(game) {
   // Fetch meta similar to games.asp (counts, last post)
+  const ownerId = game.ownerUserId || "";
   let playerCount = 0;
   try {
     const playersSnap = await getDocs(collection(doc(db, "games", game.id), "players"));
-    playerCount = playersSnap.size;
+    playerCount = playersSnap.docs.filter((docSnap) => !ownerId || docSnap.id !== ownerId).length;
   } catch {}
 
   let postCount = 0;
@@ -216,7 +217,7 @@ async function decorateRow(game) {
   try {
     if (currentUser) {
       const pDoc = await getDoc(doc(db, "games", game.id, "players", currentUser.uid));
-      joined = pDoc.exists();
+      joined = pDoc.exists() && (!ownerId || pDoc.id !== ownerId);
     }
   } catch {}
 

--- a/madia.new/public/legacy/member.js
+++ b/madia.new/public/legacy/member.js
@@ -11,7 +11,6 @@ import {
   addDoc,
   doc,
   serverTimestamp,
-  setDoc,
   getDoc,
 } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
 import {
@@ -535,7 +534,13 @@ async function loadLists() {
   for (const gid of gameIds) {
     try {
       const d = await getDoc(doc(db, "games", gid));
-      if (d.exists()) plays.push({ id: gid, ...d.data() });
+      if (d.exists()) {
+        const data = d.data();
+        if (data.ownerUserId === viewedUid) {
+          continue;
+        }
+        plays.push({ id: gid, ...data });
+      }
     } catch (error) {
       if (isPermissionDenied(error)) {
         handleListError(error);
@@ -587,16 +592,6 @@ els.createBtn.addEventListener("click", async () => {
     day: 0,
     createdAt: serverTimestamp(),
   });
-  // Auto-join owner
-  await setDoc(
-    doc(db, "games", newDoc.id, "players", currentUser.uid),
-    {
-      uid: currentUser.uid,
-      name: currentUser.displayName || "",
-      joinedAt: serverTimestamp(),
-    },
-    { merge: true }
-  );
   location.href = `/legacy/game.html?g=${newDoc.id}`;
 });
 

--- a/madia.new/public/legacy/sitesummary.js
+++ b/madia.new/public/legacy/sitesummary.js
@@ -241,6 +241,9 @@ async function fetchLatestPlayers() {
 
       snap.forEach((playerDoc) => {
         const data = playerDoc.data() || {};
+        if (gameData?.ownerUserId && playerDoc.id === gameData.ownerUserId) {
+          return;
+        }
         const joinedAt =
           data.joinedAt ||
           data.createdAt ||

--- a/madia.new/public/script.js
+++ b/madia.new/public/script.js
@@ -167,6 +167,10 @@ let currentGame = null;
 let rosterById = new Map();
 let editingPlayerId = null;
 
+function normalizeId(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
 async function ensurePlayerRecord(user) {
   if (!user) return null;
   const userRef = doc(db, "users", user.uid);
@@ -937,15 +941,19 @@ function showRosterMessage(message) {
 }
 
 function renderRoster(players) {
-  rosterById = new Map(players.map((player) => [player.id, player]));
+  const ownerId = normalizeId(currentGame?.ownerUserId);
+  const filteredPlayers = ownerId
+    ? players.filter((player) => normalizeId(player.id) !== ownerId)
+    : players;
+  rosterById = new Map(filteredPlayers.map((player) => [player.id, player]));
   if (!els.rosterTableBody) return;
   els.rosterTableBody.innerHTML = "";
-  if (!players.length) {
+  if (!filteredPlayers.length) {
     showRosterMessage("No players joined yet.");
     return;
   }
   const canEdit = isCurrentUserGameOwner();
-  players.forEach((player) => {
+  filteredPlayers.forEach((player) => {
     const row = document.createElement("tr");
     row.dataset.playerId = player.id;
 


### PR DESCRIPTION
## Summary
- filter game owner IDs out of roster rendering in the modern moderator tools
- update legacy game management flows so owners keep moderator privileges without appearing in player lists or dropdowns
- exclude owners from player counts, summaries, and new game auto-join logic across legacy pages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d859e244288328b7d73ae35479a055