### PR TITLE
Add reactor scoring and stability systems

### DIFF
--- a/madia.new/public/secret/argumentum/argumentum.css
+++ b/madia.new/public/secret/argumentum/argumentum.css
@@ -58,6 +58,80 @@ body {
   font-size: 0.95rem;
 }
 
+.reactor-status {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+  background: rgba(10, 18, 26, 0.75);
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(86, 204, 242, 0.18);
+}
+
+.reactor-metric {
+  display: grid;
+  gap: 0.25rem;
+  text-align: center;
+  padding: 0.4rem 0.25rem;
+  border-radius: 12px;
+  background: rgba(22, 34, 47, 0.8);
+  border: 1px solid rgba(99, 179, 237, 0.25);
+}
+
+.reactor-metric-label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.65rem;
+  color: #9bb4d2;
+}
+
+.reactor-metric-value {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: #f6fafc;
+}
+
+.reactor-meter {
+  display: grid;
+  gap: 0.35rem;
+  align-content: center;
+}
+
+.reactor-meter progress {
+  height: 16px;
+}
+
+.reactor-alert {
+  min-height: 1.35rem;
+  margin: 0;
+  text-align: center;
+  font-size: 0.9rem;
+  color: #9bb4d2;
+  transition: color 160ms ease, opacity 160ms ease;
+}
+
+.reactor-alert.info {
+  color: #7dd3fc;
+}
+
+.reactor-alert.warning {
+  color: #facc15;
+}
+
+.reactor-alert.danger {
+  color: #f87171;
+  font-weight: 600;
+}
+
+.reactor-alert.calm {
+  color: #9bb4d2;
+  opacity: 0.85;
+}
+
+.restart-button {
+  justify-self: center;
+}
+
 .action-button {
   background: linear-gradient(120deg, #2f80ed, #56ccf2);
   border: none;
@@ -86,6 +160,7 @@ body {
   grid-template-columns: repeat(6, 48px);
   gap: 4px;
   justify-content: center;
+  position: relative;
 }
 
 .rock-tile {
@@ -266,6 +341,7 @@ body {
   padding: 6px;
   border-radius: 12px;
   border: 1px solid rgba(76, 139, 213, 0.25);
+  position: relative;
 }
 
 .tetra-cell {
@@ -348,6 +424,7 @@ progress::-webkit-progress-value {
   border-radius: 16px;
   padding: 0.75rem;
   border: 1px solid rgba(58, 102, 167, 0.25);
+  position: relative;
 }
 
 .flow-node {
@@ -398,6 +475,122 @@ progress::-webkit-progress-value {
 .flow-node.bridge-invalid {
   box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.6);
   animation: pulseInvalid 600ms ease;
+}
+
+.match-board.resolving,
+.match-board.board-disabled,
+.tetramino-board.board-disabled,
+.flow-grid.board-disabled {
+  pointer-events: none;
+}
+
+.match-board.board-disabled,
+.tetramino-board.board-disabled,
+.flow-grid.board-disabled {
+  opacity: 0.45;
+  filter: saturate(0.75);
+}
+
+.tetramino-board.board-busy::after {
+  content: "";
+  position: absolute;
+  inset: 4px;
+  border-radius: 10px;
+  border: 1px dashed rgba(125, 211, 252, 0.5);
+  animation: rotateBorder 900ms linear infinite;
+  pointer-events: none;
+}
+
+.match-board.transform-mode::after {
+  content: "Channel active";
+  position: absolute;
+  inset: 6px;
+  border-radius: 12px;
+  border: 1px dashed rgba(249, 250, 113, 0.6);
+  color: rgba(249, 250, 113, 0.85);
+  font-size: 0.65rem;
+  display: grid;
+  place-items: center;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(15, 20, 28, 0.45);
+  pointer-events: none;
+}
+
+.rock-resolving {
+  animation: rockBurst 320ms ease forwards;
+}
+
+@keyframes rockBurst {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(0.4);
+    opacity: 0;
+  }
+}
+
+.tetra-cell.line-clearing {
+  animation: lineFlash 360ms ease forwards;
+}
+
+@keyframes lineFlash {
+  0% {
+    box-shadow: 0 0 0 0 rgba(224, 242, 254, 0.2);
+    opacity: 1;
+  }
+  50% {
+    box-shadow: 0 0 18px 6px rgba(125, 211, 252, 0.55);
+  }
+  100% {
+    opacity: 0.15;
+  }
+}
+
+.reactor-metric.pulse {
+  animation: metricPulse 600ms ease;
+}
+
+@keyframes metricPulse {
+  0% {
+    transform: scale(1);
+  }
+  45% {
+    transform: scale(1.08);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.reward-flash {
+  animation: rewardGlow 520ms ease;
+}
+
+@keyframes rewardGlow {
+  0% {
+    box-shadow: 0 0 0 rgba(56, 189, 248, 0);
+  }
+  50% {
+    box-shadow: 0 0 18px rgba(56, 189, 248, 0.55);
+  }
+  100% {
+    box-shadow: 0 0 0 rgba(56, 189, 248, 0);
+  }
+}
+
+@keyframes rotateBorder {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 @keyframes pulseInvalid {

--- a/madia.new/public/secret/argumentum/index.html
+++ b/madia.new/public/secret/argumentum/index.html
@@ -50,6 +50,28 @@
           Falling tetramino shards forge bridge schematics. Clear lines to draft shaped spans that can
           be anchored into the trail grid.
         </p>
+        <div class="reactor-status" aria-live="polite">
+          <div class="reactor-metric" id="score-metric">
+            <span class="reactor-metric-label">Score</span>
+            <span class="reactor-metric-value" id="score-display">0</span>
+          </div>
+          <div class="reactor-metric" id="lines-metric">
+            <span class="reactor-metric-label">Lines Cleared</span>
+            <span class="reactor-metric-value" id="lines-display">0</span>
+          </div>
+          <div class="reactor-metric" id="circuits-metric">
+            <span class="reactor-metric-label">Circuits Sealed</span>
+            <span class="reactor-metric-value" id="circuits-display">0</span>
+          </div>
+          <div class="reactor-meter">
+            <label for="strain-meter" class="reactor-metric-label">Reactor Strain</label>
+            <progress id="strain-meter" max="100" value="0"></progress>
+          </div>
+        </div>
+        <p class="reactor-alert" id="reactor-alert" role="status" aria-live="assertive"></p>
+        <button type="button" class="action-button restart-button" id="restart-game" hidden>
+          Restart Run
+        </button>
         <div class="tetramino-wrapper">
           <div class="tetramino-board" id="tetramino-board" aria-label="Falling pieces"></div>
           <div class="queue-panel">


### PR DESCRIPTION
## Summary
- expand tetramino definitions and add simple wall kicks so every shard can rotate cleanly
- wire up a reactor status panel with score, line, and circuit tracking plus strain-based game over/restart flow
- layer in visual cues for matches, line clears, transformations, and stability alerts to clarify player actions

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68deb136954c8328989fe5c3f99ef00c