### PR TITLE
Add flow route stabilization to restore integrity

### DIFF
--- a/madia.new/public/secret/argumentum/argumentum.css
+++ b/madia.new/public/secret/argumentum/argumentum.css
@@ -52,6 +52,11 @@ body {
   gap: 0.75rem;
 }
 
+.panel-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
 .panel-help {
   margin: 0;
   color: #a2bdde;

--- a/madia.new/public/secret/argumentum/index.html
+++ b/madia.new/public/secret/argumentum/index.html
@@ -114,11 +114,17 @@
       <section class="panel flow-network" aria-label="Flow Trail Network">
         <div class="panel-header">
           <h2>Flow Trails</h2>
-          <button type="button" class="action-button" id="route-toggle">Plan Routes</button>
+          <div class="panel-actions">
+            <button type="button" class="action-button" id="route-toggle">Plan Routes</button>
+            <button type="button" class="action-button" id="stabilize-route" disabled>
+              Stabilize Flow
+            </button>
+          </div>
         </div>
         <p class="panel-help">
           Slot schematics into the lattice to connect wells and conduits. Locked bridges glow along the
-          trail, returning circuit energy that fuels new infusions.
+          trail, returning circuit energy that fuels new infusions. Select three or more locked spans and
+          stabilize the route to restore integrity.
         </p>
         <div class="flow-grid" id="flow-grid" aria-label="Resource network"></div>
         <div class="bridge-inventory">


### PR DESCRIPTION
## Summary
- add a Stabilize Flow control to the flow trails panel so players can recover reactor integrity from locked spans
- implement cooldown-gated logic that channels selected bridges into an integrity restore event
- refresh panel help copy and layout to accommodate the new action button

## Testing
- python -m http.server 5000

------
https://chatgpt.com/codex/tasks/task_e_68dec20220f08328a70200df06a60675