### PR TITLE
feat: expand Argumentum mechanics

### DIFF
--- a/madia.new/public/secret/argumentum/argumentum.css
+++ b/madia.new/public/secret/argumentum/argumentum.css
@@ -1,0 +1,349 @@
+:root {
+  color-scheme: dark;
+  font-family: "Segoe UI", Roboto, sans-serif;
+  background: radial-gradient(circle at top, #1f2b3a, #0b1016 60%);
+  color: #f2f5f8;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.page-header,
+.page-footer {
+  text-align: center;
+  padding: 1.5rem;
+  background: rgba(12, 20, 28, 0.8);
+  backdrop-filter: blur(6px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+}
+
+.subtitle {
+  margin: 0.5rem auto 0;
+  max-width: 55ch;
+  color: #9bb4d2;
+}
+
+.game-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  padding: 1.5rem;
+  flex: 1;
+}
+
+.panel {
+  background: rgba(19, 29, 40, 0.85);
+  border-radius: 16px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.35);
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.panel-help {
+  margin: 0;
+  color: #a2bdde;
+  font-size: 0.95rem;
+}
+
+.action-button {
+  background: linear-gradient(120deg, #2f80ed, #56ccf2);
+  border: none;
+  color: #0b1016;
+  font-weight: 600;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.action-button:disabled {
+  background: linear-gradient(120deg, #3b4a5d, #2d3744);
+  color: #b4c5d9;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.action-button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(44, 140, 240, 0.35);
+}
+
+.match-board {
+  display: grid;
+  grid-template-columns: repeat(6, 48px);
+  gap: 4px;
+  justify-content: center;
+}
+
+.rock-tile {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  cursor: pointer;
+  border: 2px solid rgba(255, 255, 255, 0.12);
+  transition: transform 120ms ease, box-shadow 120ms ease;
+  position: relative;
+}
+
+.rock-tile.selected {
+  transform: scale(1.05);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.35);
+}
+
+.match-board.channeling {
+  box-shadow: 0 0 0 4px rgba(255, 168, 76, 0.35);
+  animation: channel-pulse 1.6s ease-in-out infinite alternate;
+}
+
+@keyframes channel-pulse {
+  from {
+    filter: drop-shadow(0 0 6px rgba(255, 168, 76, 0.45));
+  }
+  to {
+    filter: drop-shadow(0 0 14px rgba(255, 209, 140, 0.75));
+  }
+}
+
+.rock-sedimentary {
+  background: linear-gradient(145deg, #9c8368, #d8c09c);
+}
+
+.rock-igneous {
+  background: linear-gradient(145deg, #4f2a2d, #b64233);
+}
+
+.rock-metamorphic {
+  background: linear-gradient(145deg, #23363f, #5a9ea6);
+}
+
+.rock-crystal {
+  background: linear-gradient(145deg, #3f2f6d, #9575cd);
+}
+
+.rock-empowered {
+  position: relative;
+  box-shadow: 0 0 0 2px rgba(255, 239, 179, 0.7);
+}
+
+.rock-empowered::after {
+  content: "";
+  position: absolute;
+  inset: 4px;
+  border-radius: 8px;
+  border: 2px solid rgba(255, 239, 179, 0.9);
+  box-shadow: 0 0 12px rgba(255, 239, 179, 0.8);
+}
+
+.rock-tile.state-volatile::after,
+.rock-tile.state-stasis::after,
+.rock-tile.state-cascade::after,
+.rock-tile.state-amplified::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  font-size: 0.75rem;
+}
+
+.rock-tile.state-volatile::after {
+  content: "✴";
+  color: #ff7043;
+}
+
+.rock-tile.state-stasis::after {
+  content: "⛓";
+  color: #cbd5f5;
+}
+
+.rock-tile.state-cascade::after {
+  content: "∞";
+  color: #4dd0e1;
+}
+
+.rock-tile.state-amplified::after {
+  content: "✧";
+  color: #b39ddb;
+}
+
+.transform-toolbar {
+  background: rgba(16, 24, 33, 0.85);
+  border-radius: 12px;
+  padding: 0.75rem;
+  text-align: center;
+  border: 1px solid rgba(155, 180, 210, 0.25);
+}
+
+.tetramino-wrapper {
+  display: grid;
+  grid-template-columns: 1fr minmax(180px, 200px);
+  gap: 1.25rem;
+}
+
+.tetramino-board {
+  display: grid;
+  grid-template-columns: repeat(10, 28px);
+  grid-template-rows: repeat(20, 28px);
+  background: rgba(8, 13, 19, 0.9);
+  gap: 2px;
+  padding: 6px;
+  border-radius: 12px;
+  border: 1px solid rgba(76, 139, 213, 0.25);
+}
+
+.tetra-cell {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: rgba(33, 48, 66, 0.65);
+  transition: background 120ms ease;
+}
+
+.tetra-cell.filled-earth {
+  background: linear-gradient(140deg, #375628, #8bb974);
+}
+
+.tetra-cell.filled-water {
+  background: linear-gradient(140deg, #1f4c8f, #64b5f6);
+}
+
+.tetra-cell.filled-fire {
+  background: linear-gradient(140deg, #7b1f1f, #ef5350);
+}
+
+.tetra-cell.filled-crystal {
+  background: linear-gradient(140deg, #512da8, #b39ddb);
+}
+
+.queue-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+#piece-queue {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.queue-piece {
+  display: grid;
+  grid-template-columns: repeat(4, 12px);
+  grid-auto-rows: 12px;
+  gap: 2px;
+  justify-content: start;
+}
+
+.queue-piece div {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+}
+
+.meter-group {
+  display: grid;
+  gap: 0.4rem;
+}
+
+progress {
+  width: 100%;
+  height: 12px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(27, 40, 54, 0.8);
+}
+
+progress::-webkit-progress-bar {
+  background: rgba(27, 40, 54, 0.8);
+}
+
+progress::-webkit-progress-value {
+  background: linear-gradient(120deg, #34d399, #3b82f6);
+}
+
+.flow-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 42px);
+  grid-template-rows: repeat(6, 42px);
+  gap: 6px;
+  justify-content: center;
+  background: rgba(7, 12, 18, 0.85);
+  border-radius: 16px;
+  padding: 0.75rem;
+  border: 1px solid rgba(58, 102, 167, 0.25);
+}
+
+.flow-node {
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(32, 48, 68, 0.75);
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.flow-node.well {
+  background: linear-gradient(130deg, #2c5282, #63b3ed);
+  color: #0b1016;
+}
+
+.flow-node.conduit {
+  background: linear-gradient(130deg, #764ba2, #667eea);
+}
+
+.flow-node.bridge {
+  background: linear-gradient(130deg, #2d6a4f, #95d5b2);
+}
+
+.flow-node.bridge.locked {
+  background: linear-gradient(130deg, #5b3a1a, #d9a441);
+  color: #1f1407;
+  border: 2px solid rgba(255, 201, 71, 0.75);
+}
+
+.flow-node.route-selected {
+  transform: translateY(-2px);
+  box-shadow: 0 0 0 3px rgba(86, 204, 242, 0.35);
+}
+
+.event-log {
+  max-height: 150px;
+  overflow-y: auto;
+  border-radius: 12px;
+  background: rgba(11, 17, 24, 0.9);
+  padding: 0.75rem;
+  font-size: 0.85rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.event-log p {
+  margin: 0;
+  color: #9bb4d2;
+}
+
+@media (max-width: 960px) {
+  .tetramino-wrapper {
+    grid-template-columns: 1fr;
+  }
+}

--- a/madia.new/public/secret/argumentum/argumentum.js
+++ b/madia.new/public/secret/argumentum/argumentum.js
@@ -1,0 +1,1211 @@
+const BOARD_SIZE = 6;
+const TETRA_WIDTH = 10;
+const TETRA_HEIGHT = 20;
+const TRANSFORM_COST = { earth: 20, water: 30 };
+const SHIFT_THRESHOLD = 100;
+const BRIDGE_GRID_SIZE = 6;
+
+const stateRegistry = {
+  normal: { label: "Stable", className: "" },
+  volatile: { label: "Volcanic", className: "state-volatile" },
+  stasis: { label: "Geolocked", className: "state-stasis" },
+  cascade: { label: "Flux", className: "state-cascade" },
+  amplified: { label: "Prismatic", className: "state-amplified" }
+};
+
+const rockTypes = [
+  { id: "sedimentary", label: "Se", meter: "earth" },
+  { id: "igneous", label: "Ig", meter: "fire" },
+  { id: "metamorphic", label: "Me", meter: "water" },
+  { id: "crystal", label: "Cr", meter: "shift" }
+];
+
+const infusionMappings = {
+  sedimentary: {
+    state: "volatile",
+    message: "Magma surge stored. Ignite a rock to trigger a volcanic blast."
+  },
+  igneous: {
+    state: "stasis",
+    message: "Basalt braces gathered. Channel into a rock to geolock the trails."
+  },
+  metamorphic: {
+    state: "cascade",
+    message: "Metamorphic flux ready. Infuse a rock to reshape the crucible."
+  },
+  crystal: {
+    state: "amplified",
+    message: "Prismatic resonance sealed. Empower a rock to amplify combos."
+  }
+};
+
+const pieceDefinitions = {
+  sedimentary: {
+    colorClass: "filled-earth",
+    rotations: [
+      [
+        [0, 1, 0, 0],
+        [0, 1, 0, 0],
+        [0, 1, 1, 0],
+        [0, 0, 0, 0]
+      ],
+      [
+        [0, 0, 0, 0],
+        [0, 0, 1, 1],
+        [0, 1, 1, 0],
+        [0, 0, 0, 0]
+      ]
+    ]
+  },
+  igneous: {
+    colorClass: "filled-fire",
+    rotations: [
+      [
+        [0, 0, 0, 0],
+        [1, 1, 1, 0],
+        [0, 1, 0, 0],
+        [0, 0, 0, 0]
+      ]
+    ]
+  },
+  metamorphic: {
+    colorClass: "filled-water",
+    rotations: [
+      [
+        [0, 0, 0, 0],
+        [0, 1, 1, 0],
+        [1, 1, 0, 0],
+        [0, 0, 0, 0]
+      ],
+      [
+        [1, 0, 0, 0],
+        [1, 1, 0, 0],
+        [0, 1, 0, 0],
+        [0, 0, 0, 0]
+      ]
+    ]
+  },
+  crystal: {
+    colorClass: "filled-crystal",
+    rotations: [
+      [
+        [0, 1, 1, 0],
+        [0, 1, 1, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0]
+      ]
+    ]
+  }
+};
+
+const meters = {
+  earth: document.getElementById("earth-meter"),
+  water: document.getElementById("water-meter"),
+  fire: document.getElementById("fire-meter"),
+  shift: document.getElementById("shift-meter")
+};
+
+const matchBoardEl = document.getElementById("match-board");
+const pieceQueueEl = document.getElementById("piece-queue");
+const tetraminoBoardEl = document.getElementById("tetramino-board");
+const flowGridEl = document.getElementById("flow-grid");
+const eventLogEl = document.getElementById("event-log");
+const chargeTransformBtn = document.getElementById("charge-transform");
+const cancelTransformBtn = document.getElementById("cancel-transform");
+const transformToolbar = document.getElementById("transform-toolbar");
+const shiftBoardBtn = document.getElementById("shift-board");
+const routeToggleBtn = document.getElementById("route-toggle");
+
+let matchBoard = [];
+let matchNodes = [];
+let selectedTile = null;
+let transformMode = false;
+let resourceMeterState = {
+  earth: 0,
+  water: 0,
+  fire: 0,
+  shift: 0
+};
+
+let tetraBoard = createMatrix(TETRA_HEIGHT, TETRA_WIDTH, null);
+let pieceQueue = [];
+let activePiece = null;
+let dropIntervalId = null;
+let dropDelay = 900;
+let bridgeQueue = [];
+let routeMode = false;
+let routeSelection = [];
+let shiftOrientation = 0;
+let infusionQueue = [];
+let infusionMode = false;
+let currentInfusion = null;
+
+const flowNodes = initializeFlowNodes();
+
+function createMatrix(rows, cols, value) {
+  return Array.from({ length: rows }, () => Array.from({ length: cols }, () => value));
+}
+
+function capitalize(text) {
+  if (!text) {
+    return "";
+  }
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+function initializeMatchBoard() {
+  matchBoard = createMatrix(BOARD_SIZE, BOARD_SIZE, null);
+  for (let y = 0; y < BOARD_SIZE; y += 1) {
+    for (let x = 0; x < BOARD_SIZE; x += 1) {
+      let tile;
+      do {
+        tile = createRandomTile();
+        matchBoard[y][x] = tile;
+      } while (createsMatch(x, y));
+    }
+  }
+  renderMatchBoard();
+}
+
+function createRandomTile() {
+  const base = rockTypes[Math.floor(Math.random() * rockTypes.length)];
+  return { ...base, empowered: false, state: "normal" };
+}
+
+function createsMatch(x, y) {
+  const tile = matchBoard[y][x];
+  const horizontal =
+    x >= 2 &&
+    matchBoard[y][x - 1]?.id === tile.id &&
+    matchBoard[y][x - 2]?.id === tile.id;
+  const vertical =
+    y >= 2 &&
+    matchBoard[y - 1]?.[x]?.id === tile.id &&
+    matchBoard[y - 2]?.[x]?.id === tile.id;
+  return horizontal || vertical;
+}
+
+function renderMatchBoard() {
+  matchBoardEl.innerHTML = "";
+  matchNodes = [];
+  matchBoard.forEach((row, y) => {
+    row.forEach((tile, x) => {
+      const tileEl = document.createElement("button");
+      tileEl.type = "button";
+      tileEl.className = `rock-tile rock-${tile.id}`;
+      if (tile.empowered) {
+        tileEl.classList.add("rock-empowered");
+      }
+      const stateInfo = stateRegistry[tile.state] ?? stateRegistry.normal;
+      if (stateInfo.className) {
+        tileEl.classList.add(stateInfo.className);
+      }
+      tileEl.dataset.state = tile.state;
+      tileEl.setAttribute(
+        "aria-label",
+        `${tile.id} rock (${stateInfo.label}${tile.empowered ? ", empowered" : ""})`
+      );
+      tileEl.textContent = tile.label;
+      tileEl.setAttribute("data-x", x);
+      tileEl.setAttribute("data-y", y);
+      tileEl.addEventListener("click", () => onTileClick(x, y));
+      matchBoardEl.append(tileEl);
+      matchNodes.push(tileEl);
+    });
+  });
+}
+
+function onTileClick(x, y) {
+  if (infusionMode) {
+    applyInfusionToTile(x, y);
+    return;
+  }
+  if (transformMode) {
+    applyTransformation(x, y);
+    return;
+  }
+
+  if (!selectedTile) {
+    selectedTile = { x, y };
+    getTileElement(x, y).classList.add("selected");
+    return;
+  }
+
+  if (selectedTile.x === x && selectedTile.y === y) {
+    getTileElement(x, y).classList.remove("selected");
+    selectedTile = null;
+    return;
+  }
+
+  if (!areAdjacent(selectedTile, { x, y })) {
+    getTileElement(selectedTile.x, selectedTile.y).classList.remove("selected");
+    selectedTile = { x, y };
+    getTileElement(x, y).classList.add("selected");
+    return;
+  }
+
+  swapTiles(selectedTile, { x, y });
+  const matches = findAllMatches();
+  if (matches.length === 0) {
+    swapTiles(selectedTile, { x, y });
+    getTileElement(selectedTile.x, selectedTile.y).classList.remove("selected");
+    selectedTile = null;
+    return;
+  }
+
+  resolveMatches(matches);
+  selectedTile = null;
+}
+
+function getTileElement(x, y) {
+  return matchNodes[y * BOARD_SIZE + x];
+}
+
+function areAdjacent(a, b) {
+  return Math.abs(a.x - b.x) + Math.abs(a.y - b.y) === 1;
+}
+
+function swapTiles(a, b) {
+  const tmp = matchBoard[a.y][a.x];
+  matchBoard[a.y][a.x] = matchBoard[b.y][b.x];
+  matchBoard[b.y][b.x] = tmp;
+  renderMatchBoard();
+}
+
+function findAllMatches() {
+  const matches = [];
+  const seen = new Set();
+  for (let y = 0; y < BOARD_SIZE; y += 1) {
+    let streak = 1;
+    for (let x = 1; x < BOARD_SIZE; x += 1) {
+      if (matchBoard[y][x].id === matchBoard[y][x - 1].id) {
+        streak += 1;
+      } else {
+        if (streak >= 3) {
+          for (let k = 0; k < streak; k += 1) {
+            const key = `${x - 1 - k}-${y}`;
+            if (!seen.has(key)) {
+              matches.push({ x: x - 1 - k, y, tile: matchBoard[y][x - 1 - k] });
+              seen.add(key);
+            }
+          }
+        }
+        streak = 1;
+      }
+    }
+    if (streak >= 3) {
+      for (let k = 0; k < streak; k += 1) {
+        const key = `${BOARD_SIZE - 1 - k}-${y}`;
+        if (!seen.has(key)) {
+          matches.push({ x: BOARD_SIZE - 1 - k, y, tile: matchBoard[y][BOARD_SIZE - 1 - k] });
+          seen.add(key);
+        }
+      }
+    }
+  }
+
+  for (let x = 0; x < BOARD_SIZE; x += 1) {
+    let streak = 1;
+    for (let y = 1; y < BOARD_SIZE; y += 1) {
+      if (matchBoard[y][x].id === matchBoard[y - 1][x].id) {
+        streak += 1;
+      } else {
+        if (streak >= 3) {
+          for (let k = 0; k < streak; k += 1) {
+            const key = `${x}-${y - 1 - k}`;
+            if (!seen.has(key)) {
+              matches.push({ x, y: y - 1 - k, tile: matchBoard[y - 1 - k][x] });
+              seen.add(key);
+            }
+          }
+        }
+        streak = 1;
+      }
+    }
+    if (streak >= 3) {
+      for (let k = 0; k < streak; k += 1) {
+        const key = `${x}-${BOARD_SIZE - 1 - k}`;
+        if (!seen.has(key)) {
+          matches.push({ x, y: BOARD_SIZE - 1 - k, tile: matchBoard[BOARD_SIZE - 1 - k][x] });
+          seen.add(key);
+        }
+      }
+    }
+  }
+  return matches;
+}
+
+function resolveMatches(matches) {
+  if (matches.length === 0) {
+    return;
+  }
+  const removal = new Map();
+  const matchSummary = new Map();
+  const cascadeSources = [];
+  let stasisTriggered = false;
+  let amplifiedCount = 0;
+
+  const queueRemoval = (x, y) => {
+    if (x < 0 || x >= BOARD_SIZE || y < 0 || y >= BOARD_SIZE) {
+      return;
+    }
+    const key = `${x}-${y}`;
+    if (removal.has(key)) {
+      return;
+    }
+    const tile = matchBoard[y][x];
+    if (!tile) {
+      return;
+    }
+    removal.set(key, { x, y, tile });
+  };
+
+  matches.forEach(({ x, y, tile }) => {
+    queueRemoval(x, y);
+    if (tile.state === "volatile") {
+      for (let dx = -1; dx <= 1; dx += 1) {
+        for (let dy = -1; dy <= 1; dy += 1) {
+          if (dx === 0 && dy === 0) {
+            continue;
+          }
+          queueRemoval(x + dx, y + dy);
+        }
+      }
+    }
+    if (tile.state === "stasis") {
+      stasisTriggered = true;
+    }
+    if (tile.state === "cascade") {
+      cascadeSources.push(tile.id);
+    }
+    if (tile.state === "amplified") {
+      amplifiedCount += 1;
+    }
+  });
+
+  removal.forEach(({ x, y, tile }) => {
+    matchBoard[y][x] = null;
+    const data = matchSummary.get(tile.id) ?? { count: 0, empowered: 0, meter: tile.meter };
+    data.count += 1;
+    if (tile.empowered) {
+      data.empowered += 1;
+    }
+    matchSummary.set(tile.id, data);
+  });
+
+  collapseColumns();
+  refillColumns();
+  renderMatchBoard();
+
+  matchSummary.forEach((data, id) => {
+    logEvent(`Matched ${data.count} ${id} rocks${data.empowered ? " with empowered resonance" : ""}.`);
+    const definition = getRockDefinition(id);
+    addResources(definition.meter, data.count * 8 + data.empowered * 12);
+    enqueueTetramino(id, data.count, data.empowered);
+  });
+
+  if (stasisTriggered) {
+    lockBridgedRoutes();
+  }
+  if (cascadeSources.length > 0) {
+    applyCascade(cascadeSources);
+  }
+  if (amplifiedCount > 0) {
+    grantAmplifiedRewards(amplifiedCount);
+  }
+}
+
+function collapseColumns() {
+  for (let x = 0; x < BOARD_SIZE; x += 1) {
+    const column = [];
+    for (let y = 0; y < BOARD_SIZE; y += 1) {
+      if (matchBoard[y][x]) {
+        column.push(matchBoard[y][x]);
+      }
+    }
+    for (let y = BOARD_SIZE - 1; y >= 0; y -= 1) {
+      matchBoard[y][x] = column.pop() ?? null;
+    }
+  }
+}
+
+function refillColumns() {
+  for (let y = 0; y < BOARD_SIZE; y += 1) {
+    for (let x = 0; x < BOARD_SIZE; x += 1) {
+      if (!matchBoard[y][x]) {
+        matchBoard[y][x] = createRandomTile();
+      }
+    }
+  }
+}
+
+function getRockDefinition(id) {
+  return rockTypes.find((rock) => rock.id === id) ?? rockTypes[0];
+}
+
+function lockBridgedRoutes() {
+  let lockedAny = false;
+  flowNodes.forEach((node) => {
+    if (node.bridged && !node.locked) {
+      node.locked = true;
+      lockedAny = true;
+    }
+  });
+  if (lockedAny) {
+    renderFlowGrid();
+    logEvent("Geolocked bridges now persist across shifts.");
+  }
+}
+
+function applyCascade(sourceTypes) {
+  const available = [];
+  for (let y = 0; y < BOARD_SIZE; y += 1) {
+    for (let x = 0; x < BOARD_SIZE; x += 1) {
+      if (matchBoard[y][x]) {
+        available.push({ x, y });
+      }
+    }
+  }
+  if (available.length === 0) {
+    return;
+  }
+  const transformed = Math.min(sourceTypes.length, available.length);
+  for (let i = 0; i < transformed; i += 1) {
+    const index = Math.floor(Math.random() * available.length);
+    const [{ x, y }] = available.splice(index, 1);
+    const definition = getRockDefinition(sourceTypes[i]);
+    const tile = matchBoard[y][x];
+    matchBoard[y][x] = {
+      ...definition,
+      empowered: tile.empowered,
+      state: "normal"
+    };
+  }
+  renderMatchBoard();
+  logEvent(
+    `Metamorphic flux reshaped ${transformed} rock${transformed > 1 ? "s" : ""} within the crucible.`
+  );
+}
+
+function grantAmplifiedRewards(count) {
+  addResources("shift", Math.min(30, count * 10));
+  for (let i = 0; i < count; i += 1) {
+    enqueueBridgeEntry("crystal", 0);
+  }
+  if (count > 0) {
+    routeMode = true;
+    logEvent(`Prismatic resonance forged ${count} lattice spark${count > 1 ? "s" : ""}.`);
+    updateRouteButton();
+    renderFlowGrid();
+  }
+}
+
+function enqueueTetramino(id, count, empoweredCount) {
+  const definition = pieceDefinitions[id];
+  if (!definition) {
+    return;
+  }
+  const bonusPieces = Math.floor((count + empoweredCount) / 4);
+  const totalPieces = 1 + bonusPieces;
+  for (let i = 0; i < totalPieces; i += 1) {
+    pieceQueue.push({ id, rotation: 0 });
+  }
+  updateQueueDisplay();
+  if (!activePiece) {
+    spawnNextPiece();
+  }
+}
+
+function updateQueueDisplay() {
+  pieceQueueEl.innerHTML = "";
+  pieceQueue.forEach((piece) => {
+    const wrapper = document.createElement("div");
+    wrapper.className = "queue-piece";
+    const matrix = pieceDefinitions[piece.id].rotations[0];
+    matrix.forEach((row) => {
+      row.forEach((value) => {
+        const cell = document.createElement("div");
+        if (value) {
+          cell.style.background = getQueueColor(piece.id);
+        } else {
+          cell.style.background = "transparent";
+        }
+        wrapper.append(cell);
+      });
+    });
+    pieceQueueEl.append(wrapper);
+  });
+}
+
+function getQueueColor(id) {
+  switch (id) {
+    case "sedimentary":
+      return "#8bb974";
+    case "igneous":
+      return "#ef5350";
+    case "metamorphic":
+      return "#64b5f6";
+    case "crystal":
+      return "#b39ddb";
+    default:
+      return "#90a4ae";
+  }
+}
+
+function spawnNextPiece() {
+  if (pieceQueue.length === 0) {
+    return;
+  }
+  const next = pieceQueue.shift();
+  activePiece = {
+    ...next,
+    x: 3,
+    y: 0,
+    rotation: next.rotation ?? 0
+  };
+  if (collides(activePiece, 0, 0)) {
+    logEvent("The reactor is overwhelmed. Network flow resets.");
+    resetTetraminoBoard();
+  }
+  updateQueueDisplay();
+  renderTetraminoBoard();
+}
+
+function collides(piece, offsetX, offsetY, rotationIndex = piece.rotation) {
+  const matrix = pieceDefinitions[piece.id].rotations[rotationIndex];
+  for (let y = 0; y < matrix.length; y += 1) {
+    for (let x = 0; x < matrix[y].length; x += 1) {
+      if (!matrix[y][x]) {
+        continue;
+      }
+      const boardX = piece.x + x + offsetX;
+      const boardY = piece.y + y + offsetY;
+      if (boardX < 0 || boardX >= TETRA_WIDTH || boardY >= TETRA_HEIGHT) {
+        return true;
+      }
+      if (boardY >= 0 && tetraBoard[boardY][boardX]) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function placePiece() {
+  if (!activePiece) {
+    return;
+  }
+  const placedId = activePiece.id;
+  const placedRotation = activePiece.rotation;
+  const matrix = pieceDefinitions[activePiece.id].rotations[placedRotation];
+  for (let y = 0; y < matrix.length; y += 1) {
+    for (let x = 0; x < matrix[y].length; x += 1) {
+      if (!matrix[y][x]) {
+        continue;
+      }
+      const boardX = activePiece.x + x;
+      const boardY = activePiece.y + y;
+      if (boardY >= 0 && boardY < TETRA_HEIGHT) {
+        tetraBoard[boardY][boardX] = {
+          id: activePiece.id,
+          className: pieceDefinitions[activePiece.id].colorClass
+        };
+      }
+    }
+  }
+  activePiece = null;
+  const cleared = clearLines();
+  if (cleared > 0) {
+    handleLineClear(cleared, placedId, placedRotation);
+  }
+  spawnNextPiece();
+}
+
+function clearLines() {
+  let cleared = 0;
+  for (let y = TETRA_HEIGHT - 1; y >= 0; y -= 1) {
+    if (tetraBoard[y].every((cell) => cell)) {
+      tetraBoard.splice(y, 1);
+      tetraBoard.unshift(Array.from({ length: TETRA_WIDTH }, () => null));
+      cleared += 1;
+      y += 1;
+    }
+  }
+  if (cleared > 0) {
+    renderTetraminoBoard();
+  }
+  return cleared;
+}
+
+function handleLineClear(count, id, rotation) {
+  const awardType = id ?? "sedimentary";
+  logEvent(
+    `Cleared ${count} reactor line${count > 1 ? "s" : ""}. ${
+      count === 1 ? "A" : count
+    } ${awardType} bridge schematic stored.`
+  );
+  addResources(mapPieceToMeter(awardType), 14 * count);
+  for (let i = 0; i < count; i += 1) {
+    enqueueBridgeEntry(awardType, rotation);
+  }
+  extendFlowWithBridges(awardType, count);
+}
+
+function mapPieceToMeter(id) {
+  switch (id) {
+    case "igneous":
+      return "fire";
+    case "metamorphic":
+      return "water";
+    case "crystal":
+      return "shift";
+    default:
+      return "earth";
+  }
+}
+
+function resetTetraminoBoard() {
+  tetraBoard = createMatrix(TETRA_HEIGHT, TETRA_WIDTH, null);
+  pieceQueue = [];
+  activePiece = null;
+  renderTetraminoBoard();
+  updateQueueDisplay();
+}
+
+function renderTetraminoBoard() {
+  tetraminoBoardEl.innerHTML = "";
+  for (let y = 0; y < TETRA_HEIGHT; y += 1) {
+    for (let x = 0; x < TETRA_WIDTH; x += 1) {
+      const cell = document.createElement("div");
+      cell.className = "tetra-cell";
+      const value = tetraBoard[y][x];
+      if (value) {
+        cell.classList.add(value.className);
+      }
+      if (activePiece) {
+        const matrix = pieceDefinitions[activePiece.id].rotations[activePiece.rotation];
+        const relX = x - activePiece.x;
+        const relY = y - activePiece.y;
+        if (
+          relX >= 0 &&
+          relX < matrix[0].length &&
+          relY >= 0 &&
+          relY < matrix.length &&
+          matrix[relY][relX]
+        ) {
+          cell.classList.add(pieceDefinitions[activePiece.id].colorClass);
+        }
+      }
+      tetraminoBoardEl.append(cell);
+    }
+  }
+}
+
+function dropStep() {
+  if (!activePiece) {
+    spawnNextPiece();
+    return;
+  }
+  if (!collides(activePiece, 0, 1)) {
+    activePiece.y += 1;
+  } else {
+    placePiece();
+  }
+  renderTetraminoBoard();
+}
+
+function rotatePiece() {
+  if (!activePiece) {
+    return;
+  }
+  const nextRotation = (activePiece.rotation + 1) % pieceDefinitions[activePiece.id].rotations.length;
+  if (!collides(activePiece, 0, 0, nextRotation)) {
+    activePiece.rotation = nextRotation;
+    renderTetraminoBoard();
+  }
+}
+
+function movePiece(offset) {
+  if (!activePiece) {
+    return;
+  }
+  if (!collides(activePiece, offset, 0)) {
+    activePiece.x += offset;
+    renderTetraminoBoard();
+  }
+}
+
+function softDrop() {
+  if (!activePiece) {
+    return;
+  }
+  if (!collides(activePiece, 0, 1)) {
+    activePiece.y += 1;
+    renderTetraminoBoard();
+  }
+}
+
+function applyTransformation(x, y) {
+  const tile = matchBoard[y][x];
+  if (tile.empowered) {
+    logEvent("This rock already carries a charged state.");
+    return;
+  }
+  if (resourceMeterState.earth < TRANSFORM_COST.earth || resourceMeterState.water < TRANSFORM_COST.water) {
+    logEvent("Not enough routed energy to transmute.");
+    return;
+  }
+  resourceMeterState.earth -= TRANSFORM_COST.earth;
+  resourceMeterState.water -= TRANSFORM_COST.water;
+  tile.empowered = true;
+  renderMatchBoard();
+  updateMeters();
+  exitTransformMode();
+  logEvent(`Empowered a ${tile.id} rock via flow resonance.`);
+  addResources("shift", 16);
+}
+
+function enterTransformMode() {
+  if (transformMode) {
+    return;
+  }
+  if (resourceMeterState.earth < TRANSFORM_COST.earth || resourceMeterState.water < TRANSFORM_COST.water) {
+    logEvent("Channel requires earth and water energy reserves.");
+    return;
+  }
+  transformMode = true;
+  transformToolbar.hidden = false;
+  chargeTransformBtn.disabled = true;
+}
+
+function exitTransformMode() {
+  transformMode = false;
+  transformToolbar.hidden = true;
+  chargeTransformBtn.disabled = false;
+}
+
+function queueInfusion(sourceId) {
+  const infusion = createInfusion(sourceId);
+  infusionQueue.push(infusion);
+  if (!infusionMode) {
+    currentInfusion = infusionQueue.shift();
+    enterInfusionMode();
+  } else {
+    logEvent(`Stored an additional ${infusion.label.toLowerCase()} infusion for later.`);
+  }
+}
+
+function createInfusion(sourceId) {
+  const mapping = infusionMappings[sourceId] ?? infusionMappings.sedimentary;
+  const state = mapping?.state ?? "volatile";
+  const label = stateRegistry[state]?.label ?? "Infusion";
+  return {
+    state,
+    label,
+    message: mapping?.message ?? "Stored energy thrums. Select a rock to imbue.",
+    source: sourceId
+  };
+}
+
+function enterInfusionMode() {
+  if (!currentInfusion) {
+    return;
+  }
+  if (transformMode) {
+    exitTransformMode();
+  }
+  infusionMode = true;
+  matchBoardEl.classList.add("channeling");
+  chargeTransformBtn.disabled = true;
+  logEvent(currentInfusion.message);
+}
+
+function advanceInfusionQueue() {
+  if (infusionQueue.length > 0) {
+    currentInfusion = infusionQueue.shift();
+    logEvent(currentInfusion.message);
+    return;
+  }
+  exitInfusionMode();
+}
+
+function exitInfusionMode() {
+  infusionMode = false;
+  currentInfusion = null;
+  matchBoardEl.classList.remove("channeling");
+  chargeTransformBtn.disabled = false;
+}
+
+function applyInfusionToTile(x, y) {
+  if (!currentInfusion) {
+    return;
+  }
+  const tile = matchBoard[y][x];
+  if (!tile) {
+    return;
+  }
+  tile.state = currentInfusion.state;
+  if (tile.state === "amplified") {
+    tile.empowered = true;
+  }
+  renderMatchBoard();
+  const descriptor = stateRegistry[tile.state]?.label.toLowerCase() ?? "stored";
+  logEvent(`${capitalize(tile.id)} rock now resonates with ${descriptor} energy.`);
+  advanceInfusionQueue();
+}
+
+function addResources(type, amount) {
+  resourceMeterState[type] = Math.min(100, resourceMeterState[type] + amount);
+  updateMeters();
+  if (resourceMeterState.shift >= SHIFT_THRESHOLD) {
+    shiftBoardBtn.disabled = false;
+  }
+}
+
+function updateMeters() {
+  Object.entries(meters).forEach(([type, element]) => {
+    element.value = resourceMeterState[type];
+  });
+}
+
+function initializeFlowNodes() {
+  const nodes = [];
+  const wells = new Set([2, 7, 28]);
+  const conduits = new Set([9, 26, 33]);
+  for (let i = 0; i < 36; i += 1) {
+    let kind = "empty";
+    if (wells.has(i)) {
+      kind = "well";
+    }
+    if (conduits.has(i)) {
+      kind = "conduit";
+    }
+    nodes.push({ kind, bridged: false, bridgeType: null, locked: false });
+  }
+  return nodes;
+}
+
+function renderFlowGrid() {
+  flowGridEl.innerHTML = "";
+  flowNodes.forEach((node, index) => {
+    const cell = document.createElement("button");
+    cell.type = "button";
+    cell.className = "flow-node";
+    cell.dataset.bridgeType = node.bridgeType ?? "";
+    if (node.kind === "well") {
+      cell.classList.add("well");
+      cell.textContent = "W";
+    } else if (node.kind === "conduit") {
+      cell.classList.add("conduit");
+      cell.textContent = "C";
+    }
+    if (node.bridged) {
+      cell.classList.add("bridge");
+      cell.classList.toggle("locked", Boolean(node.locked));
+      if (!cell.textContent) {
+        cell.textContent = node.locked ? "⛓" : "B";
+      } else if (node.locked) {
+        cell.textContent = "⛓";
+      }
+    } else {
+      cell.classList.remove("locked");
+      if (node.kind !== "well" && node.kind !== "conduit") {
+        cell.textContent = "";
+      }
+    }
+    if (routeSelection.includes(index)) {
+      cell.classList.add("route-selected");
+    }
+    cell.addEventListener("click", () => onFlowNodeClick(index));
+    flowGridEl.append(cell);
+  });
+}
+
+function onFlowNodeClick(index) {
+  if (!routeMode) {
+    return;
+  }
+  let placed = false;
+  if (bridgeQueue.length > 0) {
+    placed = attemptPlaceBridge(index);
+    if (placed) {
+      return;
+    }
+  }
+  const node = flowNodes[index];
+  if (node.kind === "well" || node.kind === "conduit" || node.bridged) {
+    if (routeSelection.includes(index)) {
+      routeSelection = routeSelection.filter((value) => value !== index);
+    } else {
+      routeSelection.push(index);
+    }
+    renderFlowGrid();
+    return;
+  }
+  if (!placed && bridgeQueue.length === 0) {
+    logEvent("No forged bridges ready. Clear reactor lines to craft more.");
+  }
+}
+
+function attemptPlaceBridge(anchorIndex) {
+  if (bridgeQueue.length === 0) {
+    logEvent("No bridge schematics waiting in the forge.");
+    return false;
+  }
+  const entry = bridgeQueue[0];
+  const anchorRow = Math.floor(anchorIndex / BRIDGE_GRID_SIZE);
+  const anchorCol = anchorIndex % BRIDGE_GRID_SIZE;
+  const placements = [];
+  for (const offset of entry.pattern) {
+    const targetRow = anchorRow + offset.dy;
+    const targetCol = anchorCol + offset.dx;
+    if (
+      targetRow < 0 ||
+      targetRow >= BRIDGE_GRID_SIZE ||
+      targetCol < 0 ||
+      targetCol >= BRIDGE_GRID_SIZE
+    ) {
+      logEvent("Bridge schematic cannot fit at that anchor.");
+      return false;
+    }
+    const targetIndex = targetRow * BRIDGE_GRID_SIZE + targetCol;
+    const targetNode = flowNodes[targetIndex];
+    if (!targetNode) {
+      logEvent("Bridge schematic failed to align with the grid.");
+      return false;
+    }
+    if (targetNode.locked && !targetNode.bridged) {
+      logEvent("Locked lattice nodes refuse new connections.");
+      return false;
+    }
+    placements.push(targetIndex);
+  }
+  bridgeQueue.shift();
+  placements.forEach((targetIndex) => {
+    const targetNode = flowNodes[targetIndex];
+    targetNode.bridged = true;
+    targetNode.bridgeType = entry.id;
+  });
+  routeSelection = Array.from(new Set([...routeSelection, ...placements]));
+  logEvent(
+    `Installed a ${entry.id} bridge linking ${placements.length} node${
+      placements.length > 1 ? "s" : ""
+    }.`
+  );
+  updateRouteButton();
+  renderFlowGrid();
+  evaluateNetwork(entry.id);
+  return true;
+}
+
+function enqueueBridgeEntry(id, rotation = 0) {
+  const pattern = getBridgePattern(id, rotation);
+  if (!pattern || pattern.length === 0) {
+    return;
+  }
+  bridgeQueue.push({ id, rotation, pattern });
+}
+
+function getBridgePattern(id, rotation = 0) {
+  const definition = pieceDefinitions[id];
+  if (!definition) {
+    return null;
+  }
+  const rotations = definition.rotations;
+  const matrix = rotations[rotation % rotations.length];
+  if (!matrix) {
+    return null;
+  }
+  return normalizePattern(matrix);
+}
+
+function normalizePattern(matrix) {
+  const coordinates = [];
+  let minX = Infinity;
+  let minY = Infinity;
+  matrix.forEach((row, y) => {
+    row.forEach((value, x) => {
+      if (!value) {
+        return;
+      }
+      coordinates.push({ x, y });
+      if (x < minX) {
+        minX = x;
+      }
+      if (y < minY) {
+        minY = y;
+      }
+    });
+  });
+  return coordinates.map(({ x, y }) => ({ dx: x - minX, dy: y - minY }));
+}
+
+function extendFlowWithBridges(id, _count) {
+  routeMode = true;
+  updateRouteButton();
+  renderFlowGrid();
+  evaluateNetwork(id);
+}
+
+function updateRouteButton() {
+  const queued = bridgeQueue.length;
+  const next = bridgeQueue[0]?.id;
+  const suffix = next ? ` • ${next}` : "";
+  routeToggleBtn.textContent = routeMode
+    ? `Routing Active (${queued}${suffix})`
+    : `Plan Routes (${queued})`;
+}
+
+function toggleRouteMode() {
+  routeMode = !routeMode;
+  if (!routeMode) {
+    routeSelection = [];
+  }
+  updateRouteButton();
+  renderFlowGrid();
+}
+
+function evaluateNetwork(idHint) {
+  const adjacency = (index) => {
+    const row = Math.floor(index / 6);
+    const col = index % 6;
+    const neighbors = [];
+    const offsets = [
+      [1, 0],
+      [-1, 0],
+      [0, 1],
+      [0, -1]
+    ];
+    offsets.forEach(([dx, dy]) => {
+      const newRow = row + dy;
+      const newCol = col + dx;
+      if (newRow >= 0 && newRow < 6 && newCol >= 0 && newCol < 6) {
+        neighbors.push(newRow * 6 + newCol);
+      }
+    });
+    return neighbors;
+  };
+
+  const wells = flowNodes
+    .map((node, index) => ({ node, index }))
+    .filter(({ node }) => node.kind === "well");
+  const conduits = flowNodes
+    .map((node, index) => ({ node, index }))
+    .filter(({ node }) => node.kind === "conduit");
+
+  const bridgedNodes = new Set(
+    flowNodes
+      .map((node, index) => (node.kind !== "empty" || node.bridged ? index : null))
+      .filter((value) => value !== null)
+  );
+
+  wells.forEach(({ index }) => {
+    const visited = new Set([index]);
+    const stack = [index];
+    while (stack.length) {
+      const current = stack.pop();
+      adjacency(current).forEach((neighbor) => {
+        if (!bridgedNodes.has(neighbor) || visited.has(neighbor)) {
+          return;
+        }
+        visited.add(neighbor);
+        stack.push(neighbor);
+      });
+    }
+    conduits.forEach(({ index: conduitIndex }) => {
+      if (visited.has(conduitIndex)) {
+        completeCircuit(idHint);
+      }
+    });
+  });
+}
+
+function completeCircuit(idHint) {
+  logEvent("Completed a flow circuit. Energy surges through the lattice!");
+  addResources(idHint ? mapPieceToMeter(idHint) : "earth", 20);
+  addResources("fire", 10);
+  queueInfusion(idHint ?? "sedimentary");
+}
+
+function logEvent(message) {
+  const entry = document.createElement("p");
+  entry.textContent = message;
+  eventLogEl.prepend(entry);
+  while (eventLogEl.children.length > 8) {
+    eventLogEl.removeChild(eventLogEl.lastChild);
+  }
+}
+
+function startDropLoop() {
+  if (dropIntervalId) {
+    window.clearInterval(dropIntervalId);
+  }
+  dropIntervalId = window.setInterval(dropStep, dropDelay);
+}
+
+function applyShiftActuation() {
+  if (resourceMeterState.shift < SHIFT_THRESHOLD) {
+    return;
+  }
+  resourceMeterState.shift = 0;
+  shiftOrientation = (shiftOrientation + 1) % 4;
+  dropDelay = Math.max(400, dropDelay - 80);
+  updateMeters();
+  shiftBoardBtn.disabled = true;
+  reorientNetwork();
+  logEvent("Actuated shift realigned the reactor relative to the flow grid.");
+}
+
+function reorientNetwork() {
+  const rotated = [];
+  for (let row = 0; row < 6; row += 1) {
+    for (let col = 0; col < 6; col += 1) {
+      const sourceRow = 5 - col;
+      const sourceCol = row;
+      rotated[row * 6 + col] = { ...flowNodes[sourceRow * 6 + sourceCol] };
+    }
+  }
+  for (let i = 0; i < flowNodes.length; i += 1) {
+    flowNodes[i] = rotated[i];
+  }
+  renderFlowGrid();
+}
+
+function onKeyDown(event) {
+  switch (event.key) {
+    case "ArrowLeft":
+      movePiece(-1);
+      break;
+    case "ArrowRight":
+      movePiece(1);
+      break;
+    case "ArrowDown":
+      softDrop();
+      break;
+    case "ArrowUp":
+    case "x":
+    case "X":
+      rotatePiece();
+      break;
+    case " ":
+      while (activePiece && !collides(activePiece, 0, 1)) {
+        activePiece.y += 1;
+      }
+      placePiece();
+      renderTetraminoBoard();
+      break;
+    default:
+      break;
+  }
+}
+
+chargeTransformBtn.addEventListener("click", enterTransformMode);
+cancelTransformBtn.addEventListener("click", exitTransformMode);
+shiftBoardBtn.addEventListener("click", applyShiftActuation);
+routeToggleBtn.addEventListener("click", toggleRouteMode);
+window.addEventListener("keydown", onKeyDown);
+
+initializeMatchBoard();
+renderTetraminoBoard();
+renderFlowGrid();
+startDropLoop();

--- a/madia.new/public/secret/argumentum/index.html
+++ b/madia.new/public/secret/argumentum/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Argumentum</title>
+    <link rel="stylesheet" href="argumentum.css" />
+  </head>
+  <body>
+    <header class="page-header">
+      <h1>Argumentum</h1>
+      <p class="subtitle">
+        Fuse elementary rocks, conjure tetramino storms, and weave resource trails across the
+        Argumentum lattice.
+      </p>
+    </header>
+
+    <main class="game-layout">
+      <section class="panel match-three" aria-label="Elemental Rock Crucible">
+        <div class="panel-header">
+          <h2>Rock Crucible</h2>
+          <button type="button" class="action-button" id="charge-transform">Channel Flow</button>
+        </div>
+        <p class="panel-help">
+          Swap adjacent rocks to make trios. Matched elements energize the forge and birth new
+          tetramino fragments. Completed circuits queue infusions—click a rock to imbue volcanic,
+          geolocked, flux, or prismatic states that reshape how matches resolve.
+        </p>
+        <div class="match-board" id="match-board" role="grid" aria-live="polite"></div>
+        <div class="transform-toolbar" id="transform-toolbar" hidden>
+          <p>Select a tile to transmute using stored flow energy.</p>
+          <button type="button" class="action-button" id="cancel-transform">Cancel</button>
+        </div>
+      </section>
+
+      <section class="panel tetramino" aria-label="Tetramino Reactor">
+        <div class="panel-header">
+          <h2>Tetramino Reactor</h2>
+          <button type="button" class="action-button" id="shift-board" disabled>
+            Actuated Shift
+          </button>
+        </div>
+        <p class="panel-help">
+          Falling tetramino shards forge bridge schematics whose shapes mirror the placed piece.
+          Clear lines to unleash wipeout combos and drop bespoke segments onto the flow lattice.
+        </p>
+        <div class="tetramino-wrapper">
+          <div class="tetramino-board" id="tetramino-board" aria-label="Falling pieces"></div>
+          <div class="queue-panel">
+            <h3>Forge Queue</h3>
+            <div id="piece-queue"></div>
+            <div class="meter-group">
+              <h3>Resource Meters</h3>
+              <label>Earth <progress id="earth-meter" max="100" value="0"></progress></label>
+              <label>Water <progress id="water-meter" max="100" value="0"></progress></label>
+              <label>Fire <progress id="fire-meter" max="100" value="0"></progress></label>
+              <label>Shift <progress id="shift-meter" max="100" value="0"></progress></label>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel flow-network" aria-label="Flow Trail Network">
+        <div class="panel-header">
+          <h2>Flow Trails</h2>
+          <button type="button" class="action-button" id="route-toggle">Plan Routes</button>
+        </div>
+        <p class="panel-help">
+          Use forged schematics to connect wells and conduits. Locked bridges persist through shifts,
+          and every completed circuit feeds the crucible with fresh state-changing energy.
+        </p>
+        <div class="flow-grid" id="flow-grid" aria-label="Resource network"></div>
+        <div class="event-log" id="event-log" aria-live="polite"></div>
+      </section>
+    </main>
+
+    <footer class="page-footer">
+      <p>
+        Tip: Forge a triple of matching rocks to spawn a tetramino. Clear a tetramino line to drop a
+        bridge segment and flood the network with resources.
+      </p>
+    </footer>
+
+    <script type="module" src="argumentum.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add circuit-driven infusions that imbue rocks with volcanic, geolocked, flux, and prismatic states that influence match resolution
- translate cleared tetramino pieces into shaped bridge schematics with placement validation, locking support, and updated flow routing UI cues
- refresh Argumentum copy and styling with channeling highlights, state markers, and locked-bridge visuals

## Testing
- node --check madia.new/public/secret/argumentum/argumentum.js

------
https://chatgpt.com/codex/tasks/task_e_68de96ba9f888328b458aa1fb1cacfb3