### PR TITLE
Add isometric tetramino pixel layering

### DIFF
--- a/madia.new/public/secret/argumentum/argumentum.css
+++ b/madia.new/public/secret/argumentum/argumentum.css
@@ -52,6 +52,13 @@ body {
   gap: 0.75rem;
 }
 
+.panel-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .panel-help {
   margin: 0;
   color: #a2bdde;
@@ -332,6 +339,117 @@ body {
   gap: 1.25rem;
 }
 
+.tetramino-board[hidden] {
+  display: none;
+}
+
+.isometric-stage {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  perspective: 1200px;
+  position: relative;
+  min-height: 320px;
+}
+
+.isometric-stage.active {
+  display: flex;
+}
+
+.isometric-board {
+  position: relative;
+  transform-style: preserve-3d;
+  background: rgba(8, 13, 19, 0.9);
+  border-radius: 12px;
+  border: 1px solid rgba(76, 139, 213, 0.25);
+  padding: 6px;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.35);
+  transform: rotateX(60deg) rotateZ(45deg);
+  transform-origin: center;
+  will-change: transform;
+  overflow: visible;
+}
+
+.iso-cell {
+  position: absolute;
+  width: 28px;
+  height: 28px;
+  transform-style: preserve-3d;
+}
+
+.iso-stack {
+  position: absolute;
+  inset: 0;
+  transform-style: preserve-3d;
+}
+
+.iso-base {
+  position: absolute;
+  inset: 0;
+  border-radius: 6px;
+  background: rgba(33, 48, 66, 0.65);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.iso-base-empty {
+  opacity: 0.25;
+}
+
+.iso-base-filled {
+  opacity: 0.9;
+}
+
+.iso-cube {
+  position: absolute;
+  inset: 0;
+  border-radius: 6px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+  transform: translate3d(0, 0, calc(var(--layer) * 12px));
+  transform-style: preserve-3d;
+}
+
+.iso-cube::before,
+.iso-cube::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 6px;
+  opacity: 0.6;
+  mix-blend-mode: screen;
+}
+
+.iso-cube::before {
+  transform: rotateY(90deg) translateZ(-14px);
+  transform-origin: center;
+  filter: brightness(0.7);
+}
+
+.iso-cube::after {
+  transform: rotateX(90deg) translateZ(14px);
+  transform-origin: center;
+  filter: brightness(1.1);
+}
+
+.falling-pixel {
+  position: absolute;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2), 0 0 12px rgba(125, 211, 252, 0.5);
+  transform-style: preserve-3d;
+  transition: transform 120ms linear;
+}
+
+.pixel-instructions {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #9bb4d2;
+  text-align: center;
+  max-width: 30ch;
+}
+
 .tetramino-board {
   display: grid;
   grid-template-columns: repeat(10, 28px);
@@ -366,6 +484,42 @@ body {
 
 .tetra-cell.filled-crystal {
   background: linear-gradient(140deg, #512da8, #b39ddb);
+}
+
+.pixel-earth {
+  background: linear-gradient(140deg, #375628, #8bb974);
+}
+
+.pixel-earth::before,
+.pixel-earth::after {
+  background: linear-gradient(140deg, #2f4c21, #7aa863);
+}
+
+.pixel-water {
+  background: linear-gradient(140deg, #1f4c8f, #64b5f6);
+}
+
+.pixel-water::before,
+.pixel-water::after {
+  background: linear-gradient(140deg, #183b70, #4f9dd9);
+}
+
+.pixel-fire {
+  background: linear-gradient(140deg, #7b1f1f, #ef5350);
+}
+
+.pixel-fire::before,
+.pixel-fire::after {
+  background: linear-gradient(140deg, #611818, #d64541);
+}
+
+.pixel-shift {
+  background: linear-gradient(140deg, #512da8, #b39ddb);
+}
+
+.pixel-shift::before,
+.pixel-shift::after {
+  background: linear-gradient(140deg, #402484, #9d8cc9);
 }
 
 .queue-panel {

--- a/madia.new/public/secret/argumentum/index.html
+++ b/madia.new/public/secret/argumentum/index.html
@@ -42,9 +42,14 @@
       <section class="panel tetramino" aria-label="Tetramino Reactor">
         <div class="panel-header">
           <h2>Tetramino Reactor</h2>
-          <button type="button" class="action-button" id="shift-board" disabled>
-            Actuated Shift
-          </button>
+          <div class="panel-actions">
+            <button type="button" class="action-button" id="toggle-isometric">
+              Isometric View
+            </button>
+            <button type="button" class="action-button" id="shift-board" disabled>
+              Actuated Shift
+            </button>
+          </div>
         </div>
         <p class="panel-help">
           Falling tetramino shards forge bridge schematics. Clear lines to draft shaped spans that can
@@ -73,6 +78,12 @@
           Restart Run
         </button>
         <div class="tetramino-wrapper">
+          <div class="isometric-stage" id="isometric-stage" hidden>
+            <div class="isometric-board" id="tetramino-isometric" aria-hidden="true"></div>
+            <p class="pixel-instructions" id="pixel-instructions">
+              Guide the falling pixel with ← →, press ↓ to nudge, and space to fast-drop.
+            </p>
+          </div>
           <div class="tetramino-board" id="tetramino-board" aria-label="Falling pieces"></div>
           <div class="queue-panel">
             <h3>Forge Queue</h3>


### PR DESCRIPTION
## Summary
- add an isometric toggle and guidance for the tetramino reactor UI
- implement controllable falling pixels with per-piece color stacks that collapse matching layers
- style the 3D board, pixel cubes, and hiding behavior when switching between views

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68debf5872908328a91bdd3927ac9b54