### PR TITLE
Hide private channel section when access denied

### DIFF
--- a/madia.new/public/legacy/game.js
+++ b/madia.new/public/legacy/game.js
@@ -886,12 +886,12 @@ async function loadPrivateChannels() {
     channelSnapshot = await getDocs(collection(gameRef, "channels"));
   } catch (error) {
     console.error("Failed to load private channels", error);
-    const message =
-      error?.code === "permission-denied"
-        ? "You do not have permission to view private discussions."
-        : "Unable to load private discussions.";
-    setPrivateChannelsStatus(message, "error");
-    container.innerHTML = "";
+    if (error?.code === "permission-denied") {
+      clearPrivateChannels();
+    } else {
+      setPrivateChannelsStatus("Unable to load private discussions.", "error");
+      container.innerHTML = "";
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
- hide the private discussion panel when Firestore rejects access so players without channels do not see it

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68daf1ce270c8328a0572955697af4c5