### PR TITLE
Add Level 48 Amore Express game to 1989 arcade

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -34,6 +34,42 @@ const games = [
     `,
   },
   {
+    id: "amore-express",
+    name: "Amore Express",
+    description: "Chart cul-de-sac deliveries while keeping scooter trails pristine.",
+    url: "./amore-express/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Amore Express preview">
+        <defs>
+          <linearGradient id="amoreGlow" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#38bdf8" />
+            <stop offset="100%" stop-color="#f97316" />
+          </linearGradient>
+          <linearGradient id="trailFade" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stop-color="rgba(56,189,248,0.6)" />
+            <stop offset="100%" stop-color="rgba(249,115,22,0.6)" />
+          </linearGradient>
+        </defs>
+        <rect x="8" y="8" width="144" height="104" rx="18" fill="rgba(10,15,30,0.92)" stroke="url(#amoreGlow)" />
+        <circle cx="60" cy="60" r="30" fill="rgba(250,204,21,0.2)" stroke="rgba(250,204,21,0.65)" stroke-width="3" />
+        <path d="M60 30c16 0 30 13 30 30s-14 30-30 30-30-13-30-30 14-30 30-30z" fill="rgba(249,115,22,0.25)" stroke="rgba(249,115,22,0.75)" stroke-width="2" />
+        <path d="M60 30L60 90" stroke="rgba(249,115,22,0.75)" stroke-width="3" />
+        <path d="M30 60L90 60" stroke="rgba(249,115,22,0.75)" stroke-width="3" />
+        <circle cx="48" cy="48" r="5" fill="#f97316" />
+        <circle cx="72" cy="68" r="5" fill="#ef4444" />
+        <circle cx="50" cy="72" r="6" fill="#fbbf24" />
+        <path d="M96 76c10-10 30-10 38 0" stroke="url(#trailFade)" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+        <g transform="translate(102 70)">
+          <circle cx="0" cy="20" r="6" fill="#38bdf8" stroke="rgba(148,163,184,0.6)" />
+          <circle cx="28" cy="20" r="6" fill="#7b5bff" stroke="rgba(148,163,184,0.6)" />
+          <path d="M2 8h16l8 12" fill="none" stroke="#38bdf8" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+          <circle cx="8" cy="8" r="4" fill="#38bdf8" />
+          <circle cx="24" cy="20" r="3" fill="#f97316" />
+        </g>
+      </svg>
+    `,
+  },
+  {
     id: "velvet-syncopation",
     name: "Velvet Syncopation",
     description: "Three-lane rhythm rehearsal with the lounge trio's velvet slips.",

--- a/madia.new/public/secret/1989/amore-express/amore-express.css
+++ b/madia.new/public/secret/1989/amore-express/amore-express.css
@@ -1,0 +1,545 @@
+:root {
+  color-scheme: dark;
+  font-family: "Space Grotesk", "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --bg: #04050d;
+  --panel: rgba(10, 16, 28, 0.92);
+  --panel-soft: rgba(12, 20, 34, 0.8);
+  --border: rgba(120, 255, 255, 0.35);
+  --border-soft: rgba(120, 255, 255, 0.18);
+  --text: #f8fafc;
+  --muted: rgba(226, 232, 240, 0.7);
+  --accent: #38bdf8;
+  --accent-secondary: #f97316;
+  --danger: #f87171;
+  --success: #34d399;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 15%, rgba(56, 189, 248, 0.12), transparent 55%),
+    radial-gradient(circle at 75% 10%, rgba(249, 115, 22, 0.14), transparent 50%),
+    radial-gradient(circle at 40% 90%, rgba(52, 211, 153, 0.12), transparent 45%),
+    var(--bg);
+  color: var(--text);
+  padding-bottom: 4rem;
+}
+
+.scanlines {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.03),
+    rgba(255, 255, 255, 0.03) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  mix-blend-mode: soft-light;
+  opacity: 0.35;
+  z-index: 0;
+}
+
+.page-header {
+  position: relative;
+  padding: clamp(2rem, 6vw, 4rem) clamp(1.25rem, 4vw, 4rem) 2rem;
+  text-align: center;
+  z-index: 1;
+}
+
+.eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.page-header h1 {
+  margin: 0.75rem 0 0.5rem;
+  font-size: clamp(2.5rem, 8vw, 4.25rem);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  text-shadow: 0 10px 40px rgba(56, 189, 248, 0.45);
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1.1rem;
+}
+
+.page-layout {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  padding: 0 clamp(1.25rem, 4vw, 4rem);
+}
+
+@media (min-width: 1080px) {
+  .page-layout {
+    grid-template-columns: minmax(280px, 360px) 1fr;
+  }
+}
+
+.briefing,
+.simulator {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  box-shadow: 0 25px 45px -28px rgba(0, 0, 0, 0.75);
+}
+
+.briefing h2,
+.simulator h2,
+.simulator h3 {
+  margin-top: 0;
+}
+
+.callouts {
+  margin: 1rem 0 0.75rem;
+  padding-left: 1.2rem;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.routing-guide {
+  margin-top: 1.5rem;
+}
+
+.routing-guide ol {
+  margin: 0;
+  padding-left: 1.2rem;
+  line-height: 1.5;
+  color: var(--text);
+}
+
+.simulator-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.simulator-controls {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.action-button {
+  font: inherit;
+  border: 0;
+  padding: 0.65rem 1.2rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.9), rgba(249, 115, 22, 0.85));
+  color: white;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.action-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.action-button:not(:disabled):hover,
+.action-button:not(:disabled):focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 35px -15px rgba(56, 189, 248, 0.75);
+}
+
+.action-button:focus-visible {
+  outline: 2px solid rgba(120, 255, 255, 0.8);
+  outline-offset: 3px;
+}
+
+.simulator-help {
+  margin: 1rem 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.harmony-panel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+}
+
+.harmony-meter {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 240px;
+}
+
+.meter-label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.meter {
+  position: relative;
+  height: 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-soft);
+  background: rgba(15, 23, 42, 0.65);
+  overflow: hidden;
+}
+
+.meter-fill {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.9), rgba(249, 115, 22, 0.9));
+  transition: width 220ms ease;
+}
+
+.meter-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.status-readout {
+  flex: 1;
+  text-align: right;
+  color: var(--muted);
+}
+
+.simulator-layout {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 900px) {
+  .simulator-layout {
+    grid-template-columns: minmax(320px, 1fr) minmax(220px, 280px);
+  }
+}
+
+.board-column {
+  background: var(--panel-soft);
+  border: 1px solid var(--border-soft);
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  position: relative;
+}
+
+.board {
+  --cell-size: clamp(3rem, 6vw, 4rem);
+  display: grid;
+  grid-template-columns: repeat(6, var(--cell-size));
+  grid-auto-rows: var(--cell-size);
+  gap: clamp(0.6rem, 2vw, 0.9rem);
+  position: relative;
+  justify-content: center;
+}
+
+.board button {
+  border: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.intersection {
+  position: relative;
+  width: var(--cell-size);
+  height: var(--cell-size);
+  border-radius: 35%;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+  z-index: 1;
+}
+
+.intersection:focus-visible {
+  outline: 2px solid rgba(120, 255, 255, 0.8);
+  outline-offset: 2px;
+}
+
+.intersection:hover {
+  transform: translateY(-2px);
+}
+
+.intersection.shop {
+  background: rgba(56, 189, 248, 0.18);
+  border-color: rgba(56, 189, 248, 0.65);
+  color: #bae6fd;
+}
+
+.intersection.mansion {
+  background: rgba(249, 115, 22, 0.16);
+  border-color: rgba(249, 115, 22, 0.55);
+  color: #fed7aa;
+}
+
+.intersection.is-target {
+  box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.35), 0 0 25px rgba(249, 115, 22, 0.4);
+}
+
+.intersection.is-active {
+  box-shadow: 0 0 15px rgba(56, 189, 248, 0.45);
+  border-color: rgba(56, 189, 248, 0.75);
+}
+
+.trail-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.trail-line {
+  stroke: rgba(56, 189, 248, 0.85);
+  stroke-width: 10;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  filter: drop-shadow(0 0 6px rgba(56, 189, 248, 0.6));
+}
+
+.active-line {
+  stroke: rgba(249, 115, 22, 0.85);
+  stroke-width: 8;
+  stroke-dasharray: 6 8;
+  animation: dash 0.9s linear infinite;
+}
+
+@keyframes dash {
+  to {
+    stroke-dashoffset: -28;
+  }
+}
+
+.legend {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.legend-item::before {
+  content: "";
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 0.35rem;
+  border: 1px solid var(--border-soft);
+  background: rgba(148, 163, 184, 0.4);
+}
+
+.legend-shop::before {
+  background: rgba(56, 189, 248, 0.4);
+  border-color: rgba(56, 189, 248, 0.8);
+}
+
+.legend-mansion::before {
+  background: rgba(249, 115, 22, 0.35);
+  border-color: rgba(249, 115, 22, 0.75);
+}
+
+.legend-trail::before {
+  background: rgba(56, 189, 248, 0.8);
+  border-color: rgba(56, 189, 248, 0.8);
+  box-shadow: 0 0 12px rgba(56, 189, 248, 0.6);
+}
+
+.sidebar {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.delivered-count {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.order-queue ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.order-card {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1rem;
+  padding: 0.85rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.order-card.is-selected {
+  border-color: rgba(249, 115, 22, 0.75);
+  box-shadow: 0 0 0 2px rgba(249, 115, 22, 0.25);
+}
+
+.order-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.order-heading strong {
+  font-size: 1rem;
+}
+
+.order-heading span {
+  font-size: 0.8rem;
+  color: var(--muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.order-detail {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.timer-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.timer-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.route-button {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.45rem 0.95rem;
+  background: rgba(249, 115, 22, 0.85);
+  color: white;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.7rem;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.route-button:hover,
+.route-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 25px -12px rgba(249, 115, 22, 0.7);
+}
+
+.route-button:focus-visible {
+  outline: 2px solid rgba(249, 115, 22, 0.8);
+  outline-offset: 2px;
+}
+
+.route-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.jump-status {
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 1rem;
+  padding: 1rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.jump-status h3 {
+  margin-top: 0;
+  color: var(--text);
+}
+
+.jump-status.ready {
+  border-color: rgba(56, 189, 248, 0.7);
+  box-shadow: 0 0 15px rgba(56, 189, 248, 0.25);
+}
+
+.jump-status.spent {
+  border-color: rgba(148, 163, 184, 0.2);
+  opacity: 0.75;
+}
+
+.event-log {
+  margin-top: 2rem;
+}
+
+.event-log ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.event-log li {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.85rem;
+  padding: 0.65rem 0.85rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.page-footer {
+  margin: 3rem auto 0;
+  max-width: min(920px, 92vw);
+  text-align: center;
+  color: var(--muted);
+}
+
+.page-footer p {
+  margin: 0;
+  line-height: 1.5;
+}
+
+@media (max-width: 720px) {
+  .status-readout {
+    text-align: left;
+  }
+
+  .board {
+    justify-content: center;
+  }
+}

--- a/madia.new/public/secret/1989/amore-express/amore-express.js
+++ b/madia.new/public/secret/1989/amore-express/amore-express.js
@@ -1,0 +1,568 @@
+const boardSize = 6;
+const shop = { row: 2, col: 0, label: "Hub", name: "Amore Slices dispatch" };
+const houses = [
+  { id: "mansion-03", row: 0, col: 2, label: "03", name: "Vista Loop No. 03", note: "Observatory Terrace" },
+  { id: "mansion-08", row: 5, col: 1, label: "08", name: "Arcade Bend No. 08", note: "Atrium Statuary" },
+  { id: "mansion-12", row: 1, col: 5, label: "12", name: "Fountain Crest No. 12", note: "Champagne Veranda" },
+  { id: "mansion-19", row: 3, col: 5, label: "19", name: "Terrace Lane No. 19", note: "Skybridge Loft" },
+  { id: "mansion-27", row: 4, col: 4, label: "27", name: "Harbor View No. 27", note: "Pool Pavilion" },
+];
+
+const orderSchedule = [
+  { id: "order-01", houseId: "mansion-08", pizza: "Fig & Ricotta Serenade", duration: 24 },
+  { id: "order-02", houseId: "mansion-12", pizza: "Champagne Basil Fold", duration: 22 },
+  { id: "order-03", houseId: "mansion-27", pizza: "Truffle Triad Supreme", duration: 24 },
+  { id: "order-04", houseId: "mansion-03", pizza: "Saffron Skyline Slice", duration: 20 },
+  { id: "order-05", houseId: "mansion-19", pizza: "Garden Midnight Pie", duration: 24 },
+  { id: "order-06", houseId: "mansion-27", pizza: "After Hours Calzone", duration: 20 },
+  { id: "order-07", houseId: "mansion-12", pizza: "VIP Tuxedo Square", duration: 18 },
+];
+
+const boardElement = document.getElementById("delivery-board");
+const orderList = document.getElementById("order-list");
+const statusReadout = document.getElementById("status-readout");
+const startButton = document.getElementById("start-shift");
+const endButton = document.getElementById("end-shift");
+const clearPathButton = document.getElementById("clear-path");
+const eventList = document.getElementById("event-list");
+const deliveredCountLabel = document.getElementById("delivered-count");
+const jumpStatus = document.querySelector(".jump-status");
+const jumpStatusText = document.getElementById("jump-status-text");
+const queueMeter = document.getElementById("queue-meter");
+const queueMeterFill = document.getElementById("queue-meter-fill");
+const queueMeterValue = document.getElementById("queue-meter-value");
+
+const housesById = new Map(houses.map((house) => [house.id, house]));
+const nodeLookup = new Map();
+
+let trails = [];
+let usedEdges = new Set();
+let activeSegments = [];
+let activePath = [];
+let activeOrders = [];
+let scheduleIndex = 0;
+let selectedOrderId = null;
+let deliveredCount = 0;
+let bikeJumpCharges = 1;
+let shiftActive = false;
+let jumpUsedThisRoute = false;
+let tickTimer = null;
+
+const overlay = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+overlay.classList.add("trail-overlay");
+boardElement.append(overlay);
+
+buildBoard();
+renderTrails();
+updateJumpStatus();
+updateStatus("Awaiting shift.");
+
+startButton.addEventListener("click", () => {
+  if (shiftActive) {
+    return;
+  }
+  startShift();
+});
+
+endButton.addEventListener("click", () => {
+  if (!shiftActive) {
+    return;
+  }
+  endShift(false, "Shift closed early. The queue will reset.");
+});
+
+clearPathButton.addEventListener("click", () => {
+  if (!shiftActive) {
+    return;
+  }
+  clearActivePath();
+  updateStatus("Path cleared. Reroute from the hub.");
+});
+
+orderList.addEventListener("click", (event) => {
+  const button = event.target.closest(".route-button");
+  if (!button) {
+    return;
+  }
+  const { orderId } = button.dataset;
+  if (!orderId) {
+    return;
+  }
+  setSelectedOrder(orderId);
+});
+
+boardElement.addEventListener("click", (event) => {
+  if (!shiftActive) {
+    return;
+  }
+  const button = event.target.closest(".intersection");
+  if (!button) {
+    return;
+  }
+  const row = Number.parseInt(button.dataset.row, 10);
+  const col = Number.parseInt(button.dataset.col, 10);
+  const position = { row, col };
+
+  if (!selectedOrderId) {
+    updateStatus("Select an order before plotting a route.");
+    return;
+  }
+
+  const target = getTargetHouse();
+  if (!target) {
+    updateStatus("The chosen order no longer exists.");
+    return;
+  }
+
+  if (activePath.length === 0) {
+    if (!positionsEqual(position, shop)) {
+      updateStatus("Start at the Amore Slices hub.");
+      return;
+    }
+    activePath.push(position);
+    button.classList.add("is-active");
+    updateClearPathState();
+    renderTrails();
+    return;
+  }
+
+  const lastPosition = activePath[activePath.length - 1];
+  if (positionsEqual(lastPosition, position)) {
+    return;
+  }
+
+  if (!isAdjacent(lastPosition, position)) {
+    triggerTrafficJam("Scooters can only move to adjacent intersections.");
+    return;
+  }
+
+  const segmentKey = edgeKey(lastPosition, position);
+  const segment = { from: lastPosition, to: position };
+
+  if (usedEdges.has(segmentKey)) {
+    if (bikeJumpCharges > 0 && !jumpUsedThisRoute) {
+      bikeJumpCharges = 0;
+      jumpUsedThisRoute = true;
+      logEvent("Bike Jump deployed to glide across a locked trail.");
+      updateJumpStatus();
+    } else {
+      triggerTrafficJam("Crossed an existing trail and triggered a traffic jam.");
+      return;
+    }
+  }
+
+  activeSegments.push(segment);
+
+  activePath.push(position);
+  button.classList.add("is-active");
+  renderTrails();
+  updateClearPathState();
+
+  if (positionsEqual(position, target)) {
+    finalizeRoute();
+  }
+});
+
+window.addEventListener("resize", () => {
+  renderTrails();
+});
+
+function buildBoard() {
+  for (let row = 0; row < boardSize; row += 1) {
+    for (let col = 0; col < boardSize; col += 1) {
+      const key = positionKey({ row, col });
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "intersection";
+      button.dataset.row = String(row);
+      button.dataset.col = String(col);
+      button.setAttribute("aria-label", `Intersection ${row + 1}, ${col + 1}`);
+
+      if (positionsEqual({ row, col }, shop)) {
+        button.classList.add("shop");
+        button.textContent = shop.label;
+        button.setAttribute("aria-label", `${shop.name} hub`);
+      } else {
+        const house = houses.find((item) => item.row === row && item.col === col);
+        if (house) {
+          button.classList.add("mansion");
+          button.textContent = house.label;
+          button.setAttribute("aria-label", `${house.name} — ${house.note}`);
+        }
+      }
+
+      boardElement.append(button);
+      nodeLookup.set(key, button);
+    }
+  }
+}
+
+function startShift() {
+  resetShiftState();
+  shiftActive = true;
+  logEvent("Shift started. Orders are dialing in.");
+  updateStatus("Shift in motion. Select an order and chart a path.");
+  startButton.disabled = true;
+  endButton.disabled = false;
+  clearPathButton.disabled = true;
+  enqueueOrders();
+  if (activeOrders.length > 0) {
+    setSelectedOrder(activeOrders[0].id);
+  }
+  tickTimer = window.setInterval(handleTick, 1000);
+  handleTick();
+}
+
+function resetShiftState() {
+  clearActivePath();
+  trails = [];
+  usedEdges = new Set();
+  activeOrders = [];
+  scheduleIndex = 0;
+  deliveredCount = 0;
+  bikeJumpCharges = 1;
+  jumpUsedThisRoute = false;
+  selectedOrderId = null;
+  shiftActive = false;
+  window.clearInterval(tickTimer);
+  tickTimer = null;
+  Array.from(nodeLookup.values()).forEach((node) => {
+    node.classList.remove("is-active", "is-target");
+  });
+  renderTrails();
+  updateJumpStatus();
+  updateDeliveredCount();
+  queueMeterFill.style.width = "100%";
+  queueMeterValue.textContent = "100";
+  queueMeter.setAttribute("aria-valuenow", "100");
+  orderList.innerHTML = "";
+  eventList.innerHTML = "";
+}
+
+function enqueueOrders() {
+  const maxActive = 3;
+  while (activeOrders.length < maxActive && scheduleIndex < orderSchedule.length) {
+    const template = orderSchedule[scheduleIndex];
+    scheduleIndex += 1;
+    const order = {
+      id: template.id,
+      houseId: template.houseId,
+      pizza: template.pizza,
+      duration: template.duration,
+      remaining: template.duration,
+    };
+    activeOrders.push(order);
+    const house = housesById.get(order.houseId);
+    if (house) {
+      logEvent(`Order queued: ${house.name} requests the ${order.pizza}.`);
+    } else {
+      logEvent("An unknown address placed an order.");
+    }
+  }
+  renderOrders();
+  updateQueueMeter();
+}
+
+function handleTick() {
+  if (!shiftActive) {
+    return;
+  }
+
+  let jammedOrder = null;
+  activeOrders.forEach((order) => {
+    order.remaining = Math.max(0, order.remaining - 1);
+    if (order.remaining === 0 && !jammedOrder) {
+      jammedOrder = order;
+    }
+  });
+
+  renderOrders();
+  updateQueueMeter();
+
+  if (jammedOrder) {
+    const house = housesById.get(jammedOrder.houseId);
+    const name = house ? house.name : "a client";
+    triggerTrafficJam(`${name}'s timer expired.`);
+  }
+}
+
+function renderOrders() {
+  orderList.innerHTML = "";
+  activeOrders.forEach((order) => {
+    const house = housesById.get(order.houseId);
+    const item = document.createElement("li");
+    item.className = "order-card";
+    if (order.id === selectedOrderId) {
+      item.classList.add("is-selected");
+    }
+
+    const heading = document.createElement("div");
+    heading.className = "order-heading";
+    const title = document.createElement("strong");
+    title.textContent = house ? house.name : "Unknown Client";
+    const badge = document.createElement("span");
+    badge.textContent = order.id.replace("order-", "#");
+    heading.append(title, badge);
+
+    const detail = document.createElement("div");
+    detail.className = "order-detail";
+    detail.textContent = order.pizza;
+
+    const timerRow = document.createElement("div");
+    timerRow.className = "timer-row";
+    const timerValue = document.createElement("span");
+    timerValue.className = "timer-value";
+    timerValue.textContent = `${order.remaining}s`;
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "route-button";
+    button.dataset.orderId = order.id;
+    button.textContent = order.id === selectedOrderId ? "Routing" : "Route";
+    if (order.id === selectedOrderId) {
+      button.disabled = true;
+    }
+    timerRow.append(timerValue, button);
+
+    item.append(heading, detail, timerRow);
+    orderList.append(item);
+  });
+}
+
+function setSelectedOrder(orderId) {
+  const order = activeOrders.find((item) => item.id === orderId);
+  if (!order) {
+    updateStatus("That order is no longer active.");
+    return;
+  }
+  selectedOrderId = orderId;
+  logEvent(`Routing ${orderId} — keep it hot.`);
+  highlightTarget(order.houseId);
+  clearActivePath();
+  renderOrders();
+  updateStatus("Start from the hub and reach the highlighted mansion.");
+}
+
+function highlightTarget(houseId) {
+  Array.from(nodeLookup.values()).forEach((node) => node.classList.remove("is-target"));
+  const house = housesById.get(houseId);
+  if (!house) {
+    return;
+  }
+  const key = positionKey(house);
+  const node = nodeLookup.get(key);
+  node?.classList.add("is-target");
+}
+
+function getTargetHouse() {
+  if (!selectedOrderId) {
+    return null;
+  }
+  const order = activeOrders.find((item) => item.id === selectedOrderId);
+  if (!order) {
+    return null;
+  }
+  return housesById.get(order.houseId) ?? null;
+}
+
+function finalizeRoute() {
+  const order = activeOrders.find((item) => item.id === selectedOrderId);
+  if (!order) {
+    updateStatus("The selected order vanished.");
+    return;
+  }
+
+  if (activePath.length < 2) {
+    updateStatus("Extend the trail beyond the hub.");
+    return;
+  }
+
+  const newSegments = [];
+  let collision = false;
+
+  for (let index = 1; index < activePath.length; index += 1) {
+    const from = activePath[index - 1];
+    const to = activePath[index];
+    const key = edgeKey(from, to);
+    if (usedEdges.has(key)) {
+      collision = true;
+    } else {
+      newSegments.push({ from, to });
+    }
+  }
+
+  if (collision && bikeJumpCharges === 0 && !jumpUsedThisRoute) {
+    triggerTrafficJam("Route overlapped an existing trail.");
+    return;
+  }
+
+  newSegments.forEach((segment) => {
+    usedEdges.add(edgeKey(segment.from, segment.to));
+    trails.push(segment);
+  });
+
+  deliveredCount += 1;
+  updateDeliveredCount();
+  logEvent(`Delivered ${order.pizza} to ${housesById.get(order.houseId)?.name ?? "a client"}.`);
+  updateStatus("Delivery locked in. Queue up the next order.");
+
+  activeOrders = activeOrders.filter((item) => item.id !== order.id);
+  selectedOrderId = null;
+  jumpUsedThisRoute = false;
+  clearActivePath(true);
+  highlightTarget(null);
+  renderOrders();
+  updateQueueMeter();
+  enqueueOrders();
+
+  if (activeOrders.length === 0 && scheduleIndex >= orderSchedule.length) {
+    endShift(true, "All scheduled clients served. Night complete.");
+  } else if (activeOrders.length > 0) {
+    setSelectedOrder(activeOrders[0].id);
+  }
+}
+
+function triggerTrafficJam(reason) {
+  endShift(false, `Traffic jam! ${reason}`);
+}
+
+function endShift(success, message) {
+  if (!shiftActive && !success) {
+    resetShiftState();
+    updateStatus(message);
+    return;
+  }
+  shiftActive = false;
+  window.clearInterval(tickTimer);
+  tickTimer = null;
+  startButton.disabled = false;
+  endButton.disabled = true;
+  clearPathButton.disabled = true;
+  selectedOrderId = null;
+  clearActivePath();
+  highlightTarget(null);
+  updateStatus(message);
+  if (!success) {
+    activeOrders = [];
+    orderList.innerHTML = "";
+    updateQueueMeter();
+    logEvent(message);
+  } else {
+    logEvent("Shift cleared with every order delivered.");
+  }
+}
+
+function clearActivePath(keepJumpState = false) {
+  activePath.forEach((position) => {
+    const key = positionKey(position);
+    const node = nodeLookup.get(key);
+    node?.classList.remove("is-active");
+  });
+  activePath = [];
+  activeSegments = [];
+  if (!keepJumpState) {
+    jumpUsedThisRoute = false;
+  }
+  renderTrails();
+  updateClearPathState();
+}
+
+function renderTrails() {
+  const rect = boardElement.getBoundingClientRect();
+  overlay.setAttribute("viewBox", `0 0 ${rect.width} ${rect.height}`);
+  overlay.setAttribute("width", String(rect.width));
+  overlay.setAttribute("height", String(rect.height));
+  while (overlay.firstChild) {
+    overlay.removeChild(overlay.firstChild);
+  }
+
+  const drawSegment = (segment, className) => {
+    const fromNode = nodeLookup.get(positionKey(segment.from));
+    const toNode = nodeLookup.get(positionKey(segment.to));
+    if (!fromNode || !toNode) {
+      return;
+    }
+    const fromRect = fromNode.getBoundingClientRect();
+    const toRect = toNode.getBoundingClientRect();
+    const line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+    line.setAttribute("x1", String(fromRect.left - rect.left + fromRect.width / 2));
+    line.setAttribute("y1", String(fromRect.top - rect.top + fromRect.height / 2));
+    line.setAttribute("x2", String(toRect.left - rect.left + toRect.width / 2));
+    line.setAttribute("y2", String(toRect.top - rect.top + toRect.height / 2));
+    line.classList.add(className);
+    overlay.append(line);
+  };
+
+  trails.forEach((segment) => drawSegment(segment, "trail-line"));
+  activeSegments.forEach((segment) => drawSegment(segment, "active-line"));
+}
+
+function updateJumpStatus() {
+  if (bikeJumpCharges > 0) {
+    jumpStatus.classList.add("ready");
+    jumpStatus.classList.remove("spent");
+    jumpStatusText.textContent = "Charge ready. You may vault one locked trail this shift.";
+  } else {
+    jumpStatus.classList.remove("ready");
+    jumpStatus.classList.add("spent");
+    jumpStatusText.textContent = "Charge spent. Future routes must avoid every glowing trail.";
+  }
+}
+
+function updateDeliveredCount() {
+  deliveredCountLabel.textContent = `${deliveredCount} delivered`;
+}
+
+function updateStatus(message) {
+  statusReadout.textContent = message;
+}
+
+function updateQueueMeter() {
+  if (activeOrders.length === 0) {
+    queueMeterFill.style.width = "100%";
+    queueMeterValue.textContent = "100";
+    queueMeter.setAttribute("aria-valuenow", "100");
+    return;
+  }
+  let lowest = 100;
+  activeOrders.forEach((order) => {
+    const percent = Math.round((order.remaining / order.duration) * 100);
+    lowest = Math.min(lowest, percent);
+  });
+  queueMeterFill.style.width = `${lowest}%`;
+  queueMeterValue.textContent = String(lowest);
+  queueMeter.setAttribute("aria-valuenow", String(lowest));
+}
+
+function logEvent(message) {
+  const item = document.createElement("li");
+  item.textContent = message;
+  eventList.prepend(item);
+  while (eventList.children.length > 8) {
+    eventList.removeChild(eventList.lastChild);
+  }
+}
+
+function updateClearPathState() {
+  clearPathButton.disabled = activePath.length === 0;
+}
+
+function positionKey(position) {
+  return `${position.row},${position.col}`;
+}
+
+function positionsEqual(a, b) {
+  return a.row === b.row && a.col === b.col;
+}
+
+function isAdjacent(a, b) {
+  const dr = Math.abs(a.row - b.row);
+  const dc = Math.abs(a.col - b.col);
+  return (dr === 1 && dc === 0) || (dr === 0 && dc === 1);
+}
+
+function edgeKey(a, b) {
+  const first = a.row < b.row || (a.row === b.row && a.col <= b.col) ? a : b;
+  const second = first === a ? b : a;
+  return `${first.row},${first.col}|${second.row},${second.col}`;
+}
+

--- a/madia.new/public/secret/1989/amore-express/index.html
+++ b/madia.new/public/secret/1989/amore-express/index.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Amore Express</title>
+    <link rel="stylesheet" href="amore-express.css" />
+  </head>
+  <body>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 48 · 1989 Arcade</p>
+      <h1>Amore Express</h1>
+      <p class="subtitle">
+        Stage piping-hot pies from Amore Slices to the cul-de-sac clientele without tangling a single scooter trail.
+      </p>
+    </header>
+    <main class="page-layout">
+      <section class="briefing" aria-labelledby="briefing-title">
+        <h2 id="briefing-title">Shift Briefing</h2>
+        <p>
+          Upscale regulars have queued an entire evening of "amore" pies. Streamed orders spill out of the shop and you must
+          draft clean scooter routes that never cross. Every delivered pie locks in a glowing trail that future orders must
+          respect.
+        </p>
+        <ul class="callouts">
+          <li><strong>Order surge:</strong> Up to three mansions can call in at once, each demanding a direct trail before the timer drains.</li>
+          <li><strong>Trail rules:</strong> Trails cannot overlap or reuse segments—any collision triggers a traffic jam that wipes the queue.</li>
+          <li><strong>Bike Jump:</strong> One emergency charge lets you ghost through a single existing segment. Use it once, then it's gone.</li>
+          <li><strong>Success:</strong> Keep the queue clear through every scheduled call to ace the shift.</li>
+        </ul>
+        <section class="routing-guide" aria-labelledby="routing-guide-title">
+          <h3 id="routing-guide-title">Routing Steps</h3>
+          <ol>
+            <li>Select an order from the queue to spotlight the destination mansion.</li>
+            <li>Start from the Amore Slices hub and click adjacent intersections to extend the trail.</li>
+            <li>Reach the mansion before the timer expires to lock the delivery. Clear the path if you need a redo.</li>
+          </ol>
+        </section>
+      </section>
+      <section class="simulator" aria-labelledby="planner-title">
+        <div class="simulator-header">
+          <h2 id="planner-title">Delivery Planner</h2>
+          <div class="simulator-controls">
+            <button type="button" class="action-button" id="start-shift">Start Shift</button>
+            <button type="button" class="action-button" id="end-shift" disabled>End Shift</button>
+            <button type="button" class="action-button" id="clear-path" disabled>Clear Path</button>
+          </div>
+        </div>
+        <p class="simulator-help">
+          Select an active order, begin at the shop, and thread the scooter through open intersections. Paths may only move
+          horizontally or vertically. Crossing an existing glow causes an immediate traffic jam.
+        </p>
+        <div class="harmony-panel" role="group" aria-label="Shift status">
+          <div class="harmony-meter">
+            <span class="meter-label">Queue Health</span>
+            <div class="meter" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100" id="queue-meter">
+              <div class="meter-fill" id="queue-meter-fill" style="width: 100%"></div>
+            </div>
+            <span class="meter-value" id="queue-meter-value">100</span>
+          </div>
+          <div class="status-readout" id="status-readout">Awaiting shift.</div>
+        </div>
+        <div class="simulator-layout">
+          <div class="board-column" aria-label="Delivery grid" role="region">
+            <div class="board" id="delivery-board" role="grid" aria-label="Cul-de-sac intersections"></div>
+            <div class="legend" aria-hidden="true">
+              <span class="legend-item legend-shop">Amore Slices</span>
+              <span class="legend-item legend-mansion">Client Mansion</span>
+              <span class="legend-item legend-trail">Locked Trail</span>
+            </div>
+          </div>
+          <aside class="sidebar" aria-label="Orders and tools">
+            <section class="order-queue" aria-labelledby="order-queue-title">
+              <div class="sidebar-header">
+                <h3 id="order-queue-title">Order Queue</h3>
+                <span class="delivered-count" id="delivered-count">0 delivered</span>
+              </div>
+              <ul id="order-list"></ul>
+            </section>
+            <section class="jump-status" aria-labelledby="jump-status-title">
+              <h3 id="jump-status-title">Bike Jump</h3>
+              <p id="jump-status-text">Charge ready.</p>
+            </section>
+          </aside>
+        </div>
+        <section class="event-log" aria-labelledby="event-log-title">
+          <h3 id="event-log-title">Dispatch Log</h3>
+          <ul id="event-list"></ul>
+        </section>
+      </section>
+    </main>
+    <footer class="page-footer">
+      <p>
+        Tip: Plan exits early. Looping around the cul-de-sac is safer than squeezing past a glowing trail unless you're willing to burn the Bike Jump.
+      </p>
+    </footer>
+    <script type="module" src="amore-express.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- register the Amore Express cabinet in the 1989 arcade roster with themed thumbnail art
- add the Level 48 Amore Express page with briefing, delivery planner UI, and dispatch log
- implement styling and scripting for cul-de-sac routing, timed order queue management, and the single-use Bike Jump mechanic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ded9f93c9c8328ab26377faaa90811