### PR TITLE
fix: hide public actions for non-players

### DIFF
--- a/madia.new/public/legacy/game.js
+++ b/madia.new/public/legacy/game.js
@@ -2884,13 +2884,15 @@ function updatePublicActionControls() {
   if (!block) {
     return;
   }
-  const playerActive = currentPlayer ? playerIsAlive(currentPlayer) : false;
+  const isPlayer = !!currentPlayer;
+  const playerActive = isPlayer && playerIsAlive(currentPlayer);
   const gameActive = isGameCurrentlyActive();
   const dayStarted = hasGameDayStarted();
   const lockedForPlayer = isGameLockedForPlayers() && !isOwnerView;
   const canUseActions =
     !!auth.currentUser &&
-    (playerActive || isOwnerView) &&
+    isPlayer &&
+    playerActive &&
     gameActive &&
     dayStarted &&
     !lockedForPlayer;


### PR DESCRIPTION
## Summary
- require an active player before showing the public vote/claim controls
- keep moderators from seeing player-only public actions while still allowing players to interact as before

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd816e1454832896d7639d6a17c9a8