### PR TITLE
Add Level 49 Dream Team puzzle concept

### DIFF
--- a/docs/1989-puzzle-design.md
+++ b/docs/1989-puzzle-design.md
@@ -7,3 +7,11 @@
 - **Dynamic blockers:** Rivals execute signature movements—``Diagonal Drop`` (two diagonal tiles per turn) or ``Rope Rush`` (straight-line surges). Players must predict their telegraphed path each round.
 - **Combo payoff:** Completing the circuit triggers a "main-event slam" burst, stunning adjacent rivals for one turn and awarding a style multiplier that carries into the next level.
 - **Difficulty curve:** Starts with a single rival and static hazards, then introduces alternating current tiles that require alternating straight and corner pieces to maintain flow.
+
+## Level 49: The Dream Team
+- **Inspirational roots:** A fish-out-of-water caper about four psychiatric patients accidentally turned loose in New York City, leaning on ensemble comedy beats without calling out the source directly.
+- **Anchor pieces:** A fold-out straightjacket city map that shows the hospital launch point, subway nodes, and the stadium finish.
+- **Core mechanic:** Players queue actions for each patient according to their quirk—``Stepper`` (exactly one tile per turn), ``Liner`` (only straight paths until an obstacle forces a stop), ``Looper`` (must repeat its last move direction), and ``Wildcard`` (executes a pre-shuffled list of turns). Orders resolve simultaneously, so sequencing becomes an order-of-operations brainteaser.
+- **Dynamic blockers:** Patrol cars sweep along predictable beats—alternating avenues and cross streets—while occasional plainclothes officers mirror the nearest patient unless stunned by a crowd distraction.
+- **Sanity meter:** Collisions with authority, illegal moves, or forcing a patient to break their constraint drain a shared sanity track; hitting zero restarts the night.
+- **Difficulty curve:** Early boards teach synchronized exits across simple grids, then escalate with one-way turnstiles, traffic light timers, and bonus "pep talk" pickups that restore sanity if collected in the right order.


### PR DESCRIPTION
## Summary
- document the Level 49 Dream Team scenario for the 1989 puzzle anthology
- capture anchor piece, order-of-operations mechanic, dynamic blockers, and sanity meter progression

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ded30aed3483288f05835b6a11d94e