### PR TITLE
fix: stop argumentum arrow keys from scrolling page

### DIFF
--- a/madia.new/public/secret/argumentum/argumentum.js
+++ b/madia.new/public/secret/argumentum/argumentum.js
@@ -1859,7 +1859,12 @@ function reorientNetwork() {
   renderFlowGrid();
 }
 
+const scrollBlockingKeys = new Set(["ArrowLeft", "ArrowRight", "ArrowDown", "ArrowUp", " "]);
+
 function onKeyDown(event) {
+  if (scrollBlockingKeys.has(event.key)) {
+    event.preventDefault();
+  }
   if (gameOver) {
     return;
   }


### PR DESCRIPTION
## Summary
- prevent browser scrolling when gameplay keys are pressed in Argumentum

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68debfb6473c8328ad937e5349313974