### PR TITLE
Add Speed Zone level concept

### DIFF
--- a/docs/1989-puzzle-design.md
+++ b/docs/1989-puzzle-design.md
@@ -7,3 +7,11 @@
 - **Dynamic blockers:** Rivals execute signature movements—``Diagonal Drop`` (two diagonal tiles per turn) or ``Rope Rush`` (straight-line surges). Players must predict their telegraphed path each round.
 - **Combo payoff:** Completing the circuit triggers a "main-event slam" burst, stunning adjacent rivals for one turn and awarding a style multiplier that carries into the next level.
 - **Difficulty curve:** Starts with a single rival and static hazards, then introduces alternating current tiles that require alternating straight and corner pieces to maintain flow.
+
+## Level 46: Speed Zone
+- **Inspirational roots:** Spoofs the coast-to-coast outlaw cannonball runs where eccentric daredevils outrun police scanners with slapstick bravado.
+- **Anchor pieces:** Mandatory checkpoint hubs and a tower of constantly tumbling High-Speed Dice that broadcast movement points and risk icons.
+- **Core mechanic:** Probabilistic route planning across a stylized U.S. highway lattice—each roll reveals how far the car can surge and what hazard (sirens, blowouts, toll busts) will trigger if the player ends movement on a flagged node.
+- **Routing challenge:** Players must lock in a safe path before the dice settle on a high-risk face, threading alternate highways, detours, and rest stops to avoid hazard nodes while still clearing every checkpoint in sequence.
+- **Escalating threats:** Rival crews leak false traffic reports, shifting hazard tiles mid-turn, and patrol markers sweep ahead of the player whenever consecutive high-risk icons appear.
+- **Actuation twist:** Earning a rare ``Bypass`` actuation cancels one checkpoint requirement, but forces an immediate reroute that consumes the current movement roll and shifts the risk icons for the next throw.


### PR DESCRIPTION
## Summary
- add the Speed Zone level pitch to the 1989 puzzle concept document
- outline the racing-inspired mechanics, risks, and bypass actuation for Level 46

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ded35491dc8328b48a2f16695e6972