### PR TITLE
Add legacy my game view and surface role summaries

### DIFF
--- a/madia.new/public/legacy/game.html
+++ b/madia.new/public/legacy/game.html
@@ -116,6 +116,17 @@
             </div>
             <div id="playerTools" class="smallfont" style="display:none; margin-bottom:12px;">
               <div><strong>Private Game Tools</strong></div>
+              <div
+                id="playerRoleSummary"
+                style="display:none; margin-top:8px; margin-bottom:10px;"
+              >
+                <div id="playerRoleName" style="font-size:14px; font-weight:bold;"></div>
+                <div
+                  id="playerRoleDescription"
+                  class="smallfont"
+                  style="margin-top:4px; line-height:1.4;"
+                ></div>
+              </div>
               <form id="privateActionForm" class="stacked-form">
                 <label>
                   Action name

--- a/madia.new/public/legacy/game.js
+++ b/madia.new/public/legacy/game.js
@@ -81,6 +81,9 @@ const els = {
   daySummary: document.getElementById("daySummary"),
   playerTools: document.getElementById("playerTools"),
   playerToolsStatus: document.getElementById("playerToolsStatus"),
+  playerRoleSummary: document.getElementById("playerRoleSummary"),
+  playerRoleName: document.getElementById("playerRoleName"),
+  playerRoleDescription: document.getElementById("playerRoleDescription"),
   privateChannelsSection: document.getElementById("privateChannelsSection"),
   privateChannelsContainer: document.getElementById("privateChannelsContainer"),
   privateChannelsStatus: document.getElementById("privateChannelsStatus"),
@@ -506,6 +509,7 @@ async function loadGame() {
   }
   const g = gSnap.data();
   currentGame = { id: gameId, ...g };
+  updateHeaderNav({ joined: false });
   isOwnerView = !!(auth.currentUser && g.ownerUserId === auth.currentUser.uid);
   els.gameTitle.textContent = g.gamename || "(no name)";
   els.ownerControls.style.display = isOwnerView ? "block" : "none";
@@ -726,6 +730,29 @@ function getAssignedRoleName(player) {
     return "";
   }
   const fields = ["role", "rolename", "roleName"];
+  for (const field of fields) {
+    const raw = player[field];
+    if (typeof raw === "string") {
+      const trimmed = raw.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+  return "";
+}
+
+function getAssignedRoleDescription(player) {
+  if (!player || typeof player !== "object") {
+    return "";
+  }
+  const fields = [
+    "description",
+    "roleDescription",
+    "roleText",
+    "roleDetails",
+    "roleDescriptionText",
+  ];
   for (const field of fields) {
     const raw = player[field];
     if (typeof raw === "string") {
@@ -1125,6 +1152,75 @@ function setDisplay(el, value) {
   }
 }
 
+function updatePlayerRoleSummary(player) {
+  const summary = els.playerRoleSummary;
+  const nameEl = els.playerRoleName;
+  const descriptionEl = els.playerRoleDescription;
+  if (!summary || !nameEl || !descriptionEl) {
+    return;
+  }
+
+  if (!player) {
+    summary.style.display = "none";
+    nameEl.textContent = "";
+    descriptionEl.innerHTML = "";
+    return;
+  }
+
+  const roleName = getAssignedRoleName(player);
+  const roleDescription = getAssignedRoleDescription(player);
+  if (!roleName && !roleDescription) {
+    summary.style.display = "none";
+    nameEl.textContent = "";
+    descriptionEl.innerHTML = "";
+    return;
+  }
+
+  summary.style.display = "block";
+  nameEl.innerHTML = roleName ? `<big><big>${escapeHtml(roleName)}</big></big>` : "";
+  if (roleDescription) {
+    const escaped = escapeHtml(roleDescription).replace(/\r?\n/g, "<br />");
+    descriptionEl.innerHTML = escaped;
+  } else {
+    descriptionEl.innerHTML = "";
+  }
+}
+
+function updateHeaderNav({ joined = false } = {}) {
+  if (!header || typeof header.setNavLinks !== "function") {
+    return;
+  }
+
+  const links = [{ label: "List of Games", href: "/legacy/index.html" }];
+  if (currentGame) {
+    const gameLabel = currentGame.gamename || "(no name)";
+    const gameLink = {
+      label: gameLabel,
+      href: `/legacy/game.html?g=${encodeURIComponent(currentGame.id)}`,
+    };
+    if (!joined) {
+      gameLink.current = true;
+    }
+    links.push(gameLink);
+    if (joined) {
+      links.push({
+        label: "my game",
+        href: `/legacy/mygame.html?g=${encodeURIComponent(currentGame.id)}`,
+        current: true,
+        italic: true,
+      });
+    }
+  } else {
+    links[0].current = true;
+  }
+
+  if (!links.some((link) => link && link.current)) {
+    links[links.length - 1].current = true;
+  }
+
+  header.setNavLinks(links);
+}
+
 async function refreshMembershipAndControls() {
   const user = auth.currentUser;
   if (!user) {
@@ -1144,6 +1240,8 @@ async function refreshMembershipAndControls() {
     populatePrivateActionOptions();
     populateClaimRoleOptions();
     updatePlayerToolsFormsVisibility();
+    updatePlayerRoleSummary(null);
+    updateHeaderNav({ joined: false });
     return;
   }
   try {
@@ -1158,7 +1256,14 @@ async function refreshMembershipAndControls() {
     setDisplay(els.playerTools, joined || ownerView ? "block" : "none");
     updatePlayerToolsFormsVisibility();
     updatePublicActionControls();
-  } catch {}
+    updatePlayerRoleSummary(currentPlayer);
+    updateHeaderNav({ joined });
+  } catch (error) {
+    console.warn("Failed to refresh player membership", error);
+    currentPlayer = null;
+    updatePlayerRoleSummary(null);
+    updateHeaderNav({ joined: false });
+  }
   await loadPrivateChannels();
   await renderActionHistory();
   populatePrivateActionOptions();

--- a/madia.new/public/legacy/header.js
+++ b/madia.new/public/legacy/header.js
@@ -179,10 +179,13 @@ export function initLegacyHeader({ containerId = "legacyHeader" } = {}) {
       cellspacing="0"
     >
       <tr>
-        <td align="left" valign="top" height="48">
-          <table width="50%" align="left" border="0" cellspacing="0" cellpadding="0">
+        <td align="left" valign="middle" height="48">
+          <table width="100%" align="left" border="0" cellspacing="0" cellpadding="0">
             <tr>
-              <td align="left" valign="top" width="192" height="48">&nbsp;</td>
+              <td align="left" valign="middle" width="192" height="48">&nbsp;</td>
+              <td align="left" valign="middle" class="smallfont" id="legacyHeaderNav" style="padding-left:12px;">
+                &nbsp;
+              </td>
             </tr>
           </table>
         </td>
@@ -217,7 +220,55 @@ export function initLegacyHeader({ containerId = "legacyHeader" } = {}) {
     signupSubmit: container.querySelector("#legacyHeaderSignupSubmit"),
     showLogin: container.querySelector("#legacyHeaderShowLogin"),
     showSignup: container.querySelector("#legacyHeaderShowSignup"),
+    nav: container.querySelector("#legacyHeaderNav"),
   };
+
+  function escapeHtml(value) {
+    if (value === null || value === undefined) {
+      return "";
+    }
+    return String(value)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function setNavLinks(links = []) {
+    if (!els.nav) {
+      return;
+    }
+    if (!Array.isArray(links) || !links.length) {
+      els.nav.innerHTML = "&nbsp;";
+      return;
+    }
+    const parts = [];
+    links.forEach((link, index) => {
+      if (!link || typeof link !== "object") {
+        return;
+      }
+      const separator = index === 0 ? "" : " &raquo; ";
+      const label = escapeHtml(link.label || "");
+      if (link.current) {
+        const italicized = link.italic ? `<i>${label}</i>` : label;
+        parts.push(`${separator}<strong>${italicized}</strong>`);
+        return;
+      }
+      if (link.href) {
+        parts.push(
+          `${separator}<span class="navbar"><a href="${escapeHtml(link.href)}">${label}</a></span>`
+        );
+        return;
+      }
+      parts.push(`${separator}<span class="navbar">${label}</span>`);
+    });
+    if (!parts.length) {
+      els.nav.innerHTML = "&nbsp;";
+      return;
+    }
+    els.nav.innerHTML = parts.join("");
+  }
 
   let currentMode = "login";
   let panelVisible = false;
@@ -405,6 +456,10 @@ export function initLegacyHeader({ containerId = "legacyHeader" } = {}) {
     updateUser(user);
   });
 
+  setNavLinks([
+    { label: "List of Games", href: "/legacy/index.html", current: true },
+  ]);
+
   function disableSection(section) {
     if (!section) return;
     section.style.opacity = "0.5";
@@ -424,6 +479,7 @@ export function initLegacyHeader({ containerId = "legacyHeader" } = {}) {
     closeAuthPanel: closePanel,
     profileLink: els.profileLink,
     setUser: updateUser,
+    setNavLinks,
     destroy,
   };
 }

--- a/madia.new/public/legacy/legacy.js
+++ b/madia.new/public/legacy/legacy.js
@@ -13,6 +13,9 @@ import { auth, db, ensureUserDocument, missingConfig } from "./firebase.js";
 import { initLegacyHeader } from "./header.js";
 
 const header = initLegacyHeader();
+header?.setNavLinks([
+  { label: "List of Games", href: "/legacy/index.html", current: true },
+]);
 const els = {
   gamesBody: document.getElementById("gamesBody"),
 };

--- a/madia.new/public/legacy/mygame.html
+++ b/madia.new/public/legacy/mygame.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>My Game</title>
+    <link rel="stylesheet" href="/legacy/phalla.css" />
+  </head>
+  <body>
+    <div id="legacyHeader"></div>
+    <div align="center">
+      <div class="page" style="width:98%; text-align:left">
+        <div style="padding:0px 10px 0px 10px">
+          <table class="page" cellpadding="4" cellspacing="1" border="0" width="100%" align="center">
+            <tr>
+              <td class="page" valign="bottom" width="100%">
+                <span class="navbar"><a href="/legacy/index.html" accesskey="1">List of Games</a></span>
+                <span class="navbar" id="myGameBreadcrumb"></span>
+                &raquo; <strong><i>my game</i></strong>
+              </td>
+            </tr>
+          </table>
+
+          <table class="tborder" cellpadding="4" cellspacing="1" border="0" width="100%" align="center" style="border-bottom-width:0px">
+            <tr>
+              <td class="tcat">
+                Game<span class="normal"> : <span id="myGameName">(loading)</span></span>
+                [day <span id="myGameDay">0</span>]
+              </td>
+            </tr>
+          </table>
+
+          <div class="smallfont" id="myGameStatus" style="margin-top:8px; display:none;"></div>
+
+          <div id="myGameContent" style="display:none; margin-top:12px;">
+            <div
+              id="myGameRoleBlock"
+              class="smallfont"
+              style="display:none; margin-bottom:16px;"
+            >
+              <div id="myGameRoleName" style="font-size:16px; font-weight:bold;"></div>
+              <div id="myGameRoleDescription" style="margin-top:6px; line-height:1.5;"></div>
+            </div>
+
+            <div class="smallfont" style="margin-bottom:12px;">
+              <a id="myGameThreadLink" href="#">Return to game thread</a>
+            </div>
+
+            <div id="myGameActionSection" style="display:none;">
+              <table class="tborder" cellpadding="4" cellspacing="1" border="0" width="100%" align="center">
+                <thead>
+                  <tr align="center">
+                    <td class="thead" width="60">Day</td>
+                    <td class="thead" width="160">Action</td>
+                    <td class="thead" width="200">Target</td>
+                    <td class="thead" width="120">Result</td>
+                    <td class="thead">Logged</td>
+                  </tr>
+                </thead>
+                <tbody id="myGameActions">
+                  <tr>
+                    <td class="alt1" colspan="5" align="center">Loading private history…</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script type="module" src="/legacy/mygame.js"></script>
+  </body>
+</html>

--- a/madia.new/public/legacy/mygame.js
+++ b/madia.new/public/legacy/mygame.js
@@ -1,0 +1,519 @@
+import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js";
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  where,
+} from "https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js";
+import { auth, db, ensureUserDocument, missingConfig } from "./firebase.js";
+import { initLegacyHeader } from "./header.js";
+
+const header = initLegacyHeader();
+
+const els = {
+  breadcrumb: document.getElementById("myGameBreadcrumb"),
+  gameName: document.getElementById("myGameName"),
+  gameDay: document.getElementById("myGameDay"),
+  status: document.getElementById("myGameStatus"),
+  content: document.getElementById("myGameContent"),
+  roleBlock: document.getElementById("myGameRoleBlock"),
+  roleName: document.getElementById("myGameRoleName"),
+  roleDescription: document.getElementById("myGameRoleDescription"),
+  threadLink: document.getElementById("myGameThreadLink"),
+  actionSection: document.getElementById("myGameActionSection"),
+  actionsBody: document.getElementById("myGameActions"),
+};
+
+const params = new URLSearchParams(location.search);
+const gameId = params.get("g");
+
+let currentUser = auth.currentUser;
+let currentGame = null;
+let currentPlayer = null;
+let loadToken = 0;
+
+if (!gameId) {
+  renderStatus("Missing game id.", "error");
+} else if (missingConfig) {
+  renderStatus(
+    "Firebase configuration required. Update public/legacy/firebase.js before using this page.",
+    "warning"
+  );
+}
+
+header?.setNavLinks([
+  { label: "List of Games", href: "/legacy/index.html", current: !gameId },
+]);
+
+initializePage().catch((error) => {
+  console.error("Failed to initialise my game view", error);
+});
+
+onAuthStateChanged(auth, (user) => {
+  currentUser = user;
+  header?.setUser(user);
+  initializePage().catch((error) => {
+    console.error("Failed to refresh my game view after auth change", error);
+  });
+});
+
+async function initializePage() {
+  if (!gameId || missingConfig) {
+    return;
+  }
+
+  const token = ++loadToken;
+  renderStatus("Loading game details…", "info");
+
+  const gameRef = doc(db, "games", gameId);
+  let gameSnap;
+  try {
+    gameSnap = await getDoc(gameRef);
+  } catch (error) {
+    if (token !== loadToken) return;
+    console.error("Failed to load game", error);
+    renderStatus("Unable to load game details.", "error");
+    return;
+  }
+
+  if (token !== loadToken) return;
+
+  if (!gameSnap.exists()) {
+    currentGame = null;
+    updateBreadcrumb();
+    renderStatus("Game not found.", "error");
+    return;
+  }
+
+  currentGame = { id: gameId, ...gameSnap.data() };
+  updateGameDisplay();
+  updateBreadcrumb();
+
+  if (!currentUser) {
+    showContent();
+    renderRole(null);
+    hideActionSection();
+    renderStatus("Sign in to view your assignment.", "warning");
+    return;
+  }
+
+  try {
+    await ensureUserDocument(currentUser);
+  } catch (error) {
+    if (token !== loadToken) return;
+    console.warn("Failed to ensure user document", error);
+  }
+
+  let playerSnap;
+  try {
+    playerSnap = await getDoc(doc(gameRef, "players", currentUser.uid));
+  } catch (error) {
+    if (token !== loadToken) return;
+    console.error("Failed to load player record", error);
+    showContent();
+    renderRole(null);
+    hideActionSection();
+    renderStatus("Unable to load your assignment.", "error");
+    return;
+  }
+
+  if (token !== loadToken) return;
+
+  if (!playerSnap.exists()) {
+    currentPlayer = null;
+    showContent();
+    renderRole(null);
+    hideActionSection();
+    renderStatus(
+      "You have not joined this game yet. Visit the game thread and click Join Game to receive a role.",
+      "info"
+    );
+    return;
+  }
+
+  currentPlayer = { id: playerSnap.id, ...playerSnap.data() };
+  showContent();
+  renderRole(currentPlayer);
+  renderStatus("", "info");
+  await loadPlayerActions(currentUser.uid, token);
+}
+
+function updateGameDisplay() {
+  if (!currentGame) {
+    return;
+  }
+  if (els.gameName) {
+    els.gameName.textContent = currentGame.gamename || "(no name)";
+  }
+  if (els.gameDay) {
+    const dayValue = currentGame.day;
+    els.gameDay.textContent = Number.isFinite(dayValue) ? dayValue : dayValue || "0";
+  }
+  if (els.threadLink) {
+    els.threadLink.href = `/legacy/game.html?g=${encodeURIComponent(currentGame.id)}`;
+    els.threadLink.textContent = `Return to ${currentGame.gamename || "the game"}`;
+  }
+  if (els.breadcrumb) {
+    const name = escapeHtml(currentGame.gamename || "(no name)");
+    els.breadcrumb.innerHTML = `&gt; <a href="/legacy/game.html?g=${encodeURIComponent(
+      currentGame.id
+    )}">${name}</a>`;
+  }
+  document.title = currentGame.gamename
+    ? `My Game: ${currentGame.gamename}`
+    : "My Game";
+}
+
+function updateBreadcrumb() {
+  if (!header || typeof header.setNavLinks !== "function") {
+    return;
+  }
+  const links = [{ label: "List of Games", href: "/legacy/index.html" }];
+  if (currentGame) {
+    const label = currentGame.gamename || "(no name)";
+    links.push({
+      label,
+      href: `/legacy/game.html?g=${encodeURIComponent(currentGame.id)}`,
+    });
+    links.push({ label: "my game", current: true, italic: true });
+  } else {
+    links[0].current = true;
+  }
+  if (!links.some((link) => link.current)) {
+    links[links.length - 1].current = true;
+  }
+  header.setNavLinks(links);
+}
+
+function showContent() {
+  if (els.content) {
+    els.content.style.display = "block";
+  }
+}
+
+function hideActionSection() {
+  if (els.actionSection) {
+    els.actionSection.style.display = "none";
+  }
+  if (els.actionsBody) {
+    els.actionsBody.innerHTML = `
+      <tr>
+        <td class="alt1" colspan="5" align="center">Loading private history…</td>
+      </tr>
+    `;
+  }
+}
+
+function renderRole(player) {
+  if (!els.roleBlock || !els.roleName || !els.roleDescription) {
+    return;
+  }
+  if (!player) {
+    els.roleBlock.style.display = "none";
+    els.roleName.textContent = "";
+    els.roleDescription.innerHTML = "";
+    return;
+  }
+  const roleName = getAssignedRoleName(player);
+  const roleDescription = getAssignedRoleDescription(player);
+  if (!roleName && !roleDescription) {
+    els.roleBlock.style.display = "none";
+    els.roleName.textContent = "";
+    els.roleDescription.innerHTML = "";
+    return;
+  }
+  els.roleBlock.style.display = "block";
+  els.roleName.innerHTML = roleName ? `<big><big>${escapeHtml(roleName)}</big></big>` : "";
+  if (roleDescription) {
+    const escaped = escapeHtml(roleDescription).replace(/\r?\n/g, "<br />");
+    els.roleDescription.innerHTML = escaped;
+  } else {
+    els.roleDescription.innerHTML = "";
+  }
+}
+
+async function loadPlayerActions(userId, token) {
+  if (!els.actionSection || !els.actionsBody) {
+    return;
+  }
+  els.actionSection.style.display = "block";
+  els.actionsBody.innerHTML = `
+    <tr>
+      <td class="alt1" colspan="5" align="center">Loading private history…</td>
+    </tr>
+  `;
+
+  const actionsRef = collection(db, "games", gameId, "actions");
+  let snapshot;
+  try {
+    snapshot = await getDocs(query(actionsRef, where("playerId", "==", userId)));
+  } catch (error) {
+    if (token !== loadToken) return;
+    console.error("Failed to load private history", error);
+    if (error?.code === "permission-denied") {
+      els.actionSection.style.display = "none";
+      renderStatus("You do not have permission to view your recorded actions.", "warning");
+      return;
+    }
+    els.actionsBody.innerHTML = `
+      <tr>
+        <td class="alt1" colspan="5" align="center">Unable to load private history.</td>
+      </tr>
+    `;
+    return;
+  }
+
+  if (token !== loadToken) return;
+
+  const records = snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+  if (!records.length) {
+    els.actionsBody.innerHTML = `
+      <tr>
+        <td class="alt1" colspan="5" align="center"><i>No private history recorded yet.</i></td>
+      </tr>
+    `;
+    return;
+  }
+
+  records.sort((a, b) => {
+    const dayA = Number.isFinite(a.day) ? a.day : parseInt(a.day, 10) || 0;
+    const dayB = Number.isFinite(b.day) ? b.day : parseInt(b.day, 10) || 0;
+    if (dayA !== dayB) {
+      return dayA - dayB;
+    }
+    return toMillis(a.createdAt || a.updatedAt) - toMillis(b.createdAt || b.updatedAt);
+  });
+
+  els.actionsBody.innerHTML = "";
+  let alt = false;
+  records.forEach((record) => {
+    els.actionsBody.appendChild(renderActionRow(record, alt));
+    alt = !alt;
+  });
+}
+
+function renderActionRow(action, alt) {
+  const tr = document.createElement("tr");
+  tr.setAttribute("align", "center");
+
+  const dayCell = document.createElement("td");
+  dayCell.className = alt ? "alt2" : "alt1";
+  dayCell.textContent = formatActionDay(action);
+  tr.appendChild(dayCell);
+
+  const actionCell = document.createElement("td");
+  actionCell.className = alt ? "alt1" : "alt2";
+  actionCell.setAttribute("align", "left");
+  actionCell.textContent = formatActionName(action);
+  tr.appendChild(actionCell);
+
+  const targetCell = document.createElement("td");
+  targetCell.className = alt ? "alt2" : "alt1";
+  targetCell.setAttribute("align", "left");
+  targetCell.innerHTML = formatActionTarget(action);
+  tr.appendChild(targetCell);
+
+  const statusCell = document.createElement("td");
+  statusCell.className = alt ? "alt1" : "alt2";
+  statusCell.textContent = formatActionStatus(action);
+  tr.appendChild(statusCell);
+
+  const loggedCell = document.createElement("td");
+  loggedCell.className = alt ? "alt2" : "alt1";
+  loggedCell.textContent = formatActionLogged(action);
+  tr.appendChild(loggedCell);
+
+  return tr;
+}
+
+function formatActionDay(action = {}) {
+  const day = action.day;
+  if (Number.isFinite(day)) {
+    return day;
+  }
+  if (typeof day === "string" && day.trim()) {
+    return day.trim();
+  }
+  return "—";
+}
+
+function formatActionName(action = {}) {
+  const value = getFirstStringValue(action, [
+    "actionName",
+    "action",
+    "category",
+    "type",
+    "label",
+  ]);
+  return value || "—";
+}
+
+function formatActionTarget(action = {}) {
+  const primary =
+    getFirstStringValue(action, ["targetName", "target", "targetDisplayName"]) ||
+    getFirstStringValue(action, ["targetPlayerName"]);
+  const fallback = getFirstStringValue(action, ["targetPlayerId"]);
+  const base = primary || fallback || "—";
+  const note = getFirstStringValue(action, ["notes", "detail", "details", "extraNotes"]);
+  const pieces = [`<div>${escapeHtml(base)}</div>`];
+  if (note) {
+    pieces.push(`<div class="smallfont">${escapeHtml(note)}</div>`);
+  }
+  return pieces.join("");
+}
+
+function formatActionStatus(action = {}) {
+  const explicit = getFirstStringValue(action, [
+    "statusText",
+    "status",
+    "resultText",
+    "result",
+    "outcome",
+    "resolution",
+    "resolutionText",
+  ]);
+  if (explicit) {
+    return explicit;
+  }
+  if (action.valid === false) {
+    return "Invalidated";
+  }
+  if (action.pending === true) {
+    return "Pending";
+  }
+  if (typeof action.success === "boolean") {
+    return action.success ? "Success" : "Failed";
+  }
+  return "Recorded";
+}
+
+function formatActionLogged(action = {}) {
+  return formatDate(action.updatedAt || action.createdAt || "");
+}
+
+function getAssignedRoleName(player) {
+  if (!player || typeof player !== "object") {
+    return "";
+  }
+  const fields = ["role", "rolename", "roleName"];
+  for (const field of fields) {
+    const raw = player[field];
+    if (typeof raw === "string") {
+      const trimmed = raw.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+  return "";
+}
+
+function getAssignedRoleDescription(player) {
+  if (!player || typeof player !== "object") {
+    return "";
+  }
+  const fields = [
+    "description",
+    "roleDescription",
+    "roleText",
+    "roleDetails",
+    "roleDescriptionText",
+  ];
+  for (const field of fields) {
+    const raw = player[field];
+    if (typeof raw === "string") {
+      const trimmed = raw.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+  return "";
+}
+
+function getFirstStringValue(source, keys = []) {
+  if (!source || typeof source !== "object") {
+    return "";
+  }
+  for (const key of keys) {
+    if (!key) continue;
+    const value = source[key];
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+  return "";
+}
+
+function escapeHtml(value) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function formatDate(value) {
+  if (!value) {
+    return "";
+  }
+  if (typeof value.toDate === "function") {
+    const date = value.toDate();
+    return date instanceof Date ? date.toLocaleString() : "";
+  }
+  if (value instanceof Date) {
+    return value.toLocaleString();
+  }
+  return String(value);
+}
+
+function toMillis(value) {
+  if (!value) {
+    return 0;
+  }
+  if (typeof value.toMillis === "function") {
+    try {
+      return value.toMillis();
+    } catch {}
+  }
+  if (typeof value.toDate === "function") {
+    const date = value.toDate();
+    if (date instanceof Date) {
+      return date.getTime();
+    }
+  }
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function renderStatus(message, type = "info") {
+  if (!els.status) {
+    return;
+  }
+  if (!message) {
+    els.status.style.display = "none";
+    els.status.textContent = "";
+    return;
+  }
+  els.status.style.display = "block";
+  els.status.textContent = message;
+  let color = "#F9A906";
+  if (type === "error") {
+    color = "#ff7676";
+  } else if (type === "success") {
+    color = "#6ee7b7";
+  }
+  els.status.style.color = color;
+}

--- a/madia.new/public/legacy/playerlist.js
+++ b/madia.new/public/legacy/playerlist.js
@@ -47,6 +47,14 @@ async function loadPlayers() {
   if (gameSnap.exists()) {
     const gameName = gameSnap.data().gamename || "(no name)";
     gameBreadcrumb.innerHTML = `&gt; <a href="/legacy/game.html?g=${encodeURIComponent(gameId)}">${escapeHtml(gameName)}</a>`;
+    header?.setNavLinks([
+      { label: "List of Games", href: "/legacy/index.html" },
+      {
+        label: gameName,
+        href: `/legacy/game.html?g=${encodeURIComponent(gameId)}`,
+      },
+      { label: "Player List", current: true },
+    ]);
   }
 
   const playersSnap = await getDocs(collection(gameRef, "players"));


### PR DESCRIPTION
## Summary
- add breadcrumb navigation to the legacy header and update the games and player list views to use it
- show a signed-in player’s assigned role inside the Private Game Tools panel
- introduce a dedicated my game page that reveals the player’s role and private action history

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daf1ff69ec8328a145efb06cfa41c7