### PR TITLE
Fix restart run button overlay intercepting clicks

### DIFF
--- a/madia.new/public/secret/argumentum/argumentum.css
+++ b/madia.new/public/secret/argumentum/argumentum.css
@@ -76,6 +76,7 @@ body {
   height: 160%;
   background: radial-gradient(circle at center, rgba(56, 189, 248, 0.2), transparent 55%);
   opacity: 0;
+  pointer-events: none;
   transition: opacity 320ms ease;
 }
 


### PR DESCRIPTION
## Summary
- allow the restart run control in the Argumentum reactor HUD to be clickable by letting pointer events pass through the decorative glow overlay

## Testing
- Not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dec0c789b88328b22a2cbdaffaea90