### PR TITLE
Add combo-integrity reactor HUD to Argumentum

### DIFF
--- a/madia.new/public/secret/argumentum/argumentum.css
+++ b/madia.new/public/secret/argumentum/argumentum.css
@@ -58,14 +58,35 @@ body {
   font-size: 0.95rem;
 }
 
-.reactor-status {
+.reactor-hud {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 0.75rem;
   background: rgba(10, 18, 26, 0.75);
   border-radius: 14px;
   padding: 0.75rem 1rem;
   border: 1px solid rgba(86, 204, 242, 0.18);
+  position: relative;
+  overflow: hidden;
+}
+
+.reactor-hud::before {
+  content: "";
+  position: absolute;
+  inset: -40% -40% auto;
+  height: 160%;
+  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.2), transparent 55%);
+  opacity: 0;
+  transition: opacity 320ms ease;
+}
+
+.reactor-hud.combo-active::before {
+  opacity: 1;
+}
+
+.reactor-hud-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
 }
 
 .reactor-metric {
@@ -74,8 +95,29 @@ body {
   text-align: center;
   padding: 0.4rem 0.25rem;
   border-radius: 12px;
-  background: rgba(22, 34, 47, 0.8);
-  border: 1px solid rgba(99, 179, 237, 0.25);
+  background: rgba(22, 34, 47, 0.82);
+  border: 1px solid rgba(99, 179, 237, 0.28);
+  position: relative;
+  overflow: hidden;
+}
+
+.reactor-metric::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.16), rgba(30, 64, 175, 0.12));
+  opacity: 0;
+  transition: opacity 220ms ease;
+  pointer-events: none;
+}
+
+.reactor-metric.pulse::after,
+.reactor-metric.combo-active::after {
+  opacity: 1;
+}
+
+.reactor-metric.combo-active {
+  box-shadow: 0 0 16px rgba(59, 130, 246, 0.45);
 }
 
 .reactor-metric-label {
@@ -91,14 +133,71 @@ body {
   color: #f6fafc;
 }
 
-.reactor-meter {
+.reactor-combo-multiplier {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #60a5fa;
+}
+
+.reactor-integrity {
   display: grid;
   gap: 0.35rem;
   align-content: center;
+  text-align: center;
+  padding: 0.5rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(59, 130, 246, 0.32);
+  transition: border-color 220ms ease, box-shadow 220ms ease;
 }
 
-.reactor-meter progress {
+.integrity-bar {
+  position: relative;
   height: 16px;
+  border-radius: 999px;
+  background: rgba(30, 41, 59, 0.85);
+  overflow: hidden;
+  border: 1px solid rgba(96, 165, 250, 0.35);
+}
+
+.integrity-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 100%;
+  background: linear-gradient(120deg, rgba(56, 189, 248, 0.8), rgba(96, 165, 250, 0.6));
+  box-shadow: 0 0 12px rgba(56, 189, 248, 0.4);
+  transition: width 220ms ease, background 220ms ease, box-shadow 220ms ease;
+}
+
+.integrity-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #e0f2fe;
+}
+
+.reactor-integrity.integrity-warning {
+  border-color: rgba(250, 204, 21, 0.45);
+  box-shadow: 0 0 18px rgba(250, 204, 21, 0.22);
+}
+
+.reactor-integrity.integrity-warning .integrity-fill {
+  background: linear-gradient(120deg, rgba(250, 204, 21, 0.75), rgba(253, 186, 116, 0.65));
+  box-shadow: 0 0 12px rgba(250, 204, 21, 0.3);
+}
+
+.reactor-integrity.integrity-critical {
+  border-color: rgba(248, 113, 113, 0.55);
+  box-shadow: 0 0 18px rgba(248, 113, 113, 0.35);
+}
+
+.reactor-integrity.integrity-critical .integrity-fill {
+  background: linear-gradient(120deg, rgba(248, 113, 113, 0.8), rgba(239, 68, 68, 0.7));
+  box-shadow: 0 0 18px rgba(248, 113, 113, 0.45);
+}
+
+.reactor-hud-controls {
+  display: flex;
+  justify-content: center;
 }
 
 .reactor-alert {
@@ -132,6 +231,10 @@ body {
   justify-self: center;
 }
 
+.restart-button.ready {
+  box-shadow: 0 0 18px rgba(96, 165, 250, 0.45);
+}
+
 .action-button {
   background: linear-gradient(120deg, #2f80ed, #56ccf2);
   border: none;
@@ -161,6 +264,18 @@ body {
   gap: 4px;
   justify-content: center;
   position: relative;
+}
+
+.match-board.combo-glow::before,
+.tetramino-board.combo-glow::before {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  border-radius: 18px;
+  border: 1px solid rgba(96, 165, 250, 0.35);
+  box-shadow: 0 0 24px rgba(56, 189, 248, 0.45);
+  pointer-events: none;
+  animation: comboAura 880ms ease-in-out infinite alternate;
 }
 
 .rock-tile {
@@ -556,6 +671,21 @@ progress::-webkit-progress-value {
   animation: metricPulse 600ms ease;
 }
 
+.combo-celebration {
+  animation: comboCelebration 620ms ease;
+}
+
+@keyframes comboAura {
+  from {
+    opacity: 0.55;
+    box-shadow: 0 0 14px rgba(56, 189, 248, 0.35);
+  }
+  to {
+    opacity: 0.95;
+    box-shadow: 0 0 28px rgba(129, 140, 248, 0.55);
+  }
+}
+
 @keyframes metricPulse {
   0% {
     transform: scale(1);
@@ -565,6 +695,21 @@ progress::-webkit-progress-value {
   }
   100% {
     transform: scale(1);
+  }
+}
+
+@keyframes comboCelebration {
+  0% {
+    transform: scale(1);
+    filter: saturate(1);
+  }
+  40% {
+    transform: scale(1.03);
+    filter: saturate(1.35);
+  }
+  100% {
+    transform: scale(1);
+    filter: saturate(1);
   }
 }
 

--- a/madia.new/public/secret/argumentum/index.html
+++ b/madia.new/public/secret/argumentum/index.html
@@ -50,28 +50,51 @@
           Falling tetramino shards forge bridge schematics. Clear lines to draft shaped spans that can
           be anchored into the trail grid.
         </p>
-        <div class="reactor-status" aria-live="polite">
-          <div class="reactor-metric" id="score-metric">
-            <span class="reactor-metric-label">Score</span>
-            <span class="reactor-metric-value" id="score-display">0</span>
+        <div class="reactor-hud" aria-live="polite">
+          <div class="reactor-hud-metrics">
+            <div class="reactor-metric" id="score-metric">
+              <span class="reactor-metric-label">Score</span>
+              <span class="reactor-metric-value" id="score-display">0</span>
+            </div>
+            <div class="reactor-metric" id="lines-metric">
+              <span class="reactor-metric-label">Lines</span>
+              <span class="reactor-metric-value" id="lines-display">0</span>
+            </div>
+            <div class="reactor-metric" id="combo-metric">
+              <span class="reactor-metric-label">Combo</span>
+              <span class="reactor-metric-value" id="combo-display">—</span>
+              <span class="reactor-combo-multiplier" id="combo-multiplier">x1.0</span>
+            </div>
+            <div class="reactor-metric" id="circuits-metric">
+              <span class="reactor-metric-label">Circuits</span>
+              <span class="reactor-metric-value" id="circuits-display">0</span>
+            </div>
           </div>
-          <div class="reactor-metric" id="lines-metric">
-            <span class="reactor-metric-label">Lines Cleared</span>
-            <span class="reactor-metric-value" id="lines-display">0</span>
+          <div
+            class="reactor-integrity"
+            id="integrity-metric"
+            role="group"
+            aria-label="Reactor integrity"
+          >
+            <span class="reactor-metric-label">Integrity</span>
+            <div
+              class="integrity-bar"
+              role="progressbar"
+              aria-valuemin="0"
+              aria-valuemax="100"
+              aria-valuenow="100"
+            >
+              <div class="integrity-fill" id="integrity-fill"></div>
+            </div>
+            <span class="integrity-value" id="integrity-value">100%</span>
           </div>
-          <div class="reactor-metric" id="circuits-metric">
-            <span class="reactor-metric-label">Circuits Sealed</span>
-            <span class="reactor-metric-value" id="circuits-display">0</span>
-          </div>
-          <div class="reactor-meter">
-            <label for="strain-meter" class="reactor-metric-label">Reactor Strain</label>
-            <progress id="strain-meter" max="100" value="0"></progress>
+          <div class="reactor-hud-controls">
+            <button type="button" class="action-button restart-button" id="restart-game" disabled>
+              Restart Run
+            </button>
           </div>
         </div>
         <p class="reactor-alert" id="reactor-alert" role="status" aria-live="assertive"></p>
-        <button type="button" class="action-button restart-button" id="restart-game" hidden>
-          Restart Run
-        </button>
         <div class="tetramino-wrapper">
           <div class="tetramino-board" id="tetramino-board" aria-label="Falling pieces"></div>
           <div class="queue-panel">


### PR DESCRIPTION
## Summary
- introduce a combo-aware reactor HUD with integrity meter, restart control, and updated markup
- implement combo tracking, integrity management, audio cues, and wall kicks for tetramino and match-three flows
- refresh Argumentum styling to animate the HUD, combo glows, and restart affordances

## Testing
- node --check madia.new/public/secret/argumentum/argumentum.js

------
https://chatgpt.com/codex/tasks/task_e_68debbe58384832899965fbdf8a028fb