### PR TITLE
Add Dream Team Breakout level to the 1989 arcade

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -68,6 +68,46 @@ const games = [
     `,
   },
   {
+    id: "dream-team-breakout",
+    name: "Dream Team Breakout",
+    description: "Plan six simultaneous moves to sneak the quartet into the stadium gates.",
+    url: "./dream-team-breakout/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Dream Team Breakout preview">
+        <defs>
+          <linearGradient id="cityGlow" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#38bdf8" />
+            <stop offset="100%" stop-color="#7b5bff" />
+          </linearGradient>
+        </defs>
+        <rect x="6" y="6" width="148" height="108" rx="18" fill="rgba(9, 14, 28, 0.95)" stroke="rgba(120,255,255,0.4)" />
+        <g transform="translate(24 20)">
+          <rect x="0" y="0" width="112" height="80" rx="14" fill="rgba(10,18,36,0.9)" stroke="url(#cityGlow)" />
+          <g stroke="rgba(120,255,255,0.25)" stroke-width="1">
+            ${Array.from({ length: 3 }, (_, i) => `<line x1="16" y1="${20 + i * 20}" x2="96" y2="${20 + i * 20}" />`).join("")}
+            ${Array.from({ length: 3 }, (_, i) => `<line x1="${32 + i * 20}" y1="8" x2="${32 + i * 20}" y2="72" />`).join("")}
+          </g>
+          <g>
+            <rect x="84" y="8" width="20" height="16" rx="6" fill="rgba(59,130,246,0.45)" stroke="rgba(56,189,248,0.8)" />
+            <rect x="84" y="32" width="20" height="16" rx="6" fill="rgba(59,130,246,0.3)" stroke="rgba(123,91,255,0.6)" />
+            <rect x="84" y="56" width="20" height="16" rx="6" fill="rgba(59,130,246,0.3)" stroke="rgba(123,91,255,0.6)" />
+          </g>
+          <g>
+            <circle cx="32" cy="20" r="8" fill="#facc15" stroke="rgba(17,24,39,0.85)" />
+            <circle cx="52" cy="20" r="8" fill="#f97316" stroke="rgba(17,24,39,0.85)" />
+            <circle cx="32" cy="44" r="8" fill="#38bdf8" stroke="rgba(17,24,39,0.85)" />
+            <circle cx="52" cy="60" r="8" fill="#ec4899" stroke="rgba(17,24,39,0.85)" />
+          </g>
+          <g stroke="rgba(234,179,8,0.7)" stroke-width="2">
+            <path d="M24 52h20" stroke-dasharray="2 4" />
+            <circle cx="44" cy="52" r="4" fill="rgba(250,204,21,0.35)" />
+          </g>
+          <rect x="20" y="8" width="12" height="12" rx="4" fill="rgba(34,197,94,0.35)" stroke="rgba(34,197,94,0.9)" />
+        </g>
+      </svg>
+    `,
+  },
+  {
     id: "prototype",
     name: "Prototype Cabinet",
     description: "Drop a new game folder in \"secret\" and point the cab here.",

--- a/madia.new/public/secret/1989/dream-team-breakout/dream-team-breakout.css
+++ b/madia.new/public/secret/1989/dream-team-breakout/dream-team-breakout.css
@@ -1,0 +1,545 @@
+:root {
+  color-scheme: dark;
+  font-family: "Space Grotesk", "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --bg: #05060f;
+  --panel: rgba(10, 14, 28, 0.9);
+  --border: rgba(120, 255, 255, 0.35);
+  --border-soft: rgba(120, 255, 255, 0.2);
+  --text: #f8fafc;
+  --muted: rgba(226, 232, 240, 0.7);
+  --accent: #38bdf8;
+  --accent-strong: #7b5bff;
+  --danger: #f97316;
+  --success: #34d399;
+  --token-stepper: #facc15;
+  --token-liner: #f97316;
+  --token-looper: #38bdf8;
+  --token-wildcard: #ec4899;
+  --token-patrol: #94a3b8;
+  --token-plainclothes: #fbbf24;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 12% 10%, rgba(123, 91, 255, 0.18), transparent 55%),
+    radial-gradient(circle at 70% 0%, rgba(56, 189, 248, 0.16), transparent 45%),
+    radial-gradient(circle at 45% 88%, rgba(248, 113, 113, 0.14), transparent 38%),
+    var(--bg);
+  color: var(--text);
+  padding-bottom: 4rem;
+}
+
+.scanlines {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.04),
+    rgba(255, 255, 255, 0.04) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  mix-blend-mode: soft-light;
+  opacity: 0.35;
+  z-index: 0;
+}
+
+.page-header {
+  position: relative;
+  padding: clamp(2rem, 6vw, 4rem) clamp(1.25rem, 4vw, 4rem) 2rem;
+  text-align: center;
+  z-index: 1;
+}
+
+.eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.page-header h1 {
+  margin: 0.75rem 0 0.5rem;
+  font-size: clamp(2.5rem, 8vw, 4.5rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-shadow: 0 12px 36px rgba(56, 189, 248, 0.45);
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1.1rem;
+}
+
+.page-layout {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  padding: 0 clamp(1.25rem, 4vw, 4rem);
+}
+
+@media (min-width: 960px) {
+  .page-layout {
+    grid-template-columns: minmax(260px, 360px) 1fr;
+  }
+}
+
+.briefing,
+.simulator {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  box-shadow: 0 25px 45px -24px rgba(0, 0, 0, 0.85);
+}
+
+.briefing h2,
+.simulator h2,
+.simulator h3 {
+  margin-top: 0;
+}
+
+.callouts {
+  margin: 1rem 0;
+  padding-left: 1.2rem;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.simulator-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.simulator-controls {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.action-button {
+  font: inherit;
+  border: 0;
+  padding: 0.65rem 1.2rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(123, 91, 255, 0.9), rgba(56, 189, 248, 0.9));
+  color: white;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.action-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.action-button:not(:disabled):hover,
+.action-button:not(:disabled):focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 35px -15px rgba(123, 91, 255, 0.75);
+}
+
+.action-button:focus-visible {
+  outline: 2px solid rgba(120, 255, 255, 0.8);
+  outline-offset: 3px;
+}
+
+.simulator-help {
+  margin: 1rem 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.status-panel {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.sanity-gauge {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.meter-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.meter {
+  position: relative;
+  flex: 1;
+  height: 0.75rem;
+  background: rgba(120, 255, 255, 0.12);
+  border-radius: 999px;
+  overflow: hidden;
+  border: 1px solid var(--border-soft);
+}
+
+.meter-fill {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  background: linear-gradient(90deg, rgba(34, 211, 238, 0.9), rgba(123, 91, 255, 0.9));
+  transition: width 220ms ease;
+}
+
+.meter-value {
+  min-width: 4.5rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.status-readout {
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid var(--border-soft);
+  background: rgba(148, 163, 184, 0.08);
+  color: var(--muted);
+  min-height: 3rem;
+  display: flex;
+  align-items: center;
+}
+
+.planner {
+  margin-bottom: 2rem;
+}
+
+.planner-grid {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.looper-config {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.looper-config select {
+  font: inherit;
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--text);
+  border: 1px solid var(--border-soft);
+  border-radius: 0.75rem;
+  padding: 0.4rem 0.75rem;
+}
+
+.wildcard-label {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.direction-sequence {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0.35rem 0 0;
+  list-style: none;
+}
+
+.direction-sequence li {
+  min-width: 2.1rem;
+  padding: 0.35rem 0.4rem;
+  border-radius: 0.6rem;
+  border: 1px solid var(--border-soft);
+  text-align: center;
+  font-weight: 600;
+  background: rgba(120, 255, 255, 0.12);
+}
+
+.direction-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.1rem;
+  padding: 0.3rem 0.5rem;
+  border-radius: 0.6rem;
+  border: 1px solid var(--border-soft);
+  background: rgba(120, 255, 255, 0.12);
+  font-weight: 600;
+  font-size: 0.9rem;
+  line-height: 1;
+  margin-right: 0.35rem;
+}
+
+.planner-table {
+  width: 100%;
+  border-collapse: collapse;
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 1px solid var(--border-soft);
+}
+
+.planner-table th,
+.planner-table td {
+  border-bottom: 1px solid rgba(120, 255, 255, 0.12);
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+}
+
+.planner-table th {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+  color: var(--muted);
+  background: rgba(120, 255, 255, 0.08);
+}
+
+.planner-table td select {
+  font: inherit;
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--text);
+  border: 1px solid rgba(120, 255, 255, 0.2);
+  border-radius: 0.65rem;
+  padding: 0.35rem 0.6rem;
+  width: 100%;
+}
+
+.planner-table tbody tr:nth-child(odd) {
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.city-section {
+  margin-top: 2.25rem;
+}
+
+.city-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.turn-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.turn-button {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 1.2rem;
+  display: grid;
+  place-items: center;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.turn-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.turn-button:not(:disabled):hover,
+.turn-button:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 25px -18px rgba(123, 91, 255, 0.6);
+}
+
+.turn-button:focus-visible {
+  outline: 2px solid rgba(120, 255, 255, 0.8);
+  outline-offset: 3px;
+}
+
+#turn-indicator {
+  font-variant-numeric: tabular-nums;
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 1rem 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.legend-swatch {
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 0.3rem;
+  margin-right: 0.5rem;
+  display: inline-flex;
+  border: 1px solid rgba(120, 255, 255, 0.45);
+}
+
+.legend-swatch--goal {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.4), rgba(123, 91, 255, 0.35));
+}
+
+.legend-swatch--pep {
+  background: linear-gradient(135deg, rgba(250, 204, 21, 0.45), rgba(234, 179, 8, 0.75));
+}
+
+.legend-swatch--traffic {
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.4), rgba(15, 118, 110, 0.6));
+}
+
+.city-grid {
+  position: relative;
+  width: min(520px, 90vw);
+  aspect-ratio: 9 / 7;
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: repeat(9, 1fr);
+  grid-template-rows: repeat(7, 1fr);
+  background: rgba(5, 11, 22, 0.85);
+}
+
+.tile {
+  position: relative;
+  display: grid;
+  place-items: center;
+  font-size: 0.75rem;
+}
+
+.tile.wall {
+  background: linear-gradient(145deg, rgba(10, 12, 24, 0.95), rgba(5, 8, 16, 0.9));
+  border: 1px solid rgba(120, 255, 255, 0.05);
+}
+
+.tile.street {
+  background: linear-gradient(160deg, rgba(12, 20, 40, 0.92), rgba(15, 23, 42, 0.8));
+  border: 1px solid rgba(120, 255, 255, 0.08);
+}
+
+.tile.goal::after {
+  content: "";
+  position: absolute;
+  inset: 12%;
+  border-radius: 0.75rem;
+  border: 2px solid rgba(56, 189, 248, 0.6);
+  background: rgba(123, 91, 255, 0.22);
+}
+
+.tile.pep-talk::after {
+  content: "";
+  position: absolute;
+  width: 55%;
+  height: 55%;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(250, 204, 21, 0.8), rgba(234, 179, 8, 0.4));
+  box-shadow: 0 0 18px rgba(250, 204, 21, 0.35);
+}
+
+.tile.traffic-light {
+  box-shadow: inset 0 0 0 1px rgba(34, 211, 238, 0.35);
+}
+
+.tile.traffic-light::after {
+  content: "";
+  position: absolute;
+  width: 32%;
+  height: 32%;
+  border-radius: 50%;
+  background: rgba(20, 184, 166, 0.3);
+  box-shadow: 0 0 18px rgba(34, 197, 94, 0.25);
+  opacity: 0.35;
+  transition: opacity 160ms ease;
+}
+
+.tile.traffic-light.is-green::after {
+  opacity: 1;
+  background: radial-gradient(circle, rgba(34, 197, 94, 0.85), rgba(74, 222, 128, 0.55));
+}
+
+.token {
+  width: 60%;
+  height: 60%;
+  border-radius: 50%;
+  border: 2px solid rgba(15, 23, 42, 0.9);
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.55);
+  display: grid;
+  place-items: center;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #020617;
+}
+
+.token.patient-stepper {
+  background: var(--token-stepper);
+}
+
+.token.patient-liner {
+  background: var(--token-liner);
+}
+
+.token.patient-looper {
+  background: var(--token-looper);
+}
+
+.token.patient-wildcard {
+  background: var(--token-wildcard);
+}
+
+.token.patrol {
+  background: var(--token-patrol);
+  color: #0f172a;
+}
+
+.token.plainclothes {
+  background: var(--token-plainclothes);
+  color: #0f172a;
+}
+
+.event-log {
+  margin-top: 2rem;
+}
+
+.event-log ol {
+  margin: 0;
+  padding-left: 1.4rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.event-log li {
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.page-footer {
+  margin: 3rem auto 0;
+  max-width: min(720px, 90vw);
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 720px) {
+  .city-grid {
+    width: 100%;
+  }
+}

--- a/madia.new/public/secret/1989/dream-team-breakout/dream-team-breakout.js
+++ b/madia.new/public/secret/1989/dream-team-breakout/dream-team-breakout.js
@@ -1,0 +1,878 @@
+const TURN_COUNT = 6;
+const SANITY_MAX = 3;
+const wildcardDeck = ["S", "E", "S", "E", "S", "E"];
+
+const directionVectors = {
+  N: { dx: 0, dy: -1, name: "North", glyph: "↑" },
+  E: { dx: 1, dy: 0, name: "East", glyph: "→" },
+  S: { dx: 0, dy: 1, name: "South", glyph: "↓" },
+  W: { dx: -1, dy: 0, name: "West", glyph: "←" },
+  WAIT: { dx: 0, dy: 0, name: "Hold", glyph: "•" },
+};
+
+const patients = [
+  {
+    id: "stepper",
+    name: "Stepper",
+    token: "S",
+    start: { x: 1, y: 1 },
+  },
+  {
+    id: "liner",
+    name: "Liner",
+    token: "L",
+    start: { x: 2, y: 1 },
+  },
+  {
+    id: "looper",
+    name: "Looper",
+    token: "O",
+    start: { x: 1, y: 2 },
+  },
+  {
+    id: "wildcard",
+    name: "Wildcard",
+    token: "W",
+    start: { x: 2, y: 2 },
+  },
+];
+
+const walkableTiles = [
+  { x: 1, y: 1 },
+  { x: 2, y: 1 },
+  { x: 3, y: 1 },
+  { x: 4, y: 1 },
+  { x: 5, y: 1 },
+  { x: 1, y: 2 },
+  { x: 2, y: 2 },
+  { x: 3, y: 2 },
+  { x: 4, y: 2 },
+  { x: 5, y: 2 },
+  { x: 6, y: 2 },
+  { x: 7, y: 2 },
+  { x: 1, y: 3 },
+  { x: 2, y: 3 },
+  { x: 3, y: 3 },
+  { x: 5, y: 3 },
+  { x: 6, y: 3 },
+  { x: 7, y: 3 },
+  { x: 2, y: 4 },
+  { x: 3, y: 4 },
+  { x: 4, y: 4 },
+  { x: 5, y: 4 },
+  { x: 6, y: 4 },
+  { x: 7, y: 4 },
+  { x: 3, y: 5 },
+  { x: 4, y: 5 },
+  { x: 5, y: 5 },
+  { x: 6, y: 5 },
+];
+
+const goalTiles = [
+  { x: 4, y: 4 },
+  { x: 5, y: 3 },
+  { x: 7, y: 2 },
+  { x: 5, y: 5 },
+];
+
+const pepTalkTiles = [{ x: 3, y: 4 }];
+
+const trafficLights = new Map([
+  ["3,3", { cycle: [false, true, false, true, false, true], name: "Lex & 53rd" }],
+]);
+
+const patrolRoutes = [
+  {
+    id: "avenue",
+    name: "Avenue patrol",
+    path: [
+      { x: 4, y: 2 },
+      { x: 4, y: 3 },
+      { x: 4, y: 4 },
+      { x: 4, y: 3 },
+    ],
+  },
+  {
+    id: "cross",
+    name: "Cross-town patrol",
+    path: [
+      { x: 6, y: 4 },
+      { x: 6, y: 3 },
+      { x: 6, y: 4 },
+      { x: 6, y: 5 },
+    ],
+  },
+];
+
+const plainclothesSchedule = [{ turn: 2, spawn: { x: 6, y: 3 } }];
+
+const boardWidth = 9;
+const boardHeight = 7;
+
+const streetSet = new Set(walkableTiles.map((tile) => coordKey(tile)));
+const goalSet = new Set(goalTiles.map((tile) => coordKey(tile)));
+const pepTalkSet = new Set(pepTalkTiles.map((tile) => coordKey(tile)));
+
+const cityGrid = document.getElementById("city-grid");
+const plannerBody = document.getElementById("planner-body");
+const runButton = document.getElementById("run-plan");
+const resetButton = document.getElementById("reset-plan");
+const loadExampleButton = document.getElementById("load-example");
+const sanityMeter = document.getElementById("sanity-meter");
+const sanityFill = document.getElementById("sanity-fill");
+const sanityValue = document.getElementById("sanity-value");
+const statusReadout = document.getElementById("status-readout");
+const looperDirectionSelect = document.getElementById("looper-direction");
+const wildcardSequenceList = document.getElementById("wildcard-sequence");
+const eventList = document.getElementById("event-list");
+const prevTurnButton = document.getElementById("prev-turn");
+const nextTurnButton = document.getElementById("next-turn");
+const turnIndicator = document.getElementById("turn-indicator");
+
+const stepperSelects = [];
+const linerSelects = [];
+const tileLookup = new Map();
+const patientTokens = new Map();
+const patrolTokens = [];
+let plainclothesToken = null;
+
+let snapshots = [];
+let currentSnapshotIndex = 0;
+
+function coordKey({ x, y }) {
+  return `${x},${y}`;
+}
+
+function formatCoordinate({ x, y }) {
+  const letter = String.fromCharCode(64 + x);
+  return `${letter}${y}`;
+}
+
+function formatDirection(direction) {
+  const info = directionVectors[direction] ?? directionVectors.WAIT;
+  return `${info.glyph} ${info.name}`;
+}
+
+function createDirectionChip(direction) {
+  const info = directionVectors[direction] ?? directionVectors.WAIT;
+  const span = document.createElement("span");
+  span.className = "direction-chip";
+  span.textContent = info.glyph;
+  span.title = info.name;
+  return span;
+}
+
+function getTrafficLightState(turn) {
+  const greens = new Set();
+  trafficLights.forEach((config, key) => {
+    const cycle = config.cycle;
+    const state = cycle[turn % cycle.length];
+    if (state) {
+      greens.add(key);
+    }
+  });
+  return greens;
+}
+
+function getPatrolPositions(turn) {
+  return patrolRoutes.map((route) => {
+    const pathIndex = turn % route.path.length;
+    return route.path[pathIndex];
+  });
+}
+
+function isWalkable(position) {
+  return (
+    position.x > 0 &&
+    position.y > 0 &&
+    position.x < boardWidth - 1 &&
+    position.y < boardHeight - 1 &&
+    streetSet.has(coordKey(position))
+  );
+}
+
+function buildBoard() {
+  for (let y = 0; y < boardHeight; y += 1) {
+    for (let x = 0; x < boardWidth; x += 1) {
+      const tile = document.createElement("div");
+      tile.classList.add("tile");
+      const interior = x > 0 && x < boardWidth - 1 && y > 0 && y < boardHeight - 1;
+      const key = `${x},${y}`;
+      if (!interior || !streetSet.has(key)) {
+        tile.classList.add("wall");
+      } else {
+        tile.classList.add("street");
+        tile.dataset.coord = key;
+        if (goalSet.has(key)) {
+          tile.classList.add("goal");
+        }
+        if (pepTalkSet.has(key)) {
+          tile.classList.add("pep-talk");
+        }
+        if (trafficLights.has(key)) {
+          tile.classList.add("traffic-light");
+        }
+        tileLookup.set(key, tile);
+      }
+      cityGrid.appendChild(tile);
+    }
+  }
+}
+
+function createTokens() {
+  patients.forEach((patient) => {
+    const token = document.createElement("div");
+    token.classList.add("token", `patient-${patient.id}`);
+    token.textContent = patient.token;
+    patientTokens.set(patient.id, token);
+  });
+
+  patrolRoutes.forEach(() => {
+    const patrolToken = document.createElement("div");
+    patrolToken.classList.add("token", "patrol");
+    patrolToken.textContent = "P";
+    patrolTokens.push(patrolToken);
+  });
+
+  plainclothesToken = document.createElement("div");
+  plainclothesToken.classList.add("token", "plainclothes");
+  plainclothesToken.textContent = "C";
+}
+
+function placeToken(token, position) {
+  const tile = tileLookup.get(coordKey(position));
+  if (tile) {
+    tile.appendChild(token);
+  }
+}
+
+function buildPlanner() {
+  const stepperOptions = ["N", "E", "S", "W"];
+  const linerOptions = ["N", "E", "S", "W", "WAIT"];
+
+  for (let turn = 0; turn < TURN_COUNT; turn += 1) {
+    const row = document.createElement("tr");
+    const turnCell = document.createElement("th");
+    turnCell.scope = "row";
+    turnCell.textContent = String(turn + 1);
+
+    const stepperCell = document.createElement("td");
+    const stepperSelect = document.createElement("select");
+    const stepperPlaceholder = document.createElement("option");
+    stepperPlaceholder.value = "";
+    stepperPlaceholder.textContent = "Select";
+    stepperPlaceholder.disabled = true;
+    stepperPlaceholder.selected = true;
+    stepperSelect.appendChild(stepperPlaceholder);
+    stepperOptions.forEach((option) => {
+      const opt = document.createElement("option");
+      opt.value = option;
+      opt.textContent = formatDirection(option);
+      stepperSelect.appendChild(opt);
+    });
+    stepperCell.appendChild(stepperSelect);
+
+    const linerCell = document.createElement("td");
+    const linerSelect = document.createElement("select");
+    const linerPlaceholder = document.createElement("option");
+    linerPlaceholder.value = "";
+    linerPlaceholder.textContent = "Select";
+    linerPlaceholder.disabled = true;
+    linerPlaceholder.selected = true;
+    linerSelect.appendChild(linerPlaceholder);
+    linerOptions.forEach((option) => {
+      const opt = document.createElement("option");
+      opt.value = option;
+      opt.textContent = formatDirection(option);
+      linerSelect.appendChild(opt);
+    });
+    linerCell.appendChild(linerSelect);
+
+    const looperCell = document.createElement("td");
+    looperCell.dataset.turn = String(turn);
+
+    const wildcardCell = document.createElement("td");
+    const wildcardChip = createDirectionChip(wildcardDeck[turn]);
+    wildcardCell.appendChild(wildcardChip);
+    const wildcardLabel = document.createElement("span");
+    wildcardLabel.textContent = ` ${directionVectors[wildcardDeck[turn]].name}`;
+    wildcardCell.appendChild(wildcardLabel);
+
+    row.appendChild(turnCell);
+    row.appendChild(stepperCell);
+    row.appendChild(linerCell);
+    row.appendChild(looperCell);
+    row.appendChild(wildcardCell);
+
+    plannerBody.appendChild(row);
+    stepperSelects.push(stepperSelect);
+    linerSelects.push(linerSelect);
+  }
+}
+
+function updateLooperColumn(direction) {
+  const info = directionVectors[direction] ?? directionVectors.E;
+  plannerBody.querySelectorAll("td[data-turn]").forEach((cell) => {
+    cell.textContent = "";
+    const chip = createDirectionChip(direction);
+    cell.appendChild(chip);
+    const label = document.createElement("span");
+    label.textContent = ` ${info.name} (locked)`;
+    cell.appendChild(label);
+  });
+}
+
+function renderWildcardSequence() {
+  wildcardDeck.forEach((direction) => {
+    const item = document.createElement("li");
+    const chip = createDirectionChip(direction);
+    item.appendChild(chip);
+    wildcardSequenceList.appendChild(item);
+  });
+}
+
+function resetPlanner() {
+  stepperSelects.forEach((select) => {
+    select.value = "";
+  });
+  linerSelects.forEach((select) => {
+    select.value = "";
+  });
+  looperDirectionSelect.value = "E";
+  updateLooperColumn("E");
+}
+
+function clearEvents() {
+  eventList.innerHTML = "";
+}
+
+function pushEvent(message, type = "info") {
+  const item = document.createElement("li");
+  item.textContent = message;
+  if (type === "warning") {
+    item.style.color = "#f97316";
+  }
+  if (type === "success") {
+    item.style.color = "#34d399";
+  }
+  eventList.appendChild(item);
+}
+
+function setSanity(value) {
+  const clamped = Math.max(0, Math.min(SANITY_MAX, value));
+  sanityMeter.setAttribute("aria-valuenow", String(clamped));
+  const percentage = (clamped / SANITY_MAX) * 100;
+  sanityFill.style.width = `${percentage}%`;
+  sanityValue.textContent = `${clamped} / ${SANITY_MAX}`;
+}
+
+function copyPositions() {
+  const positions = new Map();
+  patients.forEach((patient) => {
+    positions.set(patient.id, { ...patient.start });
+  });
+  return positions;
+}
+
+function findNearestPatient(position, proposals) {
+  let nearest = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  patients.forEach((patient) => {
+    const proposal = proposals.get(patient.id);
+    if (!proposal) {
+      return;
+    }
+    const distance = Math.abs(proposal.origin.x - position.x) + Math.abs(proposal.origin.y - position.y);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      nearest = proposal;
+    }
+  });
+  return nearest;
+}
+
+function applySnapshot(snapshotArray) {
+  snapshots = snapshotArray;
+  currentSnapshotIndex = snapshots.length - 1;
+  renderCurrentSnapshot();
+}
+
+function renderCurrentSnapshot() {
+  const snapshot = snapshots[currentSnapshotIndex];
+  if (!snapshot) {
+    return;
+  }
+
+  patients.forEach((patient) => {
+    const token = patientTokens.get(patient.id);
+    const position = snapshot.positions.get(patient.id);
+    if (token && position) {
+      placeToken(token, position);
+    }
+  });
+
+  patrolTokens.forEach((token) => {
+    token.remove();
+  });
+
+  snapshot.patrols.forEach((position, index) => {
+    const token = patrolTokens[index];
+    placeToken(token, position);
+  });
+
+  plainclothesToken.remove();
+  if (snapshot.plainclothes) {
+    placeToken(plainclothesToken, snapshot.plainclothes);
+  }
+
+  pepTalkSet.forEach((key) => {
+    const tile = tileLookup.get(key);
+    if (tile) {
+      tile.classList.toggle("pep-talk", !snapshot.collectedPepTalks.has(key));
+    }
+  });
+
+  trafficLights.forEach((_, key) => {
+    const tile = tileLookup.get(key);
+    if (tile) {
+      tile.classList.toggle("is-green", snapshot.greenLights.has(key));
+    }
+  });
+
+  setSanity(snapshot.sanity);
+  const turnLabel = `Turn ${snapshot.turn} / ${TURN_COUNT}`;
+  turnIndicator.value = turnLabel;
+  turnIndicator.textContent = turnLabel;
+  prevTurnButton.disabled = currentSnapshotIndex === 0;
+  nextTurnButton.disabled = currentSnapshotIndex === snapshots.length - 1;
+}
+
+function showInitialState() {
+  const initialPositions = new Map();
+  patients.forEach((patient) => {
+    initialPositions.set(patient.id, { ...patient.start });
+  });
+  const initialSnapshot = {
+    turn: 0,
+    positions: initialPositions,
+    patrols: getPatrolPositions(0),
+    plainclothes: null,
+    sanity: SANITY_MAX,
+    greenLights: getTrafficLightState(0),
+    collectedPepTalks: new Set(),
+  };
+  applySnapshot([initialSnapshot]);
+  statusReadout.textContent = "Queue a plan to begin.";
+}
+
+function readPlans() {
+  const stepperPlan = stepperSelects.map((select) => select.value).map((value) => value.trim());
+  const linerPlan = linerSelects.map((select) => select.value).map((value) => value.trim());
+  const looperDirection = looperDirectionSelect.value;
+  return { stepperPlan, linerPlan, looperDirection };
+}
+
+function validatePlans({ stepperPlan, linerPlan }) {
+  const missingStepper = stepperPlan.some((value) => !value);
+  const missingLiner = linerPlan.some((value) => !value);
+  if (missingStepper || missingLiner) {
+    statusReadout.textContent = "Fill every turn for Stepper and Liner before running the simulation.";
+    return false;
+  }
+  return true;
+}
+
+function runSimulation(plan) {
+  const positions = new Map();
+  patients.forEach((patient) => {
+    positions.set(patient.id, { ...patient.start });
+  });
+
+  let sanity = SANITY_MAX;
+  const timeline = [];
+  const eventMessages = [];
+  const log = (message, type = "info") => {
+    eventMessages.push({ message, type });
+  };
+  const collectedPepTalks = new Set();
+  let linerHeading = null;
+  let plainclothes = null;
+  let plainclothesActive = false;
+  let failure = false;
+  let failureMessage = "";
+
+  timeline.push({
+    turn: 0,
+    positions: clonePositions(positions),
+    patrols: getPatrolPositions(0),
+    plainclothes: null,
+    sanity,
+    greenLights: getTrafficLightState(0),
+    collectedPepTalks: new Set(collectedPepTalks),
+  });
+
+  for (let turn = 0; turn < TURN_COUNT; turn += 1) {
+    const greens = getTrafficLightState(turn);
+    const patrolPositions = getPatrolPositions(turn);
+    const proposals = new Map();
+
+    const stepperDirection = plan.stepperPlan[turn];
+    const linerDirection = plan.linerPlan[turn];
+    const wildcardDirection = wildcardDeck[turn];
+
+    const stepperDelta = directionVectors[stepperDirection];
+    if (!stepperDelta || stepperDirection === "WAIT") {
+      failure = true;
+      failureMessage = `Turn ${turn + 1}: Stepper must move exactly one tile per beat.`;
+      log(failureMessage, "warning");
+      sanity -= 1;
+      break;
+    }
+
+    const linerDelta = directionVectors[linerDirection];
+    if (!linerDelta) {
+      failure = true;
+      failureMessage = `Turn ${turn + 1}: Liner needs a direction or a hold.`;
+      log(failureMessage, "warning");
+      sanity -= 1;
+      break;
+    }
+    if (linerDirection === "WAIT") {
+      linerHeading = null;
+    } else {
+      if (linerHeading && linerHeading !== linerDirection) {
+        log(
+          `Turn ${turn + 1}: Liner broke the straight-line rule pivoting from ${directionVectors[linerHeading].name} to ${directionVectors[linerDirection].name}.`,
+          "warning"
+        );
+        sanity -= 1;
+        if (sanity <= 0) {
+          failure = true;
+          failureMessage = "Sanity collapsed after Liner broke formation.";
+          break;
+        }
+      }
+      linerHeading = linerDirection;
+    }
+
+    const looperDelta = directionVectors[plan.looperDirection];
+    if (!looperDelta) {
+      failure = true;
+      failureMessage = `Looper direction "${plan.looperDirection}" is invalid.`;
+      log(failureMessage, "warning");
+      sanity -= 1;
+      break;
+    }
+
+    const wildcardDelta = directionVectors[wildcardDirection];
+
+    const stepperOrigin = positions.get("stepper");
+    const linerOrigin = positions.get("liner");
+    const looperOrigin = positions.get("looper");
+    const wildcardOrigin = positions.get("wildcard");
+
+    proposals.set("stepper", {
+      origin: stepperOrigin,
+      target: {
+        x: stepperOrigin.x + stepperDelta.dx,
+        y: stepperOrigin.y + stepperDelta.dy,
+      },
+      direction: stepperDirection,
+      delta: stepperDelta,
+    });
+
+    if (linerDirection === "WAIT") {
+      proposals.set("liner", {
+        origin: linerOrigin,
+        target: { ...linerOrigin },
+        direction: linerDirection,
+        delta: linerDelta,
+      });
+    } else {
+      proposals.set("liner", {
+        origin: linerOrigin,
+        target: {
+          x: linerOrigin.x + linerDelta.dx,
+          y: linerOrigin.y + linerDelta.dy,
+        },
+        direction: linerDirection,
+        delta: linerDelta,
+      });
+    }
+
+    proposals.set("looper", {
+      origin: looperOrigin,
+      target: {
+        x: looperOrigin.x + looperDelta.dx,
+        y: looperOrigin.y + looperDelta.dy,
+      },
+      direction: plan.looperDirection,
+      delta: looperDelta,
+    });
+
+    proposals.set("wildcard", {
+      origin: wildcardOrigin,
+      target: {
+        x: wildcardOrigin.x + wildcardDelta.dx,
+        y: wildcardOrigin.y + wildcardDelta.dy,
+      },
+      direction: wildcardDirection,
+      delta: wildcardDelta,
+    });
+
+    // Spawn plainclothes if scheduled
+    if (!plainclothesActive) {
+      const schedule = plainclothesSchedule.find((entry) => entry.turn === turn);
+      if (schedule) {
+        plainclothesActive = true;
+        plainclothes = { ...schedule.spawn };
+        log(
+          `Turn ${turn + 1}: Plainclothes tail appears at ${formatCoordinate(plainclothes)} and mirrors the nearest patient.`,
+          "warning"
+        );
+      }
+    }
+
+    // Validate moves against board and traffic lights
+    for (const [id, proposal] of proposals) {
+      if (!isWalkable(proposal.target)) {
+        failure = true;
+        failureMessage = `Turn ${turn + 1}: ${patients.find((p) => p.id === id).name} can't move to ${formatCoordinate(
+          proposal.target
+        )} — that's off the map.`;
+        log(failureMessage, "warning");
+        sanity -= 1;
+        break;
+      }
+      const key = coordKey(proposal.target);
+      if (trafficLights.has(key) && !greens.has(key)) {
+        const light = trafficLights.get(key);
+        failure = true;
+        failureMessage = `Turn ${turn + 1}: ${patients.find((p) => p.id === id).name} ran the red at ${light.name}.`;
+        log(failureMessage, "warning");
+        sanity -= 1;
+        break;
+      }
+    }
+
+    if (failure || sanity <= 0) {
+      break;
+    }
+
+    const occupancy = new Map();
+    for (const [id, proposal] of proposals) {
+      const key = coordKey(proposal.target);
+      if (occupancy.has(key)) {
+        const otherId = occupancy.get(key);
+        failure = true;
+        failureMessage = `Turn ${turn + 1}: ${patients.find((p) => p.id === id).name} collided with ${patients.find(
+          (p) => p.id === otherId
+        ).name} at ${formatCoordinate(proposal.target)}.`;
+        log(failureMessage, "warning");
+        sanity -= 1;
+        break;
+      }
+      occupancy.set(key, id);
+    }
+
+    if (failure || sanity <= 0) {
+      break;
+    }
+
+    // Plainclothes mirrors nearest patient
+    let plainclothesTarget = plainclothes;
+    if (plainclothesActive && plainclothes) {
+      const nearest = findNearestPatient(plainclothes, proposals);
+      if (nearest) {
+        const candidate = {
+          x: plainclothes.x + nearest.delta.dx,
+          y: plainclothes.y + nearest.delta.dy,
+        };
+        if (isWalkable(candidate)) {
+          plainclothesTarget = candidate;
+        }
+      }
+    }
+
+    // Check patrol collisions
+    for (const [id, proposal] of proposals) {
+      if (patrolPositions.some((patrol) => patrol.x === proposal.target.x && patrol.y === proposal.target.y)) {
+        failure = true;
+        failureMessage = `Turn ${turn + 1}: ${patients.find((p) => p.id === id).name} walked straight into a patrol car.`;
+        log(failureMessage, "warning");
+        sanity -= 1;
+        break;
+      }
+    }
+
+    if (failure || sanity <= 0) {
+      break;
+    }
+
+    // Check plainclothes collision
+    if (plainclothesActive && plainclothesTarget) {
+      if (
+        Array.from(proposals.values()).some(
+          (proposal) => proposal.target.x === plainclothesTarget.x && proposal.target.y === plainclothesTarget.y
+        )
+      ) {
+        failure = true;
+        failureMessage = `Turn ${turn + 1}: The plainclothes tail caught up and spooked the crew.`;
+        log(failureMessage, "warning");
+        sanity -= 1;
+        break;
+      }
+    }
+
+    // Apply moves
+    proposals.forEach((proposal, id) => {
+      positions.set(id, { ...proposal.target });
+    });
+
+    if (plainclothesActive && plainclothesTarget) {
+      plainclothes = { ...plainclothesTarget };
+    }
+
+    // Pep talk pickups
+    proposals.forEach((proposal, id) => {
+      const key = coordKey(proposal.target);
+      if (pepTalkSet.has(key) && !collectedPepTalks.has(key)) {
+        collectedPepTalks.add(key);
+        sanity = Math.min(SANITY_MAX, sanity + 1);
+        log(
+          `${patients.find((p) => p.id === id).name} grabbed the pep-talk at ${formatCoordinate(proposal.target)}. Sanity restored.`,
+          "success"
+        );
+      }
+    });
+
+    const moveSummary = `Turn ${turn + 1}: Stepper ${formatDirection(stepperDirection)} to ${formatCoordinate(
+      proposals.get("stepper").target
+    )}; Liner ${formatDirection(linerDirection)} to ${formatCoordinate(proposals.get("liner").target)}; Looper ${formatDirection(
+      plan.looperDirection
+    )} to ${formatCoordinate(proposals.get("looper").target)}; Wildcard ${formatDirection(
+      wildcardDirection
+    )} to ${formatCoordinate(proposals.get("wildcard").target)}`;
+    log(moveSummary);
+
+    timeline.push({
+      turn: turn + 1,
+      positions: clonePositions(positions),
+      patrols: getPatrolPositions(turn),
+      plainclothes: plainclothesActive && plainclothes ? { ...plainclothes } : null,
+      sanity,
+      greenLights: getTrafficLightState(turn + 1),
+      collectedPepTalks: new Set(collectedPepTalks),
+    });
+
+    if (sanity <= 0) {
+      failure = true;
+      failureMessage = "The crew lost their nerve.";
+      break;
+    }
+  }
+
+  if (!failure) {
+    const goalOccupancy = new Set();
+    let allOnGoals = true;
+    patients.forEach((patient) => {
+      const position = positions.get(patient.id);
+      const key = coordKey(position);
+      if (!goalSet.has(key) || goalOccupancy.has(key)) {
+        allOnGoals = false;
+      }
+      goalOccupancy.add(key);
+    });
+    if (allOnGoals) {
+      log("All four patients reached separate stadium gates. Night saved.", "success");
+    } else {
+      failure = true;
+      failureMessage = "They escaped the street beat, but someone missed a stadium gate.";
+      log(failureMessage, "warning");
+    }
+  }
+
+  if (failure && failureMessage) {
+    statusReadout.textContent = failureMessage;
+  } else if (!failure) {
+    statusReadout.textContent = "Success! The quartet slips into the stadium without triggering a chase.";
+  }
+
+  return {
+    timeline,
+    events: eventMessages,
+    success: !failure,
+    sanity,
+  };
+}
+
+function clonePositions(positions) {
+  const cloned = new Map();
+  positions.forEach((value, key) => {
+    cloned.set(key, { ...value });
+  });
+  return cloned;
+}
+
+runButton.addEventListener("click", () => {
+  const plan = readPlans();
+  if (!validatePlans(plan)) {
+    return;
+  }
+  clearEvents();
+  statusReadout.textContent = "Simulating the breakout...";
+  const result = runSimulation(plan);
+  setSanity(result.sanity);
+  applySnapshot(result.timeline);
+  result.events.forEach(({ message, type }) => {
+    pushEvent(message, type);
+  });
+});
+
+resetButton.addEventListener("click", () => {
+  resetPlanner();
+  clearEvents();
+  showInitialState();
+});
+
+loadExampleButton.addEventListener("click", () => {
+  const examplePlan = {
+    stepperPlan: ["S", "E", "S", "E", "S", "E"],
+    linerPlan: ["E", "E", "E", "WAIT", "S", "S"],
+    looperDirection: "E",
+  };
+  stepperSelects.forEach((select, index) => {
+    select.value = examplePlan.stepperPlan[index];
+  });
+  linerSelects.forEach((select, index) => {
+    select.value = examplePlan.linerPlan[index];
+  });
+  looperDirectionSelect.value = examplePlan.looperDirection;
+  updateLooperColumn(examplePlan.looperDirection);
+  statusReadout.textContent = "Example plan loaded. Run it to see the intended route.";
+});
+
+looperDirectionSelect.addEventListener("change", (event) => {
+  updateLooperColumn(event.target.value);
+});
+
+prevTurnButton.addEventListener("click", () => {
+  if (currentSnapshotIndex > 0) {
+    currentSnapshotIndex -= 1;
+    renderCurrentSnapshot();
+  }
+});
+
+nextTurnButton.addEventListener("click", () => {
+  if (currentSnapshotIndex < snapshots.length - 1) {
+    currentSnapshotIndex += 1;
+    renderCurrentSnapshot();
+  }
+});
+
+buildBoard();
+createTokens();
+buildPlanner();
+renderWildcardSequence();
+resetPlanner();
+showInitialState();

--- a/madia.new/public/secret/1989/dream-team-breakout/index.html
+++ b/madia.new/public/secret/1989/dream-team-breakout/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dream Team Breakout</title>
+    <link rel="stylesheet" href="dream-team-breakout.css" />
+  </head>
+  <body>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 49 · 1989 Arcade</p>
+      <h1>Dream Team Breakout</h1>
+      <p class="subtitle">
+        Shepherd four escape artists with clashing quirks through Midtown without rattling their shared sanity meter.
+      </p>
+    </header>
+    <main class="page-layout">
+      <section class="briefing" aria-labelledby="briefing-title">
+        <h2 id="briefing-title">City Desk Briefing</h2>
+        <p>
+          Four patients slipped the hospital shuttle and now have to thread Manhattan together. Queue their moves in advance, let
+          the turn order resolve simultaneously, and land the squad on the highlighted stadium gates before the cops close the net.
+        </p>
+        <ul class="callouts">
+          <li><strong>Stepper:</strong> Moves exactly one tile every turn. No hesitating, no double-steps.</li>
+          <li><strong>Liner:</strong> Keeps walking straight until you make them hold position. A turn of calm lets them pivot.</li>
+          <li><strong>Looper:</strong> Repeats the very first heading you assign forever. Choose wisely.</li>
+          <li><strong>Wildcard:</strong> Already pocketed a cue list. Their pre-shuffled deck shows under Wildcard.</li>
+        </ul>
+        <p>
+          Patrol cars beat the avenues in rhythm and a plainclothes tail mirrors whoever strays closest once they appear. Collide
+          with authority, break a constraint, or run a red light and the shared sanity plummets. Snag the pep-talk pickup to steady
+          nerves on the go.
+        </p>
+      </section>
+      <section class="simulator" aria-labelledby="simulator-title">
+        <div class="simulator-header">
+          <h2 id="simulator-title">Breakout Simulator</h2>
+          <div class="simulator-controls">
+            <button type="button" class="action-button" id="run-plan">Run Plan</button>
+            <button type="button" class="action-button" id="reset-plan">Reset</button>
+            <button type="button" class="action-button" id="load-example">Load Example</button>
+          </div>
+        </div>
+        <p class="simulator-help">
+          Pick a heading for Stepper and Liner each beat. Looper locks to its first direction, and Wildcard's moves are fixed. Hit
+          <em>Run Plan</em> to resolve six simultaneous turns, then scrub through the timeline to review the escape.
+        </p>
+        <section class="status-panel" aria-label="Squad status">
+          <div class="sanity-gauge">
+            <span class="meter-label">Sanity</span>
+            <div class="meter" role="progressbar" aria-valuemin="0" aria-valuemax="3" aria-valuenow="3" id="sanity-meter">
+              <div class="meter-fill" id="sanity-fill" style="width: 100%"></div>
+            </div>
+            <span class="meter-value" id="sanity-value">3 / 3</span>
+          </div>
+          <div class="status-readout" id="status-readout">Queue a plan to begin.</div>
+        </section>
+        <section class="planner" aria-labelledby="planner-title">
+          <h3 id="planner-title">Movement Planner</h3>
+          <div class="planner-grid">
+            <div class="looper-config">
+              <label for="looper-direction">Looper opening direction</label>
+              <select id="looper-direction">
+                <option value="E">East</option>
+                <option value="N">North</option>
+                <option value="S">South</option>
+                <option value="W">West</option>
+              </select>
+            </div>
+            <div class="wildcard-sequence" aria-live="polite">
+              <p class="wildcard-label">Wildcard deck</p>
+              <ol id="wildcard-sequence" class="direction-sequence"></ol>
+            </div>
+          </div>
+          <table class="planner-table">
+            <thead>
+              <tr>
+                <th scope="col">Turn</th>
+                <th scope="col">Stepper</th>
+                <th scope="col">Liner</th>
+                <th scope="col">Looper</th>
+                <th scope="col">Wildcard</th>
+              </tr>
+            </thead>
+            <tbody id="planner-body"></tbody>
+          </table>
+        </section>
+        <section class="city-section" aria-labelledby="city-title">
+          <div class="city-header">
+            <h3 id="city-title">Midtown Overlay</h3>
+            <div class="turn-controls">
+              <button type="button" class="turn-button" id="prev-turn" aria-label="Previous turn">◀</button>
+              <output id="turn-indicator" for="prev-turn next-turn">Turn 0 / 6</output>
+              <button type="button" class="turn-button" id="next-turn" aria-label="Next turn">▶</button>
+            </div>
+          </div>
+          <div class="legend" aria-label="Legend">
+            <p><span class="legend-swatch legend-swatch--goal"></span> Stadium gate</p>
+            <p><span class="legend-swatch legend-swatch--pep"></span> Pep-talk pickup</p>
+            <p><span class="legend-swatch legend-swatch--traffic"></span> Traffic light (green shows per turn)</p>
+          </div>
+          <div class="city-grid" id="city-grid" role="presentation"></div>
+        </section>
+        <section class="event-log" aria-labelledby="event-log-title">
+          <h3 id="event-log-title">Dispatch Log</h3>
+          <ol id="event-list"></ol>
+        </section>
+      </section>
+    </main>
+    <footer class="page-footer">
+      <p>
+        Tip: The crowd distraction on 3rd Street buys you a free sanity pip—thread Stepper through that pep-talk booth before the
+        plainclothes tail mirrors Wildcard into your lane.
+      </p>
+    </footer>
+    <script type="module" src="dream-team-breakout.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add the Dream Team Breakout secret level with planner, timeline review, and dispatch log UI
- implement the turn-based simulator with patrol sweeps, traffic lights, pep-talk pickups, and plainclothes mirroring logic
- register the new cabinet thumbnail and metadata in the 1989 arcade catalog

## Testing
- not run (static assets)

------
https://chatgpt.com/codex/tasks/task_e_68deda298f4c8328b6370dcd491b6e39