### PR TITLE
feat: add reactor HUD, scoring, and animations

### DIFF
--- a/madia.new/public/secret/argumentum/argumentum.css
+++ b/madia.new/public/secret/argumentum/argumentum.css
@@ -202,6 +202,7 @@ body {
   grid-auto-rows: 12px;
   gap: 2px;
   justify-content: start;
+  animation: queueSlide 240ms ease-out;
 }
 
 .queue-piece div {
@@ -221,6 +222,8 @@ progress {
   border-radius: 999px;
   overflow: hidden;
   background: rgba(27, 40, 54, 0.8);
+  appearance: none;
+  border: none;
 }
 
 progress::-webkit-progress-bar {
@@ -229,6 +232,109 @@ progress::-webkit-progress-bar {
 
 progress::-webkit-progress-value {
   background: linear-gradient(120deg, #34d399, #3b82f6);
+  transition: width 160ms ease;
+}
+
+progress::-moz-progress-bar {
+  background: linear-gradient(120deg, #34d399, #3b82f6);
+  transition: width 160ms ease;
+}
+
+.reactor-status {
+  display: grid;
+  gap: 0.75rem;
+  background: rgba(9, 16, 23, 0.9);
+  border-radius: 14px;
+  padding: 0.85rem;
+  border: 1px solid rgba(86, 129, 193, 0.25);
+}
+
+.reactor-status h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.4rem 0.75rem;
+  margin: 0;
+}
+
+.status-grid div {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+
+.status-grid dt {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #7fa1c9;
+}
+
+.status-grid dd {
+  margin: 0;
+}
+
+.status-value {
+  font-weight: 600;
+  font-size: 1rem;
+  color: #f2f5f8;
+}
+
+.status-value.status-pop {
+  animation: statusPop 300ms ease-out;
+}
+
+.status-value.danger {
+  color: #ff8a80;
+}
+
+.integrity-label {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: #7fa1c9;
+}
+
+.integrity-meter::-webkit-progress-value {
+  background: linear-gradient(120deg, #58d6a6, #3b82f6);
+}
+
+.integrity-meter::-moz-progress-bar {
+  background: linear-gradient(120deg, #58d6a6, #3b82f6);
+}
+
+.integrity-meter.danger::-webkit-progress-value {
+  background: linear-gradient(120deg, #f87171, #ef4444);
+}
+
+.integrity-meter.danger::-moz-progress-bar {
+  background: linear-gradient(120deg, #f87171, #ef4444);
+}
+
+.integrity-meter.meter-pulse {
+  animation: meterPulse 420ms ease-out;
+}
+
+.reactor-message {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #8fb0d8;
+  min-height: 1.2rem;
+}
+
+.reactor-message--danger {
+  color: #ff8a80;
+  animation: reactorFlash 480ms ease-in-out 3;
+}
+
+.reactor-status .action-button {
+  justify-self: start;
 }
 
 .flow-grid {
@@ -267,11 +373,13 @@ progress::-webkit-progress-value {
 
 .flow-node.bridge {
   background: linear-gradient(130deg, #2d6a4f, #95d5b2);
+  animation: bridgeGlow 2s ease-in-out infinite alternate;
 }
 
 .flow-node.route-selected {
   transform: translateY(-2px);
   box-shadow: 0 0 0 3px rgba(86, 204, 242, 0.35);
+  animation: routeGlow 1.4s ease-in-out infinite alternate;
 }
 
 .event-log {
@@ -288,6 +396,148 @@ progress::-webkit-progress-value {
 .event-log p {
   margin: 0;
   color: #9bb4d2;
+  animation: logAppear 260ms ease-out;
+}
+
+.rock-tile.match-highlight {
+  animation: matchPulse 260ms ease-in-out;
+}
+
+.rock-tile.match-fade {
+  animation: matchFade 220ms ease-in forwards;
+}
+
+.rock-tile.tile-enter {
+  animation: tileDrop 240ms ease-out;
+}
+
+.tetra-cell.line-clear {
+  animation: lineClearFlash 340ms ease-out 3;
+}
+
+
+@keyframes statusPop {
+  0% {
+    transform: scale(0.9);
+    opacity: 0.4;
+  }
+  55% {
+    transform: scale(1.08);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes meterPulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(63, 131, 248, 0.45);
+  }
+  100% {
+    box-shadow: 0 0 0 16px rgba(63, 131, 248, 0);
+  }
+}
+
+@keyframes reactorFlash {
+  0% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.3;
+  }
+}
+
+@keyframes bridgeGlow {
+  0% {
+    box-shadow: 0 0 0 0 rgba(149, 213, 178, 0.3);
+  }
+  100% {
+    box-shadow: 0 0 18px 4px rgba(149, 213, 178, 0.6);
+  }
+}
+
+@keyframes routeGlow {
+  0% {
+    box-shadow: 0 0 0 2px rgba(86, 204, 242, 0.35);
+  }
+  100% {
+    box-shadow: 0 0 12px 4px rgba(86, 204, 242, 0.55);
+  }
+}
+
+@keyframes logAppear {
+  0% {
+    transform: translateY(-6px);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes matchPulse {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(255, 239, 179, 0.3);
+  }
+  100% {
+    transform: scale(1.08);
+    box-shadow: 0 0 12px 4px rgba(255, 239, 179, 0.6);
+  }
+}
+
+@keyframes matchFade {
+  0% {
+    transform: scale(1.05);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(0.85);
+    opacity: 0;
+  }
+}
+
+@keyframes tileDrop {
+  0% {
+    transform: translateY(-12px);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes lineClearFlash {
+  0% {
+    box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.2);
+    transform: scale(1);
+  }
+  50% {
+    box-shadow: 0 0 18px 6px rgba(255, 255, 255, 0.6);
+    transform: scale(1.06);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.2);
+    transform: scale(1);
+  }
+}
+
+@keyframes queueSlide {
+  0% {
+    transform: translateX(12px);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    opacity: 1;
+  }
 }
 
 @media (max-width: 960px) {

--- a/madia.new/public/secret/argumentum/index.html
+++ b/madia.new/public/secret/argumentum/index.html
@@ -55,6 +55,38 @@
               <label>Fire <progress id="fire-meter" max="100" value="0"></progress></label>
               <label>Shift <progress id="shift-meter" max="100" value="0"></progress></label>
             </div>
+            <div class="reactor-status" aria-live="polite">
+              <h3>Reactor Status</h3>
+              <dl class="status-grid">
+                <div>
+                  <dt>Score</dt>
+                  <dd id="scoreDisplay" class="status-value">0</dd>
+                </div>
+                <div>
+                  <dt>Lines</dt>
+                  <dd id="linesDisplay" class="status-value">0</dd>
+                </div>
+                <div>
+                  <dt>Level</dt>
+                  <dd id="levelDisplay" class="status-value">1</dd>
+                </div>
+                <div>
+                  <dt>Combo</dt>
+                  <dd id="comboDisplay" class="status-value">&mdash;</dd>
+                </div>
+                <div>
+                  <dt>Bridges</dt>
+                  <dd id="bridgesDisplay" class="status-value">0</dd>
+                </div>
+              </dl>
+              <label class="integrity-label">
+                Integrity
+                <progress id="integrityMeter" class="integrity-meter" max="100" value="100"></progress>
+                <span id="integrityValue" class="status-value">100%</span>
+              </label>
+              <p id="reactorMessage" class="reactor-message">Stabilized</p>
+              <button type="button" class="action-button" id="restartButton">Restart Run</button>
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- ensure every Argumentum tetramino includes the full rotation set with basic wall-kick handling
- add an animated reactor status HUD with score, line, combo, integrity, and restart controls plus richer board feedback
- introduce scoring, combo, integrity, and game-over flows with visual/audio cues across the match-three and reactor boards

## Testing
- node --check madia.new/public/secret/argumentum/argumentum.js

------
https://chatgpt.com/codex/tasks/task_e_68dead227fbc83289d75551238192bce