### PR TITLE
Fix hidden overlay on 1989 arcade index

### DIFF
--- a/madia.new/public/secret/1989/1989.css
+++ b/madia.new/public/secret/1989/1989.css
@@ -16,6 +16,10 @@
   box-sizing: border-box;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 body {
   margin: 0;
   min-height: 100vh;


### PR DESCRIPTION
## Summary
- ensure the 1989 arcade overlay respects the hidden attribute so the game grid is visible on load

## Testing
- Manual QA: Loaded `http://localhost:5000/secret/1989/index.html` in a browser


------
https://chatgpt.com/codex/tasks/task_e_68dee0456534832883e0506181e40318