### PR TITLE
Add ComfyUI batch workflow for 1989 asset generation

### DIFF
--- a/docs/1989/comfyui/README.md
+++ b/docs/1989/comfyui/README.md
@@ -1,0 +1,97 @@
+# 1989 ComfyUI Batch Asset Workflow
+
+This guide explains how to turn the AI-authored art directions for the 1989 games into actual pixel assets by batching them through ComfyUI.  The package contains:
+
+- `workflow_1989_assets.json` — a reusable text-to-image workflow that exposes every setting we need for the anthology sprites.
+- `queue_1989_assets.py` — a helper that reads an asset spec JSON file and queues the workflow once for each entry.
+- `example_asset_spec.json` — a starter prompt set for smoke testing the pipeline.
+
+Follow the steps below to plug the generator straight into your local ComfyUI install.
+
+## 1. Prepare ComfyUI
+
+1. Install the base project by following the [official quick-start](https://github.com/comfyanonymous/ComfyUI#installation).  Start ComfyUI and make sure you can open `http://127.0.0.1:8188` in a browser.
+2. Drop any Stable Diffusion checkpoints, VAEs, LoRA files, or custom embeddings you plan to use into the standard `ComfyUI/models/...` folders so the workflow can locate them.
+3. (Optional) Install the [ComfyUI Manager](https://github.com/ltdrdata/ComfyUI-Manager) to simplify updating nodes and downloading new models.
+
+## 2. Understand the asset spec format
+
+The helper script expects a JSON array.  Each object describes the look, framing, and file naming for one sprite:
+
+```json
+[
+  {
+    "id": "level_50_title",
+    "positive": "isometric pixel art trophy cabinet, brushed metal, 32 color palette, cinematic rim light",
+    "negative": "low detail, photo, text watermark",
+    "model": "sdxl_base_1.0.safetensors",
+    "vae": "sdxl_vae.safetensors",
+    "sampler": "dpmpp_2m_sde",
+    "scheduler": "karras",
+    "steps": 30,
+    "cfg": 6.5,
+    "seed": 19890001,
+    "width": 512,
+    "height": 512,
+    "output_prefix": "1989/level_50/title"
+  }
+]
+```
+
+| Field | Purpose | Notes |
+| --- | --- | --- |
+| `id` | Human-friendly name stored in the render metadata. | Required, must be unique per file. |
+| `positive` | Prompt describing what the sprite should look like. | Required. |
+| `negative` | Optional safety filter prompt. | Defaults to the workflow value when omitted. |
+| `model` | Exact filename of the checkpoint in `ComfyUI/models/checkpoints`. | Falls back to the workflow default if missing. |
+| `vae` | Optional explicit VAE filename. | Leave blank to use the checkpoint's default VAE. |
+| `sampler` & `scheduler` | Any sampler/scheduler pair supported by your ComfyUI build. | Both fields are optional; omit to use the workflow defaults. |
+| `steps`, `cfg`, `seed` | Diffusion parameters. | `seed` of `-1` tells ComfyUI to randomize. |
+| `width`, `height` | Canvas size for the sprite. | Must be multiples of 8. |
+| `output_prefix` | Subdirectory-friendly name inserted before the numeric filename. | If absent the script uses the `id`. |
+
+## 3. Import the workflow
+
+1. Start ComfyUI and open the web UI.
+2. Choose **Load** → **Import Workflow** and select `workflow_1989_assets.json` from this repo.
+3. Verify that the `Checkpoint Loader`, `CLIPTextEncode` nodes, and `Save Image` node have sensible defaults for your machine (model paths, output folders, etc.).  Adjust and then save the workflow once so ComfyUI remembers your preferred defaults.
+
+The workflow sticks closely to the [ComfyUI basics tutorial](https://docs.comfy.org/tutorials/basic/text-to-image): it loads a checkpoint, encodes positive/negative prompts, runs a sampler, decodes with the VAE, and writes files.  The only customization is that the save nodes use `{id}` placeholders so the helper script can format filenames and metadata deterministically.
+
+## 4. Queue renders from JSON
+
+Use the helper script to read an asset spec file and queue prompts via ComfyUI's REST API.
+
+```bash
+python docs/1989/comfyui/queue_1989_assets.py \
+  --workflow docs/1989/comfyui/workflow_1989_assets.json \
+  --json docs/1989/comfyui/example_asset_spec.json \
+  --server http://127.0.0.1:8188
+```
+
+The script will:
+
+1. Load the workflow template.
+2. Read every asset object in the JSON array.
+3. Merge the per-asset overrides into the workflow inputs.
+4. Queue the finished prompt with the `/prompt` endpoint and print the queue ID.
+
+Because each asset submission is independent you can keep ComfyUI open, tweak nodes, or cancel individual jobs through the UI without touching the rest of the batch.
+Run with `--dry-run` to inspect the generated payloads before you start the queue.
+
+## 5. Tips for the 1989 anthology
+
+- Keep palette and pixel dimensions tight (32×32, 64×64, 128×128) when recreating NES-era sprites.  Oversample at 2× size if you want to manually downscale after export.
+- Capture the film inspiration through props, costumes, or lighting cues instead of literal title drops, per the anthology rules.
+- Store the JSON files alongside their puzzle design docs so that future revisions are traceable.
+
+## 6. Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| Images save to an unexpected directory. | Update the `output_path` widget on the `Save Image` node before queuing jobs. |
+| ComfyUI throws `Cannot find model`. | Confirm the `model` field in JSON matches a file inside `ComfyUI/models/checkpoints`. |
+| `queue_1989_assets.py` hangs. | Ensure ComfyUI is running and that the `--server` URL is reachable. |
+| Rendered size is wrong. | Check that `width`/`height` exist for that asset and that they are divisible by 8. |
+
+Once set up, you can duplicate JSON files per game and re-run the helper to rebuild art whenever prompts change.

--- a/docs/1989/comfyui/example_asset_spec.json
+++ b/docs/1989/comfyui/example_asset_spec.json
@@ -1,0 +1,31 @@
+[
+  {
+    "id": "level_50_title",
+    "positive": "isometric pixel art trophy cabinet, brushed metal, 32 color palette, cinematic rim light",
+    "negative": "low detail, photo, text watermark",
+    "model": "sdxl_base_1.0.safetensors",
+    "vae": "sdxl_vae.safetensors",
+    "sampler": "dpmpp_2m_sde",
+    "scheduler": "karras",
+    "steps": 30,
+    "cfg": 6.5,
+    "seed": 19890001,
+    "width": 512,
+    "height": 512,
+    "output_prefix": "1989/level_50/title"
+  },
+  {
+    "id": "level_49_avatar",
+    "positive": "16-bit arcade hero, leather jacket, neon skyline backdrop, stylized pixel art portrait",
+    "negative": "photo, blur, extra limbs",
+    "model": "sdxl_base_1.0.safetensors",
+    "sampler": "euler",
+    "scheduler": "normal",
+    "steps": 28,
+    "cfg": 7,
+    "seed": 19890002,
+    "width": 384,
+    "height": 512,
+    "output_prefix": "1989/level_49/avatar"
+  }
+]

--- a/docs/1989/comfyui/queue_1989_assets.py
+++ b/docs/1989/comfyui/queue_1989_assets.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Queue ComfyUI jobs for the 1989 anthology assets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+DEFAULT_SERVER = "http://127.0.0.1:8188"
+
+
+class WorkflowDefaults:
+    """Convenience wrapper for reading the exported workflow template."""
+
+    def __init__(self, workflow: Dict[str, Any]):
+        nodes = {node["id"]: node for node in workflow.get("nodes", [])}
+        try:
+            self.checkpoint = nodes[1]
+            self.positive = nodes[2]
+            self.negative = nodes[3]
+            self.latent = nodes[4]
+            self.sampler = nodes[5]
+            self.vae_decode = nodes[6]
+            self.metadata = nodes[7]
+            self.save = nodes[8]
+        except KeyError as exc:
+            raise KeyError("workflow_1989_assets.json is missing an expected node") from exc
+
+        self.model_name = self._widget_value(self.checkpoint, 0)
+        self.vae_name = self._widget_value(self.checkpoint, 1)
+        self.clip_name = self._widget_value(self.checkpoint, 2)
+        self.positive_prompt = self._widget_value(self.positive, 0)
+        self.negative_prompt = self._widget_value(self.negative, 0)
+        self.width = self._widget_value(self.latent, 0)
+        self.height = self._widget_value(self.latent, 1)
+        self.batch_size = self._widget_value(self.latent, 2, 1)
+        self.seed = self._widget_value(self.sampler, 0)
+        self.steps = self._widget_value(self.sampler, 1)
+        self.cfg = self._widget_value(self.sampler, 2)
+        self.sampler_name = self._widget_value(self.sampler, 3)
+        self.scheduler = self._widget_value(self.sampler, 4)
+        self.denoise = self._widget_value(self.sampler, 5, 1)
+        self.metadata_key = self._widget_value(self.metadata, 0, "asset_id")
+        self.metadata_value = self._widget_value(self.metadata, 1, "{id}")
+        self.output_prefix = self._widget_value(self.save, 0)
+
+    @staticmethod
+    def _widget_value(node: Dict[str, Any], index: int, fallback: Any | None = None) -> Any:
+        values: List[Any] = node.get("widgets_values", [])
+        if index < len(values):
+            return values[index]
+        if fallback is not None:
+            return fallback
+        raise IndexError(f"Node {node.get('id')} is missing widget index {index}")
+
+
+def load_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def build_prompt(asset: Dict[str, Any], defaults: WorkflowDefaults) -> Dict[str, Any]:
+    asset_id = asset.get("id")
+    if not asset_id:
+        raise ValueError("Every asset object must include an 'id' field")
+
+    positive = asset.get("positive", defaults.positive_prompt)
+    negative = asset.get("negative", defaults.negative_prompt)
+    width = int(asset.get("width", defaults.width))
+    height = int(asset.get("height", defaults.height))
+    seed = int(asset.get("seed", defaults.seed))
+    steps = int(asset.get("steps", defaults.steps))
+    cfg = float(asset.get("cfg", defaults.cfg))
+    sampler_name = asset.get("sampler", defaults.sampler_name)
+    scheduler = asset.get("scheduler", defaults.scheduler)
+    model_name = asset.get("model", defaults.model_name)
+    vae_name = asset.get("vae", defaults.vae_name)
+
+    prefix_base = asset.get("output_prefix")
+    if prefix_base:
+        filename_prefix = prefix_base
+    else:
+        filename_prefix = f"{defaults.output_prefix}/{asset_id}"
+
+    metadata_value = defaults.metadata_value.replace("{id}", asset_id)
+
+    prompt = {
+        "1": {
+            "inputs": {
+                "ckpt_name": model_name,
+                "vae_name": vae_name,
+                "clip_name": defaults.clip_name,
+            },
+            "class_type": "CheckpointLoaderSimple",
+        },
+        "2": {
+            "inputs": {
+                "text": positive,
+                "clip": ["1", 1],
+            },
+            "class_type": "CLIPTextEncode",
+        },
+        "3": {
+            "inputs": {
+                "text": negative,
+                "clip": ["1", 1],
+            },
+            "class_type": "CLIPTextEncode",
+        },
+        "4": {
+            "inputs": {
+                "width": width,
+                "height": height,
+                "batch_size": defaults.batch_size,
+            },
+            "class_type": "EmptyLatentImage",
+        },
+        "5": {
+            "inputs": {
+                "seed": seed,
+                "steps": steps,
+                "cfg": cfg,
+                "sampler_name": sampler_name,
+                "scheduler": scheduler,
+                "denoise": defaults.denoise,
+                "model": ["1", 0],
+                "positive": ["2", 0],
+                "negative": ["3", 0],
+                "latent_image": ["4", 0],
+            },
+            "class_type": "KSampler",
+        },
+        "6": {
+            "inputs": {
+                "samples": ["5", 0],
+                "vae": ["1", 2],
+            },
+            "class_type": "VAEDecode",
+        },
+        "7": {
+            "inputs": {
+                "images": ["6", 0],
+                "field_name": defaults.metadata_key,
+                "field_value": metadata_value,
+            },
+            "class_type": "SetMetadata",
+        },
+        "8": {
+            "inputs": {
+                "images": ["7", 0],
+                "filename_prefix": filename_prefix,
+                "filename_suffix": "",
+            },
+            "class_type": "SaveImage",
+        },
+    }
+
+    # Prune empty vae_name so ComfyUI uses the checkpoint default.
+    if not vae_name:
+        prompt["1"]["inputs"].pop("vae_name", None)
+
+    return prompt
+
+
+def queue_prompt(server: str, prompt: Dict[str, Any], client_id: str) -> Dict[str, Any]:
+    payload = json.dumps({"prompt": prompt, "client_id": client_id}).encode("utf-8")
+    request = urllib.request.Request(
+        url=f"{server.rstrip('/')}/prompt",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request) as response:
+        return json.load(response)
+
+
+def iter_assets(path: Path) -> Iterable[Dict[str, Any]]:
+    data = load_json(path)
+    if not isinstance(data, list):
+        raise ValueError("Asset spec must be a JSON array")
+    for entry in data:
+        if not isinstance(entry, dict):
+            raise ValueError("Each asset entry must be a JSON object")
+        yield entry
+
+
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workflow", required=True, type=Path, help="Path to workflow_1989_assets.json")
+    parser.add_argument("--json", required=True, type=Path, help="Asset specification JSON file")
+    parser.add_argument("--server", default=DEFAULT_SERVER, help="ComfyUI server URL (default: %(default)s)")
+    parser.add_argument("--dry-run", action="store_true", help="Print prompts instead of queuing them")
+
+    args = parser.parse_args(argv)
+
+    workflow_data = load_json(args.workflow)
+    defaults = WorkflowDefaults(workflow_data)
+
+    try:
+        assets = list(iter_assets(args.json))
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    if not assets:
+        parser.error("No assets found in the specification file")
+
+    for asset in assets:
+        prompt = build_prompt(asset, defaults)
+        client_id = asset.get("id", "1989")
+        if args.dry_run:
+            json.dump({"prompt": prompt, "client_id": client_id}, sys.stdout, indent=2)
+            sys.stdout.write("\n")
+            continue
+
+        try:
+            result = queue_prompt(args.server, prompt, client_id)
+        except urllib.error.URLError as exc:
+            parser.error(f"Failed to reach ComfyUI at {args.server}: {exc}")
+        else:
+            queue_id = result.get("prompt_id", "<unknown>")
+            print(f"Queued {asset['id']} as prompt {queue_id}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/docs/1989/comfyui/workflow_1989_assets.json
+++ b/docs/1989/comfyui/workflow_1989_assets.json
@@ -1,0 +1,159 @@
+{
+  "last_node_id": 8,
+  "last_link_id": 9,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "CheckpointLoaderSimple",
+      "pos": [-420, -60],
+      "size": [320, 180],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "outputs": [
+        {"name": "MODEL", "type": "MODEL", "links": [1]},
+        {"name": "CLIP", "type": "CLIP", "links": [2]},
+        {"name": "VAE", "type": "VAE", "links": [3]}
+      ],
+      "properties": {"Node name for S&R": "CheckpointLoaderSimple"},
+      "widgets_values": [
+        "sdxl_base_1.0.safetensors",
+        "sdxl_vae.safetensors",
+        "clip_g.safetensors"
+      ]
+    },
+    {
+      "id": 2,
+      "type": "CLIPTextEncode",
+      "pos": [-120, -200],
+      "size": [280, 140],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": {"clip": [1, "CLIP"]},
+      "outputs": [{"name": "CONDITIONING", "type": "CONDITIONING", "links": [4]}],
+      "properties": {"Node name for S&R": "Positive Prompt"},
+      "widgets_values": [
+        "pixel art hero standing beneath neon skyline, 1980s, cinematic lighting"
+      ]
+    },
+    {
+      "id": 3,
+      "type": "CLIPTextEncode",
+      "pos": [-120, -20],
+      "size": [280, 140],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": {"clip": [1, "CLIP"]},
+      "outputs": [{"name": "CONDITIONING", "type": "CONDITIONING", "links": [5]}],
+      "properties": {"Node name for S&R": "Negative Prompt"},
+      "widgets_values": [
+        "blurry, photo, disfigured, text watermark"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "EmptyLatentImage",
+      "pos": [-120, 160],
+      "size": [220, 180],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "outputs": [{"name": "LATENT", "type": "LATENT", "links": [6]}],
+      "properties": {"Node name for S&R": "EmptyLatentImage"},
+      "widgets_values": [512, 512, 1]
+    },
+    {
+      "id": 5,
+      "type": "KSampler",
+      "pos": [200, -60],
+      "size": [340, 260],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": {
+        "model": [1, "MODEL"],
+        "positive": [2, "CONDITIONING"],
+        "negative": [3, "CONDITIONING"],
+        "latent_image": [4, "LATENT"]
+      },
+      "outputs": [{"name": "LATENT", "type": "LATENT", "links": [7]}],
+      "properties": {"Node name for S&R": "KSampler"},
+      "widgets_values": [
+        1989,
+        30,
+        6.5,
+        "dpmpp_2m_sde",
+        "karras",
+        1
+      ]
+    },
+    {
+      "id": 6,
+      "type": "VAEDecode",
+      "pos": [560, -40],
+      "size": [260, 180],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": {
+        "samples": [5, "LATENT"],
+        "vae": [1, "VAE"]
+      },
+      "outputs": [{"name": "IMAGE", "type": "IMAGE", "links": [8]}],
+      "properties": {"Node name for S&R": "VAEDecode"}
+    },
+    {
+      "id": 7,
+      "type": "SetMetadata",
+      "pos": [560, 140],
+      "size": [260, 200],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": {
+        "images": [6, "IMAGE"]
+      },
+      "outputs": [{"name": "IMAGE", "type": "IMAGE", "links": [9]}],
+      "properties": {"Node name for S&R": "SetMetadata"},
+      "widgets_values": [
+        "asset_id",
+        "{id}"
+      ]
+    },
+    {
+      "id": 8,
+      "type": "SaveImage",
+      "pos": [840, 40],
+      "size": [300, 200],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": {
+        "images": [7, "IMAGE"]
+      },
+      "properties": {"Node name for S&R": "SaveImage"},
+      "widgets_values": [
+        "1989_assets/output",
+        "png",
+        true,
+        0,
+        "CUSTOM",
+        "{id}"
+      ]
+    }
+  ],
+  "links": [
+    [1, 1, 0, 5, 0, "MODEL"],
+    [2, 1, 1, 2, 0, "CLIP"],
+    [3, 1, 2, 6, 1, "VAE"],
+    [4, 2, 0, 5, 1, "CONDITIONING"],
+    [5, 3, 0, 5, 2, "CONDITIONING"],
+    [6, 4, 0, 5, 3, "LATENT"],
+    [7, 5, 0, 6, 0, "LATENT"],
+    [8, 6, 0, 7, 0, "IMAGE"],
+    [9, 7, 0, 8, 0, "IMAGE"]
+  ],
+  "groups": []
+}


### PR DESCRIPTION
## Summary
- add documentation for running a ComfyUI text-to-image workflow that batches JSON-defined 1989 assets
- provide workflow template, helper script, and example asset specification for repeatable art exports

## Testing
- `python docs/1989/comfyui/queue_1989_assets.py --workflow docs/1989/comfyui/workflow_1989_assets.json --json docs/1989/comfyui/example_asset_spec.json --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68dede3ac1888328aeb613065e57248b