### PR TITLE
Add real-time feedback to Velvet Syncopation

### DIFF
--- a/madia.new/public/secret/1989/velvet-syncopation/velvet-syncopation.css
+++ b/madia.new/public/secret/1989/velvet-syncopation/velvet-syncopation.css
@@ -317,6 +317,16 @@ body {
   border-style: dashed;
 }
 
+.lane-cell.is-hit {
+  border-color: rgba(34, 211, 238, 0.75);
+  box-shadow: 0 18px 35px -22px rgba(34, 211, 238, 0.65);
+}
+
+.lane-cell.is-miss {
+  border-color: rgba(248, 113, 113, 0.7);
+  box-shadow: 0 18px 35px -22px rgba(248, 113, 113, 0.5);
+}
+
 .note-badge {
   display: inline-flex;
   align-items: center;
@@ -386,6 +396,22 @@ body {
   border-radius: 0.6rem;
   border: 1px solid rgba(120, 255, 255, 0.35);
   background: rgba(123, 91, 255, 0.15);
+}
+
+.sync-sequence .sequence-step.is-hit {
+  border-color: rgba(34, 211, 238, 0.8);
+  background: rgba(34, 211, 238, 0.2);
+  color: var(--text);
+}
+
+.sync-sequence .sequence-step.is-miss {
+  border-color: rgba(248, 113, 113, 0.7);
+  background: rgba(248, 113, 113, 0.18);
+}
+
+.sync-sequence .sequence-step.is-complete {
+  border-style: dashed;
+  opacity: 0.6;
 }
 
 .virtual-keys {


### PR DESCRIPTION
## Summary
- add rhythm lane hit, miss, and clear styling to Velvet Syncopation so players see immediate feedback
- track sync cue step badges and showstopper skips to accurately reset, highlight, and clear cues during play

## Testing
- python -m http.server 5000 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68deda21f7f483289ac0a6cd06911968