### PR TITLE
feat: add 1989 level 48 amore express puzzle

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -68,6 +68,38 @@ const games = [
     `,
   },
   {
+    id: "amore-express",
+    name: "Amore Express",
+    description: "Plan neon scooter runs through the cul-de-sac without tangling past deliveries.",
+    url: "./amore-express/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Amore Express preview">
+        <defs>
+          <linearGradient id="routeGlow" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#7b5bff" />
+            <stop offset="100%" stop-color="#38bdf8" />
+          </linearGradient>
+          <linearGradient id="scooterBody" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stop-color="rgba(248,113,113,0.95)" />
+            <stop offset="100%" stop-color="rgba(236,72,153,0.75)" />
+          </linearGradient>
+        </defs>
+        <rect x="10" y="10" width="140" height="100" rx="20" fill="rgba(9,14,28,0.9)" stroke="rgba(120,255,255,0.4)" />
+        <path d="M30 84h84c6 0 12-4 14-10l8-26" fill="none" stroke="url(#routeGlow)" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" opacity="0.85" />
+        <path d="M34 46c12-16 28-26 48-26 16 0 30 6 42 18" fill="none" stroke="rgba(56,189,248,0.4)" stroke-width="4" stroke-linecap="round" stroke-dasharray="8 8" />
+        <g transform="translate(50 64)">
+          <path d="M8 0h24l10 16-8 10H8z" fill="url(#scooterBody)" stroke="rgba(248,250,252,0.8)" stroke-width="1.5" />
+          <circle cx="14" cy="34" r="10" fill="rgba(15,23,42,0.9)" stroke="url(#routeGlow)" stroke-width="4" />
+          <circle cx="42" cy="34" r="10" fill="rgba(15,23,42,0.9)" stroke="url(#routeGlow)" stroke-width="4" />
+          <path d="M22 10h12l6 8" fill="none" stroke="rgba(248,250,252,0.9)" stroke-width="3" stroke-linecap="round" />
+        </g>
+        <circle cx="42" cy="32" r="6" fill="rgba(248,250,252,0.85)" stroke="rgba(236,72,153,0.8)" stroke-width="2" />
+        <rect x="24" y="20" width="36" height="18" rx="6" fill="rgba(123,91,255,0.25)" stroke="rgba(120,255,255,0.3)" />
+        <rect x="102" y="72" width="26" height="18" rx="6" fill="rgba(123,91,255,0.35)" stroke="rgba(120,255,255,0.3)" />
+      </svg>
+    `,
+  },
+  {
     id: "prototype",
     name: "Prototype Cabinet",
     description: "Drop a new game folder in \"secret\" and point the cab here.",

--- a/madia.new/public/secret/1989/amore-express/amore-express.css
+++ b/madia.new/public/secret/1989/amore-express/amore-express.css
@@ -1,0 +1,310 @@
+.game-header {
+  text-align: center;
+  padding: clamp(2rem, 5vw, 4rem) clamp(1.5rem, 4vw, 4rem) 1.5rem;
+  position: relative;
+  z-index: 1;
+}
+
+.game-header h1 {
+  margin: 0.5rem 0 0.25rem;
+  font-size: clamp(2.75rem, 7vw, 4.25rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-shadow: 0 20px 50px rgba(123, 91, 255, 0.4);
+}
+
+.scoreboard {
+  margin: 2rem auto 0;
+  display: grid;
+  gap: 1rem clamp(1rem, 4vw, 3rem);
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  padding: 1rem 1.5rem;
+  background: rgba(10, 15, 30, 0.65);
+  border: 1px solid rgba(120, 255, 255, 0.25);
+  border-radius: 1.25rem;
+  max-width: 640px;
+}
+
+.scoreboard dt {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.8rem;
+  margin-bottom: 0.35rem;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.scoreboard dd {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.game-layout {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.75rem);
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  padding: 0 clamp(1.5rem, 4vw, 4rem) 3rem;
+  position: relative;
+  z-index: 1;
+}
+
+@media (max-width: 900px) {
+  .game-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.board-panel {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.shop-card {
+  padding: 1.5rem;
+  background: rgba(12, 18, 32, 0.7);
+  border: 1px solid rgba(120, 255, 255, 0.25);
+  border-radius: 1.25rem;
+  box-shadow: 0 25px 40px -30px rgba(123, 91, 255, 0.45);
+}
+
+.shop-card h2 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.city-grid {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.5rem;
+  background: rgba(11, 16, 29, 0.75);
+  border: 1px solid rgba(120, 255, 255, 0.2);
+  padding: 1rem;
+  border-radius: 1.25rem;
+  box-shadow: inset 0 0 0 1px rgba(123, 91, 255, 0.15);
+}
+
+.grid-cell {
+  position: relative;
+  width: min(11vw, 72px);
+  aspect-ratio: 1 / 1;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(120, 255, 255, 0.15);
+  display: grid;
+  place-items: center;
+  color: rgba(226, 232, 240, 0.85);
+  cursor: pointer;
+  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.grid-cell:hover,
+.grid-cell:focus-visible {
+  transform: translateY(-3px);
+  border-color: rgba(120, 255, 255, 0.45);
+  box-shadow: 0 10px 28px -18px rgba(123, 91, 255, 0.75);
+}
+
+.grid-cell:focus-visible {
+  outline: 2px solid rgba(120, 255, 255, 0.65);
+  outline-offset: 2px;
+}
+
+.grid-cell[data-disabled="true"] {
+  cursor: not-allowed;
+  opacity: 0.45;
+  box-shadow: none;
+}
+
+.grid-cell.is-shop {
+  background: linear-gradient(135deg, rgba(123, 91, 255, 0.9), rgba(56, 189, 248, 0.85));
+  border-color: rgba(120, 255, 255, 0.75);
+  font-weight: 600;
+}
+
+.grid-cell.is-target {
+  border-color: rgba(248, 113, 113, 0.6);
+  box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.25);
+}
+
+.grid-cell.has-trail::after,
+.grid-cell.is-path::after {
+  content: "";
+  position: absolute;
+  inset: 8px;
+  border-radius: 14px;
+}
+
+.grid-cell.has-trail::after {
+  background: linear-gradient(135deg, rgba(123, 91, 255, 0.55), rgba(56, 189, 248, 0.55));
+  opacity: 0.6;
+}
+
+.grid-cell.is-path::after {
+  background: rgba(248, 250, 252, 0.75);
+  box-shadow: 0 0 20px rgba(248, 250, 252, 0.6);
+}
+
+.grid-cell.is-blocked {
+  border-color: rgba(248, 113, 113, 0.6);
+  box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.3);
+}
+
+.grid-label {
+  position: absolute;
+  inset: auto auto 6px 6px;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.route-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.route-controls button {
+  flex: 1 1 140px;
+  font: inherit;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(120, 255, 255, 0.4);
+  background: rgba(15, 23, 42, 0.8);
+  color: var(--text);
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+}
+
+.route-controls button:hover,
+.route-controls button:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(120, 255, 255, 0.7);
+  box-shadow: 0 12px 28px -18px rgba(123, 91, 255, 0.7);
+}
+
+.route-controls button:focus-visible {
+  outline: 2px solid rgba(120, 255, 255, 0.65);
+  outline-offset: 3px;
+}
+
+.route-controls .primary {
+  background: linear-gradient(135deg, rgba(123, 91, 255, 0.85), rgba(56, 189, 248, 0.85));
+  border-color: rgba(120, 255, 255, 0.8);
+  font-weight: 600;
+}
+
+.status-panel {
+  padding: 1rem 1.25rem;
+  background: rgba(12, 18, 32, 0.7);
+  border-radius: 1rem;
+  border: 1px solid rgba(120, 255, 255, 0.2);
+  min-height: 64px;
+}
+
+.status-panel p {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.order-panel {
+  display: grid;
+  gap: 1.25rem;
+  align-content: start;
+  background: rgba(10, 15, 30, 0.6);
+  border: 1px solid rgba(120, 255, 255, 0.2);
+  padding: 1.5rem;
+  border-radius: 1.5rem;
+  box-shadow: 0 28px 45px -32px rgba(8, 10, 26, 0.9);
+}
+
+.order-panel h2 {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.order-queue {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.order-card {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(120, 255, 255, 0.2);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.order-card.is-active {
+  border-color: rgba(248, 113, 113, 0.65);
+  box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.3);
+}
+
+.order-card.is-complete {
+  opacity: 0.55;
+}
+
+.order-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.order-label {
+  margin: 0;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.order-timer {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.order-clue {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.8);
+  line-height: 1.5;
+}
+
+.order-notes h3 {
+  margin: 0 0 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.order-notes ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: rgba(226, 232, 240, 0.78);
+  line-height: 1.6;
+}
+
+.flash-success {
+  color: #4ade80;
+}
+
+.flash-warning {
+  color: #f97316;
+}
+
+.flash-error {
+  color: #f87171;
+}

--- a/madia.new/public/secret/1989/amore-express/amore-express.js
+++ b/madia.new/public/secret/1989/amore-express/amore-express.js
@@ -1,0 +1,415 @@
+const GRID_WIDTH = 6;
+const GRID_HEIGHT = 6;
+const SHOP_COORD = { x: 2, y: 5 };
+
+const mansions = [
+  { id: "estate-luminari", label: "Estate Luminari", clue: "Wrap around the mirrored fountain before the caviar melts.", x: 5, y: 1 },
+  { id: "copper-terrace", label: "Copper Terrace", clue: "Thread between the copper lanterns and avoid the garden party crowd.", x: 0, y: 2 },
+  { id: "skyline-overlook", label: "Skyline Overlook", clue: "Climb the ridge and deliver to the rooftop patio with the city view.", x: 4, y: 0 },
+  { id: "blue-awnings", label: "Blue Awnings", clue: "Hop the hedges and slide the pie under the blue-striped awning.", x: 0, y: 4 },
+];
+
+const orders = [
+  { id: "estate-luminari", timer: 45, maxSteps: 8 },
+  { id: "copper-terrace", timer: 45, maxSteps: 7 },
+  { id: "skyline-overlook", timer: 50, maxSteps: 9 },
+  { id: "blue-awnings", timer: 40, maxSteps: 6 },
+];
+
+const gridElement = document.getElementById("city-grid");
+const statusText = document.getElementById("status-text");
+const deliveredCount = document.getElementById("delivered-count");
+const timerDisplay = document.getElementById("order-timer");
+const jumpStatus = document.getElementById("jump-status");
+const undoButton = document.getElementById("undo-step");
+const resetButton = document.getElementById("reset-route");
+const commitButton = document.getElementById("commit-route");
+const queueElement = document.getElementById("order-queue");
+const orderTemplate = document.getElementById("order-template");
+
+const mansionLookup = new Map(mansions.map((mansion) => [mansion.id, mansion]));
+const orderCards = new Map();
+const cellLookup = new Map();
+
+const occupiedNodes = new Set();
+const occupiedEdges = new Set();
+
+let activeOrderIndex = -1;
+let activeOrder = null;
+let activeTarget = null;
+let acceptingInput = true;
+let delivered = 0;
+let timerId = null;
+let remainingSeconds = 0;
+let jumpUsed = false;
+let jumpUsedThisRoute = false;
+
+let currentPath = [];
+let currentPathMetadata = [];
+let highlightedKeys = [];
+
+buildGrid();
+renderOrderQueue();
+startShift();
+
+gridElement.addEventListener("click", handleCellClick);
+undoButton.addEventListener("click", undoStep);
+resetButton.addEventListener("click", clearCurrentRoute);
+commitButton.addEventListener("click", commitRoute);
+
+function buildGrid() {
+  for (let y = 0; y < GRID_HEIGHT; y += 1) {
+    for (let x = 0; x < GRID_WIDTH; x += 1) {
+      const cell = document.createElement("button");
+      cell.type = "button";
+      cell.className = "grid-cell";
+      cell.dataset.x = String(x);
+      cell.dataset.y = String(y);
+      cell.setAttribute("aria-label", `Intersection ${x + 1},${GRID_HEIGHT - y}`);
+      if (x === SHOP_COORD.x && y === SHOP_COORD.y) {
+        cell.classList.add("is-shop");
+        cell.innerHTML = '<span class="grid-label">Shop</span>';
+      }
+      const mansion = mansions.find((entry) => entry.x === x && entry.y === y);
+      if (mansion) {
+        const badge = document.createElement("span");
+        badge.className = "grid-label";
+        badge.textContent = mansion.label;
+        cell.append(badge);
+      }
+      gridElement.append(cell);
+      cellLookup.set(nodeKey({ x, y }), cell);
+    }
+  }
+}
+
+function renderOrderQueue() {
+  mansions.forEach((mansion, index) => {
+    const order = orders[index];
+    const node = orderTemplate.content.cloneNode(true);
+    const card = node.querySelector(".order-card");
+    card.dataset.orderId = mansion.id;
+    card.querySelector(".order-label").textContent = `${index + 1}. ${mansion.label}`;
+    card.querySelector(".order-clue").textContent = mansion.clue;
+    const timer = card.querySelector(".order-timer");
+    timer.textContent = `${order.timer}s`;
+    queueElement.append(card);
+    orderCards.set(mansion.id, { element: card, timerElement: timer });
+  });
+}
+
+function startShift() {
+  occupiedNodes.clear();
+  occupiedEdges.clear();
+  jumpUsed = false;
+  resetJumpStatus();
+  delivered = 0;
+  deliveredCount.textContent = `${delivered} / ${orders.length}`;
+  timerDisplay.textContent = "--";
+  clearCurrentRoute();
+  cellLookup.forEach((cell) => {
+    cell.classList.remove("has-trail", "is-target", "is-blocked");
+    cell.dataset.disabled = "false";
+  });
+  orderCards.forEach(({ element, timerElement }, id) => {
+    element.classList.remove("is-active", "is-complete");
+    const order = orders.find((entry) => entry.id === id);
+    timerElement.textContent = order ? `${order.timer}s` : "--";
+  });
+  stopTimer();
+  acceptingInput = true;
+  flashStatus("Tap the shop to launch the first delivery.", "");
+  activateOrder(0);
+}
+
+function activateOrder(index) {
+  if (index >= orders.length) {
+    handleShiftComplete();
+    return;
+  }
+  activeOrderIndex = index;
+  activeOrder = orders[index];
+  activeTarget = mansionLookup.get(activeOrder.id);
+  orderCards.forEach(({ element }) => {
+    element.classList.remove("is-active");
+  });
+  const card = orderCards.get(activeOrder.id);
+  card?.element.classList.add("is-active");
+  highlightTarget();
+  clearCurrentRoute();
+  remainingSeconds = activeOrder.timer;
+  updateTimerDisplay();
+  startTimer();
+  flashStatus(`Route ${index + 1}: ${activeTarget.label} is waiting.`, "");
+}
+
+function highlightTarget() {
+  cellLookup.forEach((cell) => cell.classList.remove("is-target"));
+  if (!activeTarget) {
+    return;
+  }
+  const targetCell = cellLookup.get(nodeKey(activeTarget));
+  targetCell?.classList.add("is-target");
+}
+
+function startTimer() {
+  stopTimer();
+  timerId = window.setInterval(() => {
+    remainingSeconds -= 1;
+    updateTimerDisplay();
+    if (remainingSeconds <= 0) {
+      window.clearInterval(timerId);
+      timerId = null;
+      handleFailure("Order expired on the curb. Queue resetting.");
+    }
+  }, 1000);
+}
+
+function stopTimer() {
+  if (timerId !== null) {
+    window.clearInterval(timerId);
+    timerId = null;
+  }
+}
+
+function updateTimerDisplay() {
+  if (!activeOrder) {
+    timerDisplay.textContent = "--";
+    return;
+  }
+  timerDisplay.textContent = `${Math.max(remainingSeconds, 0)}s`;
+  const card = orderCards.get(activeOrder.id);
+  if (card) {
+    card.timerElement.textContent = `${Math.max(remainingSeconds, 0)}s`;
+  }
+}
+
+function handleCellClick(event) {
+  if (!acceptingInput || !activeOrder) {
+    return;
+  }
+  const target = event.target.closest(".grid-cell");
+  if (!target) {
+    return;
+  }
+  const position = {
+    x: Number(target.dataset.x),
+    y: Number(target.dataset.y),
+  };
+  extendPath(position);
+}
+
+function extendPath(position) {
+  if (currentPath.length === 0) {
+    if (!positionsEqual(position, SHOP_COORD)) {
+      flashStatus("Deliveries must launch from Amore Slices.", "flash-warning");
+      return;
+    }
+    currentPath.push(position);
+    updatePathHighlight();
+    return;
+  }
+
+  const last = currentPath[currentPath.length - 1];
+  if (!areAdjacent(last, position)) {
+    flashStatus("Scooter moves one block at a time—only orthogonal turns allowed.", "flash-warning");
+    return;
+  }
+
+  const key = nodeKey(position);
+  const priorIndex = currentPath.findIndex((node) => node.x === position.x && node.y === position.y);
+  if (priorIndex !== -1) {
+    if (priorIndex === currentPath.length - 2) {
+      undoStep();
+    } else {
+      flashStatus("Routes can't loop over themselves.", "flash-warning");
+    }
+    return;
+  }
+
+  const edge = edgeKey(last, position);
+  const collidesEdge = occupiedEdges.has(edge);
+  const collidesNode = occupiedNodes.has(key) && !positionsEqual(position, SHOP_COORD);
+  if (collidesEdge || collidesNode) {
+    if (jumpUsed || jumpUsedThisRoute) {
+      flashStatus("That lane is already glowing—no room to squeeze by without a jump.", "flash-error");
+      return;
+    }
+    jumpUsedThisRoute = true;
+    flashStatus("Bike Jump engaged! You ghosted through a glowing trail.", "flash-success");
+    updateJumpStatus();
+  }
+
+  currentPath.push(position);
+  currentPathMetadata.push({ usedJump: collidesEdge || collidesNode });
+  updatePathHighlight();
+}
+
+function undoStep() {
+  if (currentPath.length === 0) {
+    return;
+  }
+  const removed = currentPath.pop();
+  if (currentPathMetadata.length > 0) {
+    const meta = currentPathMetadata.pop();
+    if (meta.usedJump) {
+      jumpUsedThisRoute = false;
+      flashStatus("Bike Jump charge restored—choose a cleaner lane.", "flash-warning");
+      updateJumpStatus();
+    }
+  }
+  if (currentPath.length === 0) {
+    clearCurrentRoute();
+    return;
+  }
+  updatePathHighlight();
+}
+
+function clearCurrentRoute() {
+  currentPath = [];
+  currentPathMetadata = [];
+  jumpUsedThisRoute = false;
+  updateJumpStatus();
+  removePathHighlight();
+}
+
+function commitRoute() {
+  if (!activeOrder || currentPath.length < 2) {
+    flashStatus("Map a route from the shop to the mansion before delivering.", "flash-warning");
+    return;
+  }
+  const destination = currentPath[currentPath.length - 1];
+  if (!positionsEqual(destination, activeTarget)) {
+    flashStatus(`This trail ends at the wrong address—aim for ${activeTarget.label}.`, "flash-error");
+    return;
+  }
+  const stepCount = currentPath.length - 1;
+  if (stepCount > activeOrder.maxSteps) {
+    flashStatus("Too many blocks! Reroute with fewer turns.", "flash-error");
+    return;
+  }
+  if (jumpUsed && jumpUsedThisRoute) {
+    flashStatus("Bike Jump already spent earlier—no extra charge to burn.", "flash-error");
+    return;
+  }
+
+  finalizeRoute();
+}
+
+function finalizeRoute() {
+  stopTimer();
+  for (let i = 1; i < currentPath.length; i += 1) {
+    const prev = currentPath[i - 1];
+    const next = currentPath[i];
+    const edge = edgeKey(prev, next);
+    occupiedEdges.add(edge);
+    const nextKey = nodeKey(next);
+    if (!positionsEqual(next, SHOP_COORD)) {
+      occupiedNodes.add(nextKey);
+    }
+  }
+  currentPath.forEach((node) => {
+    const cell = cellLookup.get(nodeKey(node));
+    cell?.classList.add("has-trail");
+  });
+  const card = orderCards.get(activeOrder.id);
+  if (card) {
+    card.element.classList.remove("is-active");
+    card.element.classList.add("is-complete");
+    card.timerElement.textContent = "Delivered";
+  }
+  delivered += 1;
+  deliveredCount.textContent = `${delivered} / ${orders.length}`;
+  if (jumpUsedThisRoute) {
+    jumpUsed = true;
+  }
+  jumpUsedThisRoute = false;
+  updateJumpStatus();
+  flashStatus(`${activeTarget.label} enjoyed the pie!`, "flash-success");
+  clearCurrentRoute();
+  window.setTimeout(() => {
+    activateOrder(activeOrderIndex + 1);
+  }, 600);
+}
+
+function handleShiftComplete() {
+  flashStatus("Shift complete! Every mansion is satisfied.", "flash-success");
+  stopTimer();
+  acceptingInput = false;
+  window.setTimeout(() => {
+    acceptingInput = true;
+    startShift();
+  }, 3200);
+}
+
+function handleFailure(message) {
+  stopTimer();
+  flashStatus(message, "flash-error");
+  acceptingInput = false;
+  window.setTimeout(() => {
+    acceptingInput = true;
+    startShift();
+  }, 2000);
+}
+
+function updatePathHighlight() {
+  removePathHighlight();
+  highlightedKeys = currentPath.map((node) => nodeKey(node));
+  highlightedKeys.forEach((key) => {
+    const cell = cellLookup.get(key);
+    if (cell) {
+      cell.classList.add("is-path");
+    }
+  });
+}
+
+function removePathHighlight() {
+  highlightedKeys.forEach((key) => {
+    const cell = cellLookup.get(key);
+    cell?.classList.remove("is-path");
+  });
+  highlightedKeys = [];
+}
+
+function updateJumpStatus() {
+  if (jumpUsed || jumpUsedThisRoute) {
+    jumpStatus.textContent = jumpUsed ? "Spent" : "Engaged";
+  } else {
+    jumpStatus.textContent = "Ready";
+  }
+}
+
+function resetJumpStatus() {
+  jumpStatus.textContent = "Ready";
+}
+
+function flashStatus(message, toneClass) {
+  statusText.classList.remove("flash-success", "flash-warning", "flash-error");
+  if (toneClass) {
+    statusText.classList.add(toneClass);
+  }
+  statusText.textContent = message;
+}
+
+function nodeKey(node) {
+  return `${node.x},${node.y}`;
+}
+
+function edgeKey(a, b) {
+  if (a.x === b.x && a.y === b.y) {
+    return `${a.x},${a.y}`;
+  }
+  const forward = `${a.x},${a.y}|${b.x},${b.y}`;
+  const reverse = `${b.x},${b.y}|${a.x},${a.y}`;
+  return forward < reverse ? forward : reverse;
+}
+
+function areAdjacent(a, b) {
+  const dx = Math.abs(a.x - b.x);
+  const dy = Math.abs(a.y - b.y);
+  return (dx === 1 && dy === 0) || (dx === 0 && dy === 1);
+}
+
+function positionsEqual(a, b) {
+  return a.x === b.x && a.y === b.y;
+}

--- a/madia.new/public/secret/1989/amore-express/index.html
+++ b/madia.new/public/secret/1989/amore-express/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Amore Express · Level 48</title>
+    <link rel="stylesheet" href="../1989.css" />
+    <link rel="stylesheet" href="amore-express.css" />
+  </head>
+  <body>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="game-header">
+      <p class="eyebrow">Level 48 · 1989 Arcade</p>
+      <h1>Amore Express</h1>
+      <p class="tagline">
+        Keep the Amore Slices scooter weaving through the cul-de-sac without tangling previous trails.
+      </p>
+      <dl class="scoreboard">
+        <div>
+          <dt>Orders Delivered</dt>
+          <dd id="delivered-count">0 / 4</dd>
+        </div>
+        <div>
+          <dt>Clock</dt>
+          <dd id="order-timer">--</dd>
+        </div>
+        <div>
+          <dt>Bike Jump</dt>
+          <dd id="jump-status">Ready</dd>
+        </div>
+      </dl>
+    </header>
+    <main class="game-layout">
+      <section class="board-panel" aria-label="Delivery board">
+        <div class="shop-card">
+          <h2>Amore Slices</h2>
+          <p>
+            Every route must launch from the neon shop at the bottom of the map. Trails cannot reuse a single
+            segment once it has been ridden—except for one dramatic bike jump that lets you ghost through a
+            blocked segment exactly once.
+          </p>
+        </div>
+        <div class="city-grid" id="city-grid" role="grid" aria-label="Delivery grid"></div>
+        <div class="route-controls">
+          <button type="button" id="undo-step">Undo step</button>
+          <button type="button" id="reset-route">Clear route</button>
+          <button type="button" id="commit-route" class="primary">Deliver order</button>
+        </div>
+        <div class="status-panel" role="status" aria-live="polite">
+          <p id="status-text">Tap the shop to start your first trail.</p>
+        </div>
+      </section>
+      <aside class="order-panel" aria-label="Order queue">
+        <h2>Delivery Queue</h2>
+        <ol id="order-queue" class="order-queue"></ol>
+        <section class="order-notes">
+          <h3>Route Rules</h3>
+          <ul>
+            <li>Move orthogonally from intersection to intersection.</li>
+            <li>Reach the highlighted mansion before the timer expires.</li>
+            <li>
+              Existing trails and mansions block movement—map a clean route that never collides with glowing segments.
+            </li>
+            <li>The Bike Jump can ignore a collision exactly once for the whole shift.</li>
+          </ul>
+        </section>
+      </aside>
+    </main>
+    <template id="order-template">
+      <li class="order-card">
+        <article>
+          <header>
+            <p class="order-label"></p>
+            <p class="order-timer" aria-hidden="true"></p>
+          </header>
+          <p class="order-clue"></p>
+        </article>
+      </li>
+    </template>
+    <script type="module" src="amore-express.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- register the Amore Express cabinet in the 1989 arcade catalog with a custom neon thumbnail
- build the Level 48 delivery puzzle experience with timers, order queue, and single-use bike jump logic
- style the new level with bespoke scoreboard, grid, and order panel presentation

## Testing
- python -m http.server 5000


------
https://chatgpt.com/codex/tasks/task_e_68deda26717083288a5007c3b8caaf45