### PR TITLE
feat: add isometric landing highlight

### DIFF
--- a/madia.new/public/secret/argumentum/argumentum.css
+++ b/madia.new/public/secret/argumentum/argumentum.css
@@ -499,6 +499,54 @@ body {
   overflow: visible;
 }
 
+.pixel-target-highlight {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: 8px;
+  background: radial-gradient(
+    circle at center,
+    rgba(191, 219, 254, 0.65) 0%,
+    rgba(96, 165, 250, 0.35) 42%,
+    rgba(59, 130, 246, 0)
+  );
+  box-shadow:
+    0 0 18px rgba(125, 211, 252, 0.4),
+    0 0 36px rgba(56, 189, 248, 0.35);
+  transform-style: preserve-3d;
+  mix-blend-mode: screen;
+  animation: pixel-target-pulse 1.4s ease-in-out infinite alternate;
+}
+
+.pixel-target-highlight::after {
+  content: "";
+  position: absolute;
+  left: 6px;
+  right: 6px;
+  bottom: 6px;
+  height: var(--column-height, 120px);
+  border-radius: 6px 6px 12px 12px;
+  background: linear-gradient(
+    180deg,
+    rgba(191, 219, 254, 0.85) 0%,
+    rgba(191, 219, 254, 0.25) 55%,
+    rgba(37, 99, 235, 0)
+  );
+  transform-origin: center bottom;
+  transform: translate3d(0, 0, 0);
+  opacity: 0.85;
+  filter: blur(0.5px);
+}
+
+@keyframes pixel-target-pulse {
+  from {
+    opacity: 0.75;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 .iso-cell {
   position: absolute;
   width: 28px;

--- a/madia.new/public/secret/argumentum/argumentum.js
+++ b/madia.new/public/secret/argumentum/argumentum.js
@@ -1393,6 +1393,25 @@ function renderIsometricBoard() {
       isometricBoardEl.append(cellEl);
     }
   }
+  if (
+    fallingPixel &&
+    typeof fallingPixel.column === "number" &&
+    typeof fallingPixel.targetRow === "number" &&
+    fallingPixel.targetRow >= 0 &&
+    fallingPixel.targetRow < TETRA_HEIGHT
+  ) {
+    const landingCell = tetraBoard[fallingPixel.targetRow][fallingPixel.column];
+    if (landingCell) {
+      const highlightEl = document.createElement("div");
+      highlightEl.className = "pixel-target-highlight";
+      highlightEl.style.transform = `translate3d(${fallingPixel.column * ISO_CELL_SIZE}px, ${fallingPixel.targetRow * ISO_CELL_SIZE}px, 0)`;
+      const stackHeight = Array.isArray(landingCell.pixels) ? landingCell.pixels.length : 0;
+      const landingHeight = stackHeight * PIXEL_LAYER_HEIGHT;
+      const travelHeight = Math.max((fallingPixel.height ?? 0) - landingHeight, PIXEL_LAYER_HEIGHT * 2);
+      highlightEl.style.setProperty("--column-height", `${travelHeight}px`);
+      isometricBoardEl.append(highlightEl);
+    }
+  }
   if (fallingPixel) {
     const pixelEl = document.createElement("div");
     pixelEl.className = `falling-pixel pixel-${fallingPixel.color}`;


### PR DESCRIPTION
## Summary
- add a glowing landing column indicator to the isometric reactor view
- style the indicator with an animated translucent beam to emphasise the targeted cell

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68decc98a7b8832896da9813d32304e6