### PR TITLE
feat: add 1989 arcade landing page

### DIFF
--- a/madia.new/public/secret/1989/1989.css
+++ b/madia.new/public/secret/1989/1989.css
@@ -1,0 +1,293 @@
+:root {
+  color-scheme: dark;
+  font-family: "Space Grotesk", "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --bg: #05060f;
+  --grid: rgba(120, 255, 255, 0.2);
+  --card-bg: rgba(17, 25, 40, 0.8);
+  --card-border: rgba(120, 255, 255, 0.35);
+  --accent: #7b5bff;
+  --accent-soft: rgba(123, 91, 255, 0.25);
+  --text: #f8fafc;
+  --muted: rgba(226, 232, 240, 0.7);
+  --danger: #f87171;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--text);
+  background: radial-gradient(circle at 10% 20%, rgba(123, 91, 255, 0.3), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(56, 189, 248, 0.15), transparent 45%),
+    radial-gradient(circle at 50% 90%, rgba(248, 113, 113, 0.15), transparent 40%),
+    var(--bg);
+  padding-bottom: 4rem;
+}
+
+.scanlines {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.04),
+    rgba(255, 255, 255, 0.04) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  mix-blend-mode: soft-light;
+  opacity: 0.35;
+  z-index: 0;
+}
+
+.arcade-header {
+  position: relative;
+  padding: 4rem clamp(1.5rem, 4vw, 4rem) 2rem;
+  text-align: center;
+  z-index: 1;
+}
+
+.eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.arcade-header h1 {
+  margin: 0.75rem 0 0.5rem;
+  font-size: clamp(2.5rem, 8vw, 4.5rem);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  text-shadow: 0 10px 40px rgba(123, 91, 255, 0.5);
+}
+
+.tagline {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1.1rem;
+}
+
+main {
+  position: relative;
+  z-index: 1;
+  padding: 0 clamp(1.5rem, 4vw, 4rem);
+}
+
+.arcade-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  padding-bottom: 3rem;
+}
+
+.game-card {
+  position: relative;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.25rem;
+  grid-template-rows: auto 1fr auto;
+  box-shadow: 0 25px 45px -20px rgba(0, 0, 0, 0.8);
+  transition: transform 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
+  overflow: hidden;
+}
+
+.game-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top, rgba(123, 91, 255, 0.35), transparent 55%);
+  opacity: 0;
+  transition: opacity 220ms ease;
+  pointer-events: none;
+}
+
+.game-card:hover,
+.game-card:focus-within {
+  transform: translateY(-6px);
+  border-color: rgba(120, 255, 255, 0.6);
+  box-shadow: 0 35px 60px -25px rgba(123, 91, 255, 0.65);
+}
+
+.game-card:hover::before,
+.game-card:focus-within::before {
+  opacity: 1;
+}
+
+.game-thumb {
+  height: 120px;
+  display: grid;
+  place-items: center;
+}
+
+.game-thumb svg {
+  width: 100%;
+  height: 100%;
+  max-width: 180px;
+  filter: drop-shadow(0 15px 25px rgba(123, 91, 255, 0.35));
+}
+
+.game-info {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.game-title {
+  margin: 0;
+  font-size: 1.35rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.game-meta {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.card-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.play-button,
+.back-button {
+  font: inherit;
+  border: 0;
+  padding: 0.65rem 1.1rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(123, 91, 255, 0.9), rgba(56, 189, 248, 0.9));
+  color: white;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.play-button:hover,
+.play-button:focus-visible,
+.back-button:hover,
+.back-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 35px -15px rgba(123, 91, 255, 0.75);
+}
+
+.play-button:focus-visible,
+.back-button:focus-visible {
+  outline: 2px solid rgba(120, 255, 255, 0.8);
+  outline-offset: 3px;
+}
+
+.player-overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 10;
+}
+
+.overlay-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(5, 6, 15, 0.85);
+  backdrop-filter: blur(14px);
+}
+
+.overlay-frame {
+  position: relative;
+  width: min(1200px, 92vw);
+  height: min(760px, 88vh);
+  background: rgba(9, 13, 24, 0.92);
+  border: 1px solid rgba(120, 255, 255, 0.35);
+  border-radius: 1.5rem;
+  box-shadow: 0 35px 60px -25px rgba(0, 0, 0, 0.75);
+  display: grid;
+  grid-template-rows: auto 1fr;
+  overflow: hidden;
+  animation: overlay-in 180ms ease;
+}
+
+@keyframes overlay-in {
+  from {
+    transform: translateY(12px) scale(0.98);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+}
+
+.overlay-header {
+  padding: 1.2rem clamp(1rem, 2.5vw, 2rem);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.25rem;
+  background: rgba(17, 24, 39, 0.85);
+  border-bottom: 1px solid rgba(120, 255, 255, 0.2);
+}
+
+.overlay-title {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.overlay-eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.overlay-header h2 {
+  margin: 0;
+  font-size: 1.75rem;
+  letter-spacing: 0.05em;
+}
+
+.overlay-description {
+  margin: 0;
+  color: var(--muted);
+  max-width: 50ch;
+}
+
+#game-frame {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: rgba(2, 6, 23, 0.85);
+}
+
+@media (max-width: 720px) {
+  .arcade-header {
+    padding-top: 3rem;
+  }
+
+  .overlay-header {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .back-button {
+    align-self: flex-end;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -1,0 +1,161 @@
+/**
+ * Register launchable cabinets here. You can also import { registerGame }
+ * elsewhere and call it at runtime for dynamic catalogs.
+ */
+const games = [
+  {
+    id: "argumentum",
+    name: "Argumentum",
+    description: "Synth-grid puzzle fusion hidden deep in the archives.",
+    url: "../argumentum/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Argumentum preview">
+        <defs>
+          <linearGradient id="gridGlow" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#7b5bff" />
+            <stop offset="100%" stop-color="#38bdf8" />
+          </linearGradient>
+          <linearGradient id="tileFill" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0" stop-color="rgba(123, 91, 255, 0.5)" />
+            <stop offset="1" stop-color="rgba(56, 189, 248, 0.3)" />
+          </linearGradient>
+        </defs>
+        <rect x="4" y="4" width="152" height="112" rx="16" fill="rgba(7, 11, 28, 0.9)" stroke="url(#gridGlow)" />
+        <g stroke="rgba(120,255,255,0.35)" stroke-width="1">
+          ${Array.from({ length: 5 }, (_, i) => `<line x1="${32 + i * 24}" y1="16" x2="${32 + i * 24}" y2="104" />`).join("")}
+          ${Array.from({ length: 3 }, (_, i) => `<line x1="32" y1="${32 + i * 24}" x2="128" y2="${32 + i * 24}" />`).join("")}
+        </g>
+        <rect x="56" y="40" width="24" height="24" rx="6" fill="url(#tileFill)" stroke="rgba(123,91,255,0.9)" />
+        <rect x="80" y="64" width="24" height="24" rx="6" fill="url(#tileFill)" stroke="rgba(123,91,255,0.9)" />
+        <rect x="104" y="40" width="24" height="24" rx="6" fill="url(#tileFill)" stroke="rgba(123,91,255,0.9)" />
+        <circle cx="48" cy="72" r="12" fill="rgba(56,189,248,0.4)" stroke="#38bdf8" />
+        <circle cx="72" cy="88" r="8" fill="rgba(248,113,113,0.35)" stroke="#f97316" />
+      </svg>
+    `,
+  },
+  {
+    id: "prototype",
+    name: "Prototype Cabinet",
+    description: "Drop a new game folder in \"secret\" and point the cab here.",
+    url: "../argumentum/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Placeholder cabinet">
+        <defs>
+          <linearGradient id="cabGradient" x1="0" x2="1" y1="0" y2="1">
+            <stop offset="0" stop-color="rgba(123,91,255,0.6)" />
+            <stop offset="1" stop-color="rgba(56,189,248,0.6)" />
+          </linearGradient>
+        </defs>
+        <rect x="12" y="12" width="136" height="96" rx="18" fill="rgba(8, 12, 26, 0.9)" stroke="rgba(120,255,255,0.4)" />
+        <rect x="36" y="28" width="88" height="52" rx="10" fill="rgba(15,23,42,0.9)" stroke="url(#cabGradient)" />
+        <path d="M36 88h88l-12 12H48z" fill="rgba(123, 91, 255, 0.45)" stroke="rgba(120,255,255,0.4)" />
+        <circle cx="80" cy="54" r="8" fill="rgba(56,189,248,0.5)" />
+        <circle cx="60" cy="98" r="6" fill="#38bdf8" />
+        <circle cx="100" cy="98" r="6" fill="#7b5bff" />
+      </svg>
+    `,
+  },
+];
+
+const grid = document.getElementById("game-grid");
+const template = document.getElementById("game-card-template");
+const overlay = document.getElementById("player-overlay");
+const closeButton = document.getElementById("close-player");
+const overlayBackdrop = document.getElementById("overlay-backdrop");
+const overlayFrame = document.getElementById("overlay-frame");
+const frame = document.getElementById("game-frame");
+const title = document.getElementById("player-title");
+const description = document.getElementById("player-description");
+
+const gameLookup = new Map(games.map((game) => [game.id, game]));
+let lastFocusElement = null;
+
+function renderGames() {
+  const fragment = document.createDocumentFragment();
+  games.forEach((game) => {
+    const card = template.content.cloneNode(true);
+    const tile = card.querySelector(".game-card");
+    tile.dataset.gameId = game.id;
+    const thumb = card.querySelector(".game-thumb");
+    thumb.innerHTML = game.thumbnail;
+    card.querySelector(".game-title").textContent = game.name;
+    card.querySelector(".game-meta").textContent = game.description;
+    card.querySelector(".play-button").dataset.gameId = game.id;
+    fragment.appendChild(card);
+  });
+  grid.appendChild(fragment);
+}
+
+function openGame(game) {
+  title.textContent = game.name;
+  description.textContent = game.description;
+  frame.src = game.url;
+  overlay.hidden = false;
+  overlay.dataset.activeGame = game.id;
+  requestAnimationFrame(() => {
+    overlayFrame.focus({ preventScroll: true });
+  });
+}
+
+function closeGame() {
+  overlay.hidden = true;
+  overlay.dataset.activeGame = "";
+  frame.src = "";
+  if (lastFocusElement && document.body.contains(lastFocusElement)) {
+    lastFocusElement.focus({ preventScroll: true });
+  } else {
+    const fallbackButton = grid.querySelector(".play-button");
+    fallbackButton?.focus({ preventScroll: true });
+  }
+}
+
+renderGames();
+
+grid.addEventListener("click", (event) => {
+  const button = event.target.closest(".play-button");
+  if (!button) {
+    return;
+  }
+  const game = gameLookup.get(button.dataset.gameId);
+  if (!game) {
+    console.warn("No game registered for", button.dataset.gameId);
+    return;
+  }
+  lastFocusElement = button;
+  openGame(game);
+});
+
+closeButton.addEventListener("click", closeGame);
+overlayBackdrop.addEventListener("click", closeGame);
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape" && overlay.hidden === false) {
+    closeGame();
+  }
+});
+
+export function registerGame(gameConfig) {
+  const { id, name, description, url, thumbnail } = gameConfig;
+  if (!id || !name || !url) {
+    throw new Error("registerGame requires id, name, and url properties");
+  }
+  if (gameLookup.has(id)) {
+    throw new Error(`A game with id "${id}" is already registered.`);
+  }
+  const game = {
+    id,
+    name,
+    description: description ?? "",
+    url,
+    thumbnail: thumbnail ?? "",
+  };
+  gameLookup.set(id, game);
+  games.push(game);
+  const card = template.content.cloneNode(true);
+  card.querySelector(".game-thumb").innerHTML = game.thumbnail;
+  card.querySelector(".game-title").textContent = game.name;
+  card.querySelector(".game-meta").textContent = game.description;
+  const playButton = card.querySelector(".play-button");
+  playButton.dataset.gameId = game.id;
+  grid.appendChild(card);
+}

--- a/madia.new/public/secret/1989/index.html
+++ b/madia.new/public/secret/1989/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>1989 Arcade</title>
+    <link rel="stylesheet" href="1989.css" />
+  </head>
+  <body>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="arcade-header">
+      <p class="eyebrow">Secret Annex</p>
+      <h1>1989 Arcade</h1>
+      <p class="tagline">Slot in a cartridge and let the neon hum.</p>
+    </header>
+    <main>
+      <section class="arcade-grid" id="game-grid" aria-label="Game selection"></section>
+    </main>
+    <template id="game-card-template">
+      <article class="game-card">
+        <div class="game-thumb" aria-hidden="true"></div>
+        <div class="game-info">
+          <h2 class="game-title"></h2>
+          <p class="game-meta"></p>
+        </div>
+        <div class="card-actions">
+          <button class="play-button" type="button">Play</button>
+        </div>
+      </article>
+    </template>
+    <div class="player-overlay" id="player-overlay" hidden>
+      <div class="overlay-backdrop" id="overlay-backdrop"></div>
+      <section
+        class="overlay-frame"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="player-title"
+        tabindex="-1"
+        id="overlay-frame"
+      >
+        <header class="overlay-header">
+          <div class="overlay-title">
+            <p class="overlay-eyebrow">Now Playing</p>
+            <h2 id="player-title"></h2>
+            <p class="overlay-description" id="player-description"></p>
+          </div>
+          <button class="back-button" type="button" id="close-player" aria-label="Back to game select">
+            ◀ Back
+          </button>
+        </header>
+        <iframe id="game-frame" title="Game frame" loading="lazy"></iframe>
+      </section>
+    </div>
+    <script type="module" src="1989.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a secret/1989 arcade landing page with neon grid styling and cabinet cards
- include inline SVG thumbnails and an overlay launcher with back navigation
- expose a registerGame helper so additional cabinets can be registered without editing HTML

## Testing
- python -m http.server 5000

------
https://chatgpt.com/codex/tasks/task_e_68deccf8e6848328bffa77aa84c9965d