### PR TITLE
feat: expand argumentum circuits and routing

### DIFF
--- a/madia.new/public/secret/argumentum/argumentum.css
+++ b/madia.new/public/secret/argumentum/argumentum.css
@@ -99,11 +99,16 @@ body {
   cursor: pointer;
   border: 2px solid rgba(255, 255, 255, 0.12);
   transition: transform 120ms ease, box-shadow 120ms ease;
+  position: relative;
 }
 
 .rock-tile.selected {
   transform: scale(1.05);
   box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.35);
+}
+
+.rock-label {
+  z-index: 1;
 }
 
 .rock-sedimentary {
@@ -134,6 +139,108 @@ body {
   border-radius: 8px;
   border: 2px solid rgba(255, 239, 179, 0.9);
   box-shadow: 0 0 12px rgba(255, 239, 179, 0.8);
+}
+
+.rock-infused::before {
+  content: "";
+  position: absolute;
+  inset: 2px;
+  border-radius: 9px;
+  opacity: 0.65;
+  transition: opacity 150ms ease;
+}
+
+.rock-infused:hover::before {
+  opacity: 0.85;
+}
+
+.rock-volcanic::before {
+  background: radial-gradient(circle at top, rgba(255, 87, 34, 0.45), transparent 65%);
+}
+
+.rock-geolocked::before {
+  background: radial-gradient(circle at center, rgba(226, 232, 240, 0.5), transparent 70%);
+}
+
+.rock-flux::before {
+  background: radial-gradient(circle at top, rgba(30, 136, 229, 0.45), transparent 65%);
+}
+
+.rock-prismatic::before {
+  background: radial-gradient(circle at top, rgba(236, 72, 153, 0.45), transparent 65%);
+}
+
+.rock-state {
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  font-size: 0.55rem;
+  font-weight: 700;
+  padding: 2px 4px;
+  border-radius: 6px;
+  color: #0b1016;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.45);
+}
+
+.rock-state.volcanic {
+  background: linear-gradient(120deg, #ff7043, #ffcc80);
+}
+
+.rock-state.geolocked {
+  background: linear-gradient(120deg, #e2e8f0, #94a3b8);
+}
+
+.rock-state.flux {
+  background: linear-gradient(120deg, #60a5fa, #38bdf8);
+}
+
+.rock-state.prismatic {
+  background: linear-gradient(120deg, #c084fc, #f472b6);
+}
+
+.state-legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem 0.75rem;
+  font-size: 0.7rem;
+  color: #b7c6da;
+}
+
+.legend-label {
+  font-weight: 600;
+  color: #f2f5f8;
+}
+
+.legend-item {
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(56, 79, 108, 0.55);
+  color: inherit;
+  border: 1px solid rgba(138, 166, 200, 0.35);
+}
+
+.legend-item.volcanic {
+  border-color: rgba(255, 112, 67, 0.65);
+  color: #ffb74d;
+}
+
+.legend-item.geolocked {
+  border-color: rgba(226, 232, 240, 0.45);
+  color: #e2e8f0;
+}
+
+.legend-item.flux {
+  border-color: rgba(96, 165, 250, 0.55);
+  color: #60a5fa;
+}
+
+.legend-item.prismatic {
+  border-color: rgba(192, 132, 252, 0.6);
+  color: #c084fc;
 }
 
 .transform-toolbar {
@@ -272,6 +379,100 @@ progress::-webkit-progress-value {
 .flow-node.route-selected {
   transform: translateY(-2px);
   box-shadow: 0 0 0 3px rgba(86, 204, 242, 0.35);
+}
+
+.flow-node.locked {
+  position: relative;
+  background: linear-gradient(130deg, #1b4332, #81b29a);
+}
+
+.flow-node.locked::after {
+  content: "\1f512";
+  font-size: 0.8rem;
+}
+
+.flow-node.bridge-preview {
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.6);
+}
+
+.flow-node.bridge-invalid {
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.6);
+  animation: pulseInvalid 600ms ease;
+}
+
+@keyframes pulseInvalid {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(0.95);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.bridge-inventory {
+  display: grid;
+  gap: 0.75rem;
+  background: rgba(12, 20, 28, 0.6);
+  border-radius: 12px;
+  padding: 0.75rem;
+  border: 1px solid rgba(76, 139, 213, 0.25);
+}
+
+.bridge-inventory h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: #d8e4f7;
+}
+
+#bridge-inventory {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.schematic-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.6rem;
+  align-items: center;
+  background: rgba(17, 27, 38, 0.85);
+  border-radius: 10px;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgba(120, 180, 255, 0.2);
+}
+
+.schematic-card.active {
+  border-color: rgba(99, 179, 237, 0.6);
+  box-shadow: 0 0 12px rgba(99, 179, 237, 0.35);
+}
+
+.schematic-grid {
+  display: grid;
+  gap: 2px;
+}
+
+.schematic-grid div {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  background: rgba(41, 56, 73, 0.8);
+}
+
+.schematic-grid div.filled {
+  background: linear-gradient(130deg, #34d399, #2dd4bf);
+}
+
+.schematic-label {
+  font-size: 0.8rem;
+  color: #9bb4d2;
+}
+
+.inventory-hint {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #7fa0c0;
 }
 
 .event-log {

--- a/madia.new/public/secret/argumentum/index.html
+++ b/madia.new/public/secret/argumentum/index.html
@@ -10,7 +10,7 @@
     <header class="page-header">
       <h1>Argumentum</h1>
       <p class="subtitle">
-        Fuse elementary rocks, conjure tetramino storms, and weave resource trails across the
+        Channel elemental currents, ignite infused rock states, and weave radiant bridges across the
         Argumentum lattice.
       </p>
     </header>
@@ -22,10 +22,17 @@
           <button type="button" class="action-button" id="charge-transform">Channel Flow</button>
         </div>
         <p class="panel-help">
-          Swap adjacent rocks to make trios. Matched elements energize the forge and birth new
-          tetramino fragments. Charged flows can transmute a selected rock into an empowered state.
+          Swap adjacent rocks to make trios. Completed circuits infuse rocks with volcanic, geolocked,
+          flux, or prismatic states that reshape match outcomes and resource surges.
         </p>
         <div class="match-board" id="match-board" role="grid" aria-live="polite"></div>
+        <div class="state-legend">
+          <span class="legend-label">Infusions:</span>
+          <span class="legend-item volcanic">Volcanic</span>
+          <span class="legend-item geolocked">Geolocked</span>
+          <span class="legend-item flux">Flux</span>
+          <span class="legend-item prismatic">Prismatic</span>
+        </div>
         <div class="transform-toolbar" id="transform-toolbar" hidden>
           <p>Select a tile to transmute using stored flow energy.</p>
           <button type="button" class="action-button" id="cancel-transform">Cancel</button>
@@ -40,8 +47,8 @@
           </button>
         </div>
         <p class="panel-help">
-          Falling tetramino shards forge bridges into the flow network. Clear lines to unleash
-          wipeout combos and extend the trail grid.
+          Falling tetramino shards forge bridge schematics. Clear lines to draft shaped spans that can
+          be anchored into the trail grid.
         </p>
         <div class="tetramino-wrapper">
           <div class="tetramino-board" id="tetramino-board" aria-label="Falling pieces"></div>
@@ -65,10 +72,15 @@
           <button type="button" class="action-button" id="route-toggle">Plan Routes</button>
         </div>
         <p class="panel-help">
-          Use bridges dropped from the reactor to connect wells and conduits. Completed circuits feed
-          back into the crucible, empowering new rock states and amplifying combos.
+          Slot schematics into the lattice to connect wells and conduits. Locked bridges glow along the
+          trail, returning circuit energy that fuels new infusions.
         </p>
         <div class="flow-grid" id="flow-grid" aria-label="Resource network"></div>
+        <div class="bridge-inventory">
+          <h3>Bridge Schematics</h3>
+          <div id="bridge-inventory" aria-live="polite"></div>
+          <p id="bridge-hint" class="inventory-hint"></p>
+        </div>
         <div class="event-log" id="event-log" aria-live="polite"></div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- add circuit-driven volcanic, geolocked, flux, and prismatic infusions that alter match rewards
- translate cleared tetramino lines into placeable bridge schematics with locking and placement feedback
- refresh Argumentum copy and styling with infusion legend, schematic inventory, and locked-bridge visuals

## Testing
- no automated tests were run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68dead0f8de8832895c8bcaa94a91c4a