### PR TITLE
Add Loverboy delivery level concept

### DIFF
--- a/docs/1989-puzzle-design.md
+++ b/docs/1989-puzzle-design.md
@@ -7,3 +7,10 @@
 - **Dynamic blockers:** Rivals execute signature movements—``Diagonal Drop`` (two diagonal tiles per turn) or ``Rope Rush`` (straight-line surges). Players must predict their telegraphed path each round.
 - **Combo payoff:** Completing the circuit triggers a "main-event slam" burst, stunning adjacent rivals for one turn and awarding a style multiplier that carries into the next level.
 - **Difficulty curve:** Starts with a single rival and static hazards, then introduces alternating current tiles that require alternating straight and corner pieces to maintain flow.
+
+## Level 48: Loverboy
+- **Inspirational roots:** Tips its visor to a late-80s campus comedy about a charm-heavy pizza courier whose side hustle involves upscale clientele.
+- **Anchor pieces:** A retro "Amore Slices" pizza shop, a suburban cul-de-sac grid with numbered mansions, and scooter trails that glow once a route is committed.
+- **Core mechanic:** Streamed "Pizza Order" tiles queue up at the shop; players draw non-intersecting delivery trails that must reach each customer within a tight timer while preserving unique path segments.
+- **Escalating challenge:** Juggling simultaneous orders requires threading routes around earlier deliveries—any overlap or crossing triggers a traffic-jam failure and wipes the entire queue.
+- **Actuation twist:** A single-charge "Bike Jump" lets players vault one existing trail segment, temporarily ghosting through it to rescue an otherwise blocked order.


### PR DESCRIPTION
## Summary
- document a Loverboy-inspired neighborhood delivery stage for the 1989 puzzle game set
- outline anchor pieces, flow-routing mechanic, escalating order pressure, and the one-time Bike Jump actuation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ded31d1250832882b733ef3a8e5c38