### PR TITLE
Fix mafia players missing access to private discussions

### DIFF
--- a/madia.new/public/legacy/game.js
+++ b/madia.new/public/legacy/game.js
@@ -783,6 +783,13 @@ function getAssignedRoleName(player) {
       }
     }
   }
+  const roleDefinitionName = player.roleDefinition?.name;
+  if (typeof roleDefinitionName === "string") {
+    const trimmed = roleDefinitionName.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
   return "";
 }
 
@@ -1336,7 +1343,8 @@ async function loadPrivateChannels() {
   const ownerId = normalizeIdentifier(currentGame?.ownerUserId);
   const isOwner = ownerId && userId === ownerId;
   const assignedRole = getAssignedRoleName(currentPlayer);
-  if (!isOwner && !assignedRole) {
+  const assignedLegacyRoleId = getAssignedLegacyRoleId(currentPlayer);
+  if (!isOwner && !assignedRole && assignedLegacyRoleId === null) {
     clearPrivateChannels();
     return;
   }


### PR DESCRIPTION
## Summary
- allow player role detection to fall back to the canonical role definition name
- permit players with only a legacy role id to load private discussion channels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd8263bbcc83289679b56904735119