### PR TITLE
Fix breadcrumb link to My Game view

### DIFF
--- a/madia.new/public/legacy/game.js
+++ b/madia.new/public/legacy/game.js
@@ -1637,15 +1637,12 @@ function updateHeaderNav({ joined = false } = {}) {
       label: gameLabel,
       href: `/legacy/game.html?g=${encodeURIComponent(currentGame.id)}`,
     };
-    if (!joined) {
-      gameLink.current = true;
-    }
+    gameLink.current = true;
     links.push(gameLink);
     if (joined) {
       links.push({
         label: "my game",
         href: `/legacy/mygame.html?g=${encodeURIComponent(currentGame.id)}`,
-        current: true,
         italic: true,
       });
     }

--- a/madia.new/public/legacy/header.js
+++ b/madia.new/public/legacy/header.js
@@ -250,18 +250,18 @@ export function initLegacyHeader({ containerId = "legacyHeader" } = {}) {
       }
       const separator = index === 0 ? "" : " &raquo; ";
       const label = escapeHtml(link.label || "");
+      const formattedLabel = link.italic ? `<i>${label}</i>` : label;
       if (link.current) {
-        const italicized = link.italic ? `<i>${label}</i>` : label;
-        parts.push(`${separator}<strong>${italicized}</strong>`);
+        parts.push(`${separator}<strong>${formattedLabel}</strong>`);
         return;
       }
       if (link.href) {
         parts.push(
-          `${separator}<span class="navbar"><a href="${escapeHtml(link.href)}">${label}</a></span>`
+          `${separator}<span class="navbar"><a href="${escapeHtml(link.href)}">${formattedLabel}</a></span>`
         );
         return;
       }
-      parts.push(`${separator}<span class="navbar">${label}</span>`);
+      parts.push(`${separator}<span class="navbar">${formattedLabel}</span>`);
     });
     if (!parts.length) {
       els.nav.innerHTML = "&nbsp;";


### PR DESCRIPTION
## Summary
- ensure the game page breadcrumb keeps the game thread as the current item
- render the "my game" breadcrumb entry as a navigable link when viewing the game
- allow breadcrumb items to display in italics even when linked

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd8225dfac83289e209ec21d070d34