### PR TITLE
Add Paper Trail Blaze level to the 1989 arcade

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -242,6 +242,45 @@ const games = [
       </svg>
     `,
   },
+  {
+    id: "paper-trail-blaze",
+    name: "Paper Trail Blaze",
+    description: "Guide the bill past Blaze's scandals and into the archives before Capital dries up.",
+    url: "./blaze/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Paper Trail Blaze preview">
+        <defs>
+          <linearGradient id="deskGlow" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#5eead4" />
+            <stop offset="100%" stop-color="#38bdf8" />
+          </linearGradient>
+          <linearGradient id="scandalGlow" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stop-color="#f97316" />
+            <stop offset="100%" stop-color="#ef4444" />
+          </linearGradient>
+          <linearGradient id="paperTrail" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(94,234,212,0.7)" />
+            <stop offset="100%" stop-color="rgba(14,165,233,0.45)" />
+          </linearGradient>
+        </defs>
+        <rect x="8" y="8" width="144" height="104" rx="18" fill="rgba(6,10,22,0.92)" stroke="rgba(148,163,184,0.35)" />
+        <rect x="18" y="22" width="56" height="76" rx="12" fill="rgba(15,23,42,0.88)" stroke="url(#deskGlow)" />
+        <rect x="86" y="22" width="56" height="76" rx="12" fill="rgba(15,23,42,0.88)" stroke="url(#scandalGlow)" />
+        <g stroke="rgba(94,234,212,0.6)" stroke-width="3" stroke-linecap="round">
+          <path d="M42 36 C42 60 64 48 64 72" fill="none" />
+          <path d="M64 72 C70 84 90 82 96 94" fill="none" />
+        </g>
+        <g stroke="rgba(248,113,113,0.5)" stroke-width="3" stroke-linecap="round">
+          <path d="M112 36 C120 48 124 60 122 72" fill="none" />
+          <path d="M122 72 C118 86 98 88 96 94" fill="none" stroke-dasharray="4 4" />
+        </g>
+        <rect x="34" y="30" width="22" height="32" rx="8" fill="url(#paperTrail)" stroke="rgba(94,234,212,0.8)" />
+        <circle cx="118" cy="40" r="10" fill="rgba(248,113,113,0.75)" stroke="rgba(248,113,113,0.9)" />
+        <circle cx="98" cy="90" r="8" fill="rgba(251,191,36,0.75)" stroke="rgba(251,191,36,0.9)" />
+        <rect x="102" y="70" width="18" height="20" rx="6" fill="rgba(148,163,184,0.35)" stroke="rgba(148,163,184,0.6)" />
+      </svg>
+    `,
+  },
 ];
 
 const grid = document.getElementById("game-grid");

--- a/madia.new/public/secret/1989/blaze/blaze.css
+++ b/madia.new/public/secret/1989/blaze/blaze.css
@@ -1,0 +1,473 @@
+:root {
+  color-scheme: dark;
+  font-family: "Space Grotesk", "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --bg: #04060f;
+  --panel: rgba(9, 13, 24, 0.92);
+  --border: rgba(94, 234, 212, 0.4);
+  --border-soft: rgba(94, 234, 212, 0.18);
+  --text: #f8fafc;
+  --muted: rgba(226, 232, 240, 0.72);
+  --bill: linear-gradient(135deg, rgba(94, 234, 212, 0.85), rgba(20, 184, 166, 0.7));
+  --scandal: linear-gradient(135deg, rgba(248, 113, 113, 0.85), rgba(239, 68, 68, 0.65));
+  --shadow-bill: 0 0 14px rgba(94, 234, 212, 0.45);
+  --shadow-scandal: 0 0 14px rgba(248, 113, 113, 0.45);
+  --meter: rgba(251, 191, 36, 0.75);
+  --danger: #f97316;
+  --success: #34d399;
+  --barricade: rgba(30, 41, 59, 0.9);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 12% 10%, rgba(94, 234, 212, 0.18), transparent 55%),
+    radial-gradient(circle at 88% 12%, rgba(248, 113, 113, 0.18), transparent 50%),
+    radial-gradient(circle at 48% 85%, rgba(250, 204, 21, 0.12), transparent 40%),
+    var(--bg);
+  color: var(--text);
+  padding-bottom: 4rem;
+}
+
+.scanlines {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.04),
+    rgba(255, 255, 255, 0.04) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  mix-blend-mode: soft-light;
+  opacity: 0.35;
+  z-index: 0;
+}
+
+.page-header {
+  position: relative;
+  padding: clamp(2rem, 6vw, 4rem) clamp(1.25rem, 4vw, 4rem) 2rem;
+  text-align: center;
+  z-index: 1;
+}
+
+.eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.page-header h1 {
+  margin: 0.75rem 0 0.5rem;
+  font-size: clamp(2.5rem, 8vw, 4.5rem);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-shadow: 0 12px 36px rgba(94, 234, 212, 0.45);
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1.1rem;
+}
+
+.page-layout {
+  position: relative;
+  display: grid;
+  gap: clamp(1.5rem, 5vw, 3.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  padding: 0 clamp(1.25rem, 5vw, 4rem) 3rem;
+  z-index: 1;
+}
+
+.briefing,
+.arena {
+  background: var(--panel);
+  border-radius: 28px;
+  border: 1px solid var(--border-soft);
+  padding: clamp(1.5rem, 4vw, 2.75rem);
+  box-shadow: 0 30px 60px rgba(7, 89, 133, 0.18);
+}
+
+.briefing h2,
+.arena h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.briefing p {
+  margin-top: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.callouts {
+  margin: 1.25rem 0;
+  padding-left: 1.25rem;
+  color: var(--muted);
+}
+
+.callouts li + li {
+  margin-top: 0.65rem;
+}
+
+.controls dl {
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.controls dt {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+.controls dd {
+  margin: 0.15rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.key-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.05rem 0.35rem;
+  border-radius: 0.35rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  font-family: "JetBrains Mono", "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
+  font-size: 0.8rem;
+}
+
+.arena-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.arena-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.mode-toggle,
+.piece-palette {
+  display: inline-flex;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: 0.25rem;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.mode-button,
+.palette-button,
+.action-button {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.mode-button[aria-pressed="true"],
+.palette-button[aria-pressed="true"] {
+  background: linear-gradient(135deg, rgba(94, 234, 212, 0.35), rgba(59, 130, 246, 0.25));
+  box-shadow: 0 8px 20px rgba(59, 130, 246, 0.25);
+}
+
+.mode-button:hover,
+.palette-button:hover,
+.action-button:hover {
+  transform: translateY(-1px);
+  background: rgba(94, 234, 212, 0.18);
+}
+
+.action-button {
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.65);
+}
+
+.status-bar {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.75);
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.capital-meter {
+  margin-top: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--meter);
+}
+
+.capital-meter.low {
+  color: var(--danger);
+}
+
+.capital-meter.strong {
+  color: var(--success);
+}
+
+.board {
+  margin-top: 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.35rem;
+  background: rgba(2, 6, 23, 0.6);
+  padding: 0.85rem;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.tile {
+  position: relative;
+  width: 100%;
+  padding-top: 100%;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(51, 65, 85, 0.6);
+  cursor: pointer;
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.tile:hover {
+  border-color: rgba(94, 234, 212, 0.65);
+  transform: translateY(-1px);
+}
+
+.tile.locked,
+.tile.disabled {
+  cursor: default;
+  border-color: rgba(148, 163, 184, 0.45);
+}
+
+.tile-content {
+  position: absolute;
+  inset: 12%;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tile.start {
+  background: linear-gradient(135deg, rgba(94, 234, 212, 0.75), rgba(59, 130, 246, 0.6));
+  border-color: rgba(94, 234, 212, 0.9);
+}
+
+.tile.goal {
+  background: linear-gradient(135deg, rgba(250, 204, 21, 0.8), rgba(251, 191, 36, 0.6));
+  border-color: rgba(250, 204, 21, 0.85);
+}
+
+.tile.source {
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.78), rgba(190, 24, 93, 0.6));
+  border-color: rgba(248, 113, 113, 0.9);
+}
+
+.tile.archive {
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.45), rgba(71, 85, 105, 0.6));
+  border-style: dashed;
+}
+
+.tile.barricade {
+  background: var(--barricade);
+  border-style: dashed;
+  cursor: not-allowed;
+}
+
+.segment {
+  position: absolute;
+  inset: 24% 10%;
+  border-radius: 10px;
+  background: var(--bill);
+  box-shadow: var(--shadow-bill);
+}
+
+.segment.bill {
+  background: var(--bill);
+  box-shadow: var(--shadow-bill);
+}
+
+.segment.scandal {
+  background: var(--scandal);
+  box-shadow: var(--shadow-scandal);
+}
+
+.segment.straight.horizontal {
+  inset: 40% 12%;
+}
+
+.segment.straight.vertical {
+  inset: 12% 40%;
+}
+
+.segment.corner {
+  inset: 12%;
+}
+
+.segment.corner.ne {
+  clip-path: polygon(0% 0%, 100% 0%, 100% 45%, 55% 45%, 55% 100%, 0% 100%);
+}
+
+.segment.corner.nw {
+  clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 45% 100%, 45% 45%, 0% 45%);
+}
+
+.segment.corner.se {
+  clip-path: polygon(45% 0%, 100% 0%, 100% 100%, 0% 100%, 0% 55%, 45% 55%);
+}
+
+.segment.corner.sw {
+  clip-path: polygon(55% 0%, 100% 0%, 100% 100%, 0% 100%, 0% 0%, 55% 0%);
+}
+
+.segment.junction {
+  inset: 16%;
+  clip-path: polygon(0% 42%, 42% 42%, 42% 100%, 58% 100%, 58% 42%, 100% 42%, 100% 58%, 58% 58%, 58% 42%, 42% 42%, 42% 58%, 0% 58%);
+  transform-origin: center;
+}
+
+.segment.junction.east {
+  transform: rotate(90deg);
+}
+
+.segment.junction.south {
+  transform: rotate(180deg);
+}
+
+.segment.junction.west {
+  transform: rotate(270deg);
+}
+
+.token {
+  position: absolute;
+  inset: 30%;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(248, 250, 252, 0.95), rgba(148, 163, 184, 0.45));
+  box-shadow: 0 0 12px rgba(248, 250, 252, 0.35);
+  border: 2px solid rgba(248, 250, 252, 0.7);
+}
+
+.token.bill {
+  background: radial-gradient(circle, rgba(94, 234, 212, 0.95), rgba(20, 184, 166, 0.6));
+  border-color: rgba(94, 234, 212, 0.9);
+}
+
+.token.scandal {
+  background: radial-gradient(circle, rgba(248, 113, 113, 0.95), rgba(239, 68, 68, 0.6));
+  border-color: rgba(248, 113, 113, 0.9);
+}
+
+.legend {
+  margin-top: 1.5rem;
+}
+
+.legend ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.legend-swatch {
+  display: inline-flex;
+  width: 1.2rem;
+  height: 1.2rem;
+  border-radius: 0.35rem;
+  margin-right: 0.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.legend-swatch.start {
+  background: linear-gradient(135deg, rgba(94, 234, 212, 0.75), rgba(59, 130, 246, 0.6));
+}
+
+.legend-swatch.goal {
+  background: linear-gradient(135deg, rgba(250, 204, 21, 0.8), rgba(251, 191, 36, 0.6));
+}
+
+.legend-swatch.blaze {
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.8), rgba(190, 24, 93, 0.6));
+}
+
+.legend-swatch.archive {
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.45), rgba(71, 85, 105, 0.6));
+}
+
+.legend-swatch.barricade {
+  background: rgba(30, 41, 59, 0.9);
+}
+
+.log {
+  margin-top: 1.75rem;
+}
+
+#log-entries {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 220px;
+  overflow-y: auto;
+  display: grid;
+  gap: 0.5rem;
+}
+
+#log-entries li {
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.page-footer {
+  margin: 2rem auto 4rem;
+  max-width: 720px;
+  padding: 0 1.5rem;
+  color: var(--muted);
+  text-align: center;
+}
+
+.page-footer p {
+  margin: 0;
+}
+
+@media (max-width: 720px) {
+  .arena-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .arena-controls {
+    justify-content: center;
+  }
+}

--- a/madia.new/public/secret/1989/blaze/blaze.js
+++ b/madia.new/public/secret/1989/blaze/blaze.js
@@ -1,0 +1,689 @@
+const boardElement = document.getElementById("board");
+const statusBar = document.getElementById("status-bar");
+const capitalMeter = document.getElementById("capital-meter");
+const logList = document.getElementById("log-entries");
+const modeButtons = Array.from(document.querySelectorAll(".mode-button"));
+const paletteButtons = Array.from(document.querySelectorAll(".palette-button"));
+const rotateButton = document.getElementById("rotate-piece");
+const advanceButton = document.getElementById("advance-flow");
+const resetButton = document.getElementById("reset-board");
+
+const GRID_ROWS = 7;
+const GRID_COLS = 7;
+const START = { row: 6, col: 1 };
+const GOAL = { row: 0, col: 5 };
+const SCANDAL_SOURCE = { row: 3, col: 3 };
+const ARCHIVES = [
+  { row: 1, col: 6 },
+  { row: 6, col: 5 },
+];
+const BARRICADES = new Set(["2,3", "4,3", "1,5", "5,1"]);
+
+const STARTING_CAPITAL = 6;
+const DIVERT_COST = 1;
+const BILL_REWARD = 3;
+const BILLS_REQUIRED = 2;
+
+const ORIENTATION_SEQUENCE = {
+  straight: ["horizontal", "vertical"],
+  corner: ["ne", "se", "sw", "nw"],
+  junction: ["north", "east", "south", "west"],
+};
+
+const ORIENTATION_CONNECTORS = {
+  horizontal: ["west", "east"],
+  vertical: ["north", "south"],
+  ne: ["north", "east"],
+  se: ["south", "east"],
+  sw: ["south", "west"],
+  nw: ["north", "west"],
+  north: ["south", "east", "west"],
+  east: ["north", "south", "west"],
+  south: ["north", "east", "west"],
+  west: ["north", "south", "east"],
+};
+
+const DIRECTION_DELTAS = {
+  north: { row: -1, col: 0 },
+  south: { row: 1, col: 0 },
+  west: { row: 0, col: -1 },
+  east: { row: 0, col: 1 },
+};
+
+const OPPOSITE = {
+  north: "south",
+  south: "north",
+  east: "west",
+  west: "east",
+};
+
+const START_CONNECTORS = ["north", "east"];
+const GOAL_CONNECTORS = ["west", "south"];
+const SOURCE_CONNECTORS = ["north", "east", "south"];
+
+let activeMode = "bill";
+let selectedPiece = { type: "straight", orientation: "horizontal" };
+let boardState = new Map();
+let lockedSegments = new Map();
+let tileRoles = new Map();
+let tileElements = new Map();
+let billPosition = { ...START };
+let politicalCapital = STARTING_CAPITAL;
+let signedBills = 0;
+let scandalPoints = [];
+let scandalId = 0;
+let gameOver = false;
+
+function key(row, col) {
+  return `${row},${col}`;
+}
+
+function inBounds(row, col) {
+  return row >= 0 && row < GRID_ROWS && col >= 0 && col < GRID_COLS;
+}
+
+function setStatus(message) {
+  statusBar.textContent = message;
+}
+
+function logEvent(message) {
+  const item = document.createElement("li");
+  item.textContent = message;
+  logList.appendChild(item);
+  logList.scrollTop = logList.scrollHeight;
+}
+
+function updateCapitalMeter() {
+  capitalMeter.textContent = `Political Capital: ${politicalCapital}`;
+  capitalMeter.classList.toggle("low", politicalCapital <= 2);
+  capitalMeter.classList.toggle("strong", politicalCapital >= 8);
+  if (politicalCapital < 0) {
+    triggerLoss("Political Capital collapsed below zero. The caucus walks out.");
+  } else if (politicalCapital === 0) {
+    triggerLoss("Political Capital is exhausted. No one will back another vote.");
+  }
+}
+
+function resetState() {
+  boardState = new Map();
+  lockedSegments = new Map();
+  tileRoles = new Map();
+  tileElements = new Map();
+  scandalPoints = [];
+  scandalId = 0;
+  signedBills = 0;
+  billPosition = { ...START };
+  politicalCapital = STARTING_CAPITAL;
+  gameOver = false;
+  setSelectedPiece("straight", "horizontal");
+  setActiveMode("bill");
+  buildBoard();
+  renderBillToken();
+  renderScandals();
+  setStatus("Select a tile to begin the paper trail.");
+  logList.innerHTML = "";
+  logEvent("Session reset. Governor queues a fresh bill.");
+  updateCapitalMeter();
+}
+
+function buildBoard() {
+  boardElement.innerHTML = "";
+  tileElements.clear();
+  lockedSegments.clear();
+  tileRoles.clear();
+
+  for (let row = 0; row < GRID_ROWS; row += 1) {
+    for (let col = 0; col < GRID_COLS; col += 1) {
+      const tile = document.createElement("button");
+      tile.type = "button";
+      tile.classList.add("tile");
+      tile.dataset.row = String(row);
+      tile.dataset.col = String(col);
+      tile.setAttribute("role", "gridcell");
+      tile.setAttribute("aria-label", `Tile ${row + 1}, ${col + 1}`);
+      const content = document.createElement("div");
+      content.classList.add("tile-content");
+      tile.appendChild(content);
+
+      const tileKey = key(row, col);
+      if (row === START.row && col === START.col) {
+        tile.classList.add("start", "locked");
+        tile.disabled = true;
+        tile.setAttribute("aria-disabled", "true");
+        tileRoles.set(tileKey, "start");
+        lockedSegments.set(tileKey, {
+          occupant: "bill",
+          connectors: START_CONNECTORS,
+          type: "start",
+          locked: true,
+        });
+      } else if (row === GOAL.row && col === GOAL.col) {
+        tile.classList.add("goal", "locked");
+        tile.disabled = true;
+        tile.setAttribute("aria-disabled", "true");
+        tileRoles.set(tileKey, "goal");
+        lockedSegments.set(tileKey, {
+          occupant: "bill",
+          connectors: GOAL_CONNECTORS,
+          type: "goal",
+          locked: true,
+        });
+      } else if (row === SCANDAL_SOURCE.row && col === SCANDAL_SOURCE.col) {
+        tile.classList.add("source", "locked");
+        tile.disabled = true;
+        tile.setAttribute("aria-disabled", "true");
+        tileRoles.set(tileKey, "source");
+        lockedSegments.set(tileKey, {
+          occupant: "scandal",
+          connectors: SOURCE_CONNECTORS,
+          type: "source",
+          locked: true,
+        });
+      } else if (ARCHIVES.some((archive) => archive.row === row && archive.col === col)) {
+        tile.classList.add("archive", "locked");
+        tile.disabled = true;
+        tile.setAttribute("aria-disabled", "true");
+        tileRoles.set(tileKey, "archive");
+      } else if (BARRICADES.has(tileKey)) {
+        tile.classList.add("barricade", "locked");
+        tile.disabled = true;
+        tile.setAttribute("aria-disabled", "true");
+        tileRoles.set(tileKey, "barricade");
+      } else {
+        tile.addEventListener("click", () => handleTileClick(row, col));
+      }
+
+      boardElement.appendChild(tile);
+      tileElements.set(tileKey, tile);
+    }
+  }
+}
+
+function handleTileClick(row, col) {
+  if (gameOver) {
+    setStatus("Session complete. Reset to try again.");
+    return;
+  }
+
+  const tileKey = key(row, col);
+  const role = tileRoles.get(tileKey);
+  if (role && role !== "") {
+    if (role === "barricade" || role === "start" || role === "goal" || role === "source" || role === "archive") {
+      setStatus("That tile is bound by statute—choose another.");
+      return;
+    }
+  }
+
+  if (activeMode === "clear") {
+    clearSegment(tileKey);
+    return;
+  }
+
+  if (activeMode === "bill" && selectedPiece.type === "junction") {
+    setStatus("Bill drafters can't install a junction. Switch to Scandal mode for that piece.");
+    return;
+  }
+
+  const existing = boardState.get(tileKey);
+  if (existing && existing.occupant !== activeMode) {
+    setStatus("That tile already carries the other conduit. Find a new route.");
+    return;
+  }
+
+  placeSegment(tileKey, {
+    occupant: activeMode,
+    type: selectedPiece.type,
+    orientation: selectedPiece.orientation,
+  });
+}
+
+function clearSegment(tileKey) {
+  const existing = boardState.get(tileKey);
+  if (!existing) {
+    setStatus("Nothing to clear on that tile.");
+    return;
+  }
+  boardState.delete(tileKey);
+  const tile = tileElements.get(tileKey);
+  if (tile) {
+    const existingSegment = tile.querySelector(".segment");
+    if (existingSegment) {
+      existingSegment.remove();
+    }
+  }
+  setStatus("Conduit removed. Rework the flow before advancing.");
+}
+
+function placeSegment(tileKey, segment) {
+  boardState.set(tileKey, { ...segment });
+  renderSegment(tileKey);
+  setStatus(
+    segment.occupant === "bill"
+      ? "Bill conduit laid."
+      : "Scandal channel positioned."
+  );
+}
+
+function renderSegment(tileKey) {
+  const tile = tileElements.get(tileKey);
+  if (!tile) {
+    return;
+  }
+  const content = tile.querySelector(".tile-content");
+  if (!content) {
+    return;
+  }
+  const existingSegment = content.querySelector(".segment");
+  if (existingSegment) {
+    existingSegment.remove();
+  }
+  const data = boardState.get(tileKey);
+  if (!data) {
+    return;
+  }
+  const segment = document.createElement("div");
+  segment.classList.add("segment", data.occupant, data.type, data.orientation);
+  content.appendChild(segment);
+}
+
+function renderBillToken() {
+  boardElement.querySelectorAll(".token.bill").forEach((token) => token.remove());
+  const tile = tileElements.get(key(billPosition.row, billPosition.col));
+  if (!tile) {
+    return;
+  }
+  const content = tile.querySelector(".tile-content");
+  if (!content) {
+    return;
+  }
+  const token = document.createElement("div");
+  token.classList.add("token", "bill");
+  content.appendChild(token);
+}
+
+function renderScandals() {
+  boardElement.querySelectorAll(".token.scandal").forEach((token) => token.remove());
+  scandalPoints.forEach((point) => {
+    const tile = tileElements.get(key(point.row, point.col));
+    if (!tile) {
+      return;
+    }
+    const content = tile.querySelector(".tile-content");
+    if (!content) {
+      return;
+    }
+    const token = document.createElement("div");
+    token.classList.add("token", "scandal");
+    content.appendChild(token);
+  });
+}
+
+function getConnectorsFor(mode, row, col) {
+  const tileKey = key(row, col);
+  if (mode === "bill") {
+    if (row === START.row && col === START.col) {
+      return START_CONNECTORS;
+    }
+    if (row === GOAL.row && col === GOAL.col) {
+      return GOAL_CONNECTORS;
+    }
+  } else if (mode === "scandal" && row === SCANDAL_SOURCE.row && col === SCANDAL_SOURCE.col) {
+    return SOURCE_CONNECTORS;
+  }
+
+  const locked = lockedSegments.get(tileKey);
+  if (locked && locked.occupant === mode) {
+    return locked.connectors;
+  }
+  const data = boardState.get(tileKey);
+  if (!data) {
+    return null;
+  }
+  if (data.occupant !== mode) {
+    return null;
+  }
+  return ORIENTATION_CONNECTORS[data.orientation] ?? null;
+}
+
+function tileHasBill(row, col) {
+  const tileKey = key(row, col);
+  if (row === START.row && col === START.col) {
+    return true;
+  }
+  if (row === GOAL.row && col === GOAL.col) {
+    return true;
+  }
+  const data = boardState.get(tileKey);
+  return data?.occupant === "bill";
+}
+
+function computeBillRoute() {
+  const visited = new Set();
+  const route = [];
+  let current = { ...START };
+  let previousDirection = null;
+  visited.add(key(current.row, current.col));
+  route.push({ ...current });
+
+  while (!(current.row === GOAL.row && current.col === GOAL.col)) {
+    const connectors = getConnectorsFor("bill", current.row, current.col);
+    if (!connectors || connectors.length === 0) {
+      return null;
+    }
+    const options = connectors
+      .filter((direction) => !(previousDirection && direction === OPPOSITE[previousDirection]))
+      .map((direction) => {
+        const delta = DIRECTION_DELTAS[direction];
+        const nextRow = current.row + delta.row;
+        const nextCol = current.col + delta.col;
+        return { direction, row: nextRow, col: nextCol };
+      })
+      .filter((option) => inBounds(option.row, option.col));
+
+    let nextOption = null;
+    for (const option of options) {
+      const connectorsNext = getConnectorsFor("bill", option.row, option.col);
+      if (!connectorsNext || !connectorsNext.includes(OPPOSITE[option.direction])) {
+        continue;
+      }
+      const optionKey = key(option.row, option.col);
+      if (visited.has(optionKey) && !(option.row === GOAL.row && option.col === GOAL.col)) {
+        continue;
+      }
+      nextOption = option;
+      break;
+    }
+
+    if (!nextOption) {
+      return null;
+    }
+
+    current = { row: nextOption.row, col: nextOption.col };
+    previousDirection = nextOption.direction;
+    route.push({ ...current });
+    const currentKey = key(current.row, current.col);
+    if (visited.has(currentKey) && !(current.row === GOAL.row && current.col === GOAL.col)) {
+      return null;
+    }
+    visited.add(currentKey);
+    if (route.length > GRID_ROWS * GRID_COLS + 2) {
+      return null;
+    }
+  }
+
+  return route;
+}
+
+function advanceFlow() {
+  if (gameOver) {
+    setStatus("Session complete. Reset to launch another run.");
+    return;
+  }
+
+  const route = computeBillRoute();
+  if (!route) {
+    setStatus("The bill's conduit is incomplete. Shore it up before advancing.");
+    logEvent("Bill route collapsed—paper trail must be continuous.");
+    return;
+  }
+
+  const currentIndex = route.findIndex((step) => step.row === billPosition.row && step.col === billPosition.col);
+  if (currentIndex === -1) {
+    setStatus("The bill lost the paper trail. Rebuild from the desk.");
+    logEvent("Bill position is off the conduit. Resetting to the desk.");
+    billPosition = { ...START };
+    renderBillToken();
+    return;
+  }
+
+  if (currentIndex >= route.length - 1) {
+    setStatus("A fresh bill is staged at the Governor's Desk.");
+  } else {
+    const nextStep = route[currentIndex + 1];
+    billPosition = { ...nextStep };
+    if (billPosition.row === GOAL.row && billPosition.col === GOAL.col) {
+      signedBills += 1;
+      politicalCapital += BILL_REWARD;
+      logEvent(`Bill signed cleanly. Political Capital +${BILL_REWARD} (now ${politicalCapital}).`);
+      updateCapitalMeter();
+      if (gameOver) {
+        return;
+      }
+      if (signedBills >= BILLS_REQUIRED) {
+        renderBillToken();
+        triggerWin();
+        return;
+      }
+      billPosition = { ...START };
+      logEvent("Fresh legislation drafted at the Governor's Desk.");
+      setStatus("Bill signed without scandal. A new draft is ready.");
+    } else {
+      logEvent(`Bill advanced to row ${billPosition.row + 1}, column ${billPosition.col + 1}.`);
+      setStatus("Bill advanced along the conduit.");
+    }
+  }
+
+  renderBillToken();
+  spawnScandalPoint();
+  moveScandals();
+  renderScandals();
+}
+
+function spawnScandalPoint() {
+  if (gameOver) {
+    return;
+  }
+  scandalId += 1;
+  scandalPoints.push({
+    id: scandalId,
+    row: SCANDAL_SOURCE.row,
+    col: SCANDAL_SOURCE.col,
+    lastDirection: null,
+    cameFrom: null,
+  });
+  logEvent(`Scandal Point ${scandalId} erupts from Blaze's parlor.`);
+}
+
+function moveScandals() {
+  if (gameOver) {
+    return;
+  }
+  const survivors = [];
+  for (const point of scandalPoints) {
+    const outcome = advanceScandal(point);
+    if (gameOver) {
+      return;
+    }
+    if (outcome === "contained") {
+      politicalCapital -= DIVERT_COST;
+      logEvent(
+        `Scandal Point ${point.id} filed into archives. Political Capital -${DIVERT_COST} (now ${politicalCapital}).`
+      );
+      updateCapitalMeter();
+      if (gameOver) {
+        return;
+      }
+    } else if (outcome === "moved") {
+      survivors.push(point);
+    } else if (outcome === "stalled") {
+      logEvent(`Scandal Point ${point.id} jammed with nowhere to go.`);
+      triggerLoss("A scandal jammed and burst across the floor.");
+      return;
+    }
+  }
+  scandalPoints = survivors;
+}
+
+function advanceScandal(point) {
+  const connectors = getConnectorsFor("scandal", point.row, point.col);
+  if (!connectors || connectors.length === 0) {
+    return "stalled";
+  }
+
+  const options = connectors
+    .filter((direction) => !(point.cameFrom && direction === point.cameFrom))
+    .map((direction) => {
+      const delta = DIRECTION_DELTAS[direction];
+      return {
+        direction,
+        row: point.row + delta.row,
+        col: point.col + delta.col,
+      };
+    })
+    .filter((option) => inBounds(option.row, option.col));
+
+  let chosen = null;
+  for (const option of options) {
+    const role = tileRoles.get(key(option.row, option.col));
+    if (role === "barricade") {
+      continue;
+    }
+    if (role === "archive") {
+      chosen = option;
+      break;
+    }
+    const connectorsNext = getConnectorsFor("scandal", option.row, option.col);
+    if (!connectorsNext || !connectorsNext.includes(OPPOSITE[option.direction])) {
+      continue;
+    }
+    if (tileHasBill(option.row, option.col)) {
+      continue;
+    }
+    if (!chosen) {
+      chosen = option;
+    } else if (point.lastDirection && option.direction === point.lastDirection) {
+      chosen = option;
+    }
+  }
+
+  if (!chosen) {
+    return "stalled";
+  }
+
+  const role = tileRoles.get(key(chosen.row, chosen.col));
+  if (tileHasBill(chosen.row, chosen.col)) {
+    triggerLoss("A scandal crossed into the bill's conduit. The legislation is ruined.");
+    return "collision";
+  }
+
+  if (role === "archive") {
+    return "contained";
+  }
+
+  const connectorsNext = getConnectorsFor("scandal", chosen.row, chosen.col);
+  if (!connectorsNext || !connectorsNext.includes(OPPOSITE[chosen.direction])) {
+    return "stalled";
+  }
+
+  point.row = chosen.row;
+  point.col = chosen.col;
+  point.cameFrom = OPPOSITE[chosen.direction];
+  point.lastDirection = chosen.direction;
+  return "moved";
+}
+
+function triggerLoss(message) {
+  if (gameOver) {
+    return;
+  }
+  gameOver = true;
+  setStatus(message);
+  logEvent("Proceedings collapse. Reset to attempt another session.");
+}
+
+function triggerWin() {
+  if (gameOver) {
+    return;
+  }
+  gameOver = true;
+  setStatus("Two clean bills signed. The chamber erupts in relief.");
+  logEvent("Victory! The paper trail held under pressure.");
+}
+
+function setActiveMode(mode) {
+  activeMode = mode;
+  modeButtons.forEach((button) => {
+    const pressed = button.dataset.mode === mode;
+    button.setAttribute("aria-pressed", pressed ? "true" : "false");
+  });
+  paletteButtons.forEach((button) => {
+    const isJunction = button.dataset.piece === "junction";
+    button.disabled = mode === "bill" && isJunction;
+    if (button.disabled) {
+      button.setAttribute("aria-pressed", "false");
+    }
+  });
+  if (mode === "bill" && selectedPiece.type === "junction") {
+    setSelectedPiece("straight", "horizontal");
+  }
+  if (mode === "clear") {
+    setStatus("Clear mode: select a placed conduit to remove it.");
+  }
+}
+
+function setSelectedPiece(type, orientation) {
+  selectedPiece = { type, orientation };
+  paletteButtons.forEach((button) => {
+    const pressed = button.dataset.piece === type;
+    button.setAttribute("aria-pressed", pressed ? "true" : "false");
+    if (pressed) {
+      button.dataset.orientation = orientation;
+    }
+  });
+}
+
+function rotateSelectedPiece() {
+  const sequence = ORIENTATION_SEQUENCE[selectedPiece.type];
+  if (!sequence || sequence.length === 0) {
+    return;
+  }
+  const index = sequence.indexOf(selectedPiece.orientation);
+  const nextOrientation = sequence[(index + 1) % sequence.length];
+  selectedPiece = { ...selectedPiece, orientation: nextOrientation };
+  paletteButtons.forEach((button) => {
+    if (button.dataset.piece === selectedPiece.type) {
+      button.dataset.orientation = selectedPiece.orientation;
+    }
+  });
+}
+
+modeButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    setActiveMode(button.dataset.mode);
+  });
+});
+
+paletteButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    if (button.disabled) {
+      return;
+    }
+    const type = button.dataset.piece;
+    const orientation = button.dataset.orientation;
+    setSelectedPiece(type, orientation);
+  });
+});
+
+rotateButton.addEventListener("click", () => {
+  rotateSelectedPiece();
+});
+
+advanceButton.addEventListener("click", () => {
+  advanceFlow();
+});
+
+resetButton.addEventListener("click", () => {
+  resetState();
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "r" || event.key === "R") {
+    event.preventDefault();
+    rotateSelectedPiece();
+  } else if (event.key === "Enter") {
+    event.preventDefault();
+    advanceFlow();
+  }
+});
+
+resetState();

--- a/madia.new/public/secret/1989/blaze/index.html
+++ b/madia.new/public/secret/1989/blaze/index.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Paper Trail Blaze</title>
+    <link rel="stylesheet" href="blaze.css" />
+  </head>
+  <body>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 45 · 1989 Arcade</p>
+      <h1>Paper Trail Blaze</h1>
+      <p class="subtitle">
+        Shepherd the governor's bill through the capitol maze while siphoning scandal into cold archives.
+      </p>
+    </header>
+    <main class="page-layout">
+      <section class="briefing" aria-labelledby="briefing-title">
+        <h2 id="briefing-title">Legislative Briefing</h2>
+        <p>
+          The bill is prepped on the Governor's Desk and the signing chamber is waiting up north. Blaze Starr keeps
+          feeding scandal into the press line—divert it into containment archives before it splashes onto the paper trail.
+        </p>
+        <ul class="callouts">
+          <li><strong>Bill objective:</strong> Build a continuous conduit from the Governor's Desk to the Signed Law dais.</li>
+          <li>
+            <strong>Scandal control:</strong> Channel each Scandal Point from Blaze's parlor into an archive chute. Crossing a
+            bill conduit corrupts the legislation.
+          </li>
+          <li>
+            <strong>Political Capital:</strong> Earn 3 Capital whenever a bill is signed. Spending 1 Capital contains each
+            Scandal Point that reaches an archive.
+          </li>
+          <li><strong>Victory:</strong> Deliver two clean bills before Capital dries up.</li>
+        </ul>
+        <section class="controls" aria-labelledby="controls-title">
+          <h3 id="controls-title">Controls</h3>
+          <dl>
+            <div>
+              <dt>Place conduit</dt>
+              <dd>Select a conduit type, choose Bill or Scandal mode, then click a tile.</dd>
+            </div>
+            <div>
+              <dt>Rotate piece</dt>
+              <dd>Press <span class="key-label">R</span> or the rotate button to cycle orientations.</dd>
+            </div>
+            <div>
+              <dt>Advance flow</dt>
+              <dd>Press <span class="key-label">Enter</span> or the <strong>Advance Flow</strong> button to resolve a turn.</dd>
+            </div>
+            <div>
+              <dt>Clear tile</dt>
+              <dd>Use the <strong>Clear</strong> button then click a placed conduit to remove it.</dd>
+            </div>
+          </dl>
+        </section>
+      </section>
+      <section class="arena" aria-labelledby="arena-title">
+        <div class="arena-header">
+          <h2 id="arena-title">Capitol Floor</h2>
+          <div class="arena-controls">
+            <div class="mode-toggle" role="group" aria-label="Conduit mode">
+              <button type="button" class="mode-button" data-mode="bill" aria-pressed="true">Bill</button>
+              <button type="button" class="mode-button" data-mode="scandal" aria-pressed="false">Scandal</button>
+              <button type="button" class="mode-button" data-mode="clear" aria-pressed="false">Clear</button>
+            </div>
+            <div class="piece-palette" role="group" aria-label="Piece selection">
+              <button type="button" class="palette-button" data-piece="straight" data-orientation="horizontal" aria-pressed="true">
+                Straight
+              </button>
+              <button type="button" class="palette-button" data-piece="corner" data-orientation="ne">Corner</button>
+              <button type="button" class="palette-button" data-piece="junction" data-orientation="north">Junction</button>
+            </div>
+            <button type="button" class="action-button" id="rotate-piece" aria-label="Rotate piece">Rotate</button>
+            <button type="button" class="action-button" id="advance-flow">Advance Flow</button>
+            <button type="button" class="action-button" id="reset-board">Reset</button>
+          </div>
+        </div>
+        <div class="status-bar" id="status-bar" role="status" aria-live="polite">Select a tile to begin the paper trail.</div>
+        <div class="capital-meter" id="capital-meter" aria-live="polite">Political Capital: 6</div>
+        <div class="board" id="board" role="grid" aria-label="Capitol flow grid"></div>
+        <section class="legend" aria-labelledby="legend-title">
+          <h3 id="legend-title">Legend</h3>
+          <ul>
+            <li><span class="legend-swatch start"></span> Governor's Desk</li>
+            <li><span class="legend-swatch goal"></span> Signed Law</li>
+            <li><span class="legend-swatch blaze"></span> Blaze Starr Scandal Source</li>
+            <li><span class="legend-swatch archive"></span> Containment Archive</li>
+            <li><span class="legend-swatch barricade"></span> Bureaucratic Barrier</li>
+          </ul>
+        </section>
+        <section class="log" aria-labelledby="log-title">
+          <h3 id="log-title">Floor Log</h3>
+          <ul id="log-entries"></ul>
+        </section>
+      </section>
+    </main>
+    <footer class="page-footer">
+      <p>
+        Tip: Junctions only split scandal flows—use them to fork toward multiple archives without letting a branch cross the bill
+        conduit.
+      </p>
+    </footer>
+    <script type="module" src="blaze.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add the Paper Trail Blaze level with bill routing and scandal diversion mechanics
- style the new board with capital meter, legend, and flow controls
- surface the cartridge in the 1989 arcade catalog with custom thumbnail art

## Testing
- Manual verification: served `madia.new/public` with `python3 -m http.server 5000` and exercised `/secret/1989/blaze/` in the browser

------
https://chatgpt.com/codex/tasks/task_e_68dee0da15f883289d75a1abe0decbac