### PR TITLE
feat: add halo hustle level to 1989 arcade

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -106,6 +106,43 @@ const games = [
     `,
   },
   {
+    id: "halo-hustle",
+    name: "Halo Hustle",
+    description: "Keep the Time-Sand alive with cup runs, lucky sums, and haloed sequences.",
+    url: "./halo-hustle/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Halo Hustle preview">
+        <defs>
+          <linearGradient id="haloGlow" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#7b5bff" />
+            <stop offset="100%" stop-color="#14b8a6" />
+          </linearGradient>
+          <linearGradient id="sandFill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(123,91,255,0.35)" />
+            <stop offset="100%" stop-color="rgba(20,184,166,0.2)" />
+          </linearGradient>
+        </defs>
+        <rect x="8" y="8" width="144" height="104" rx="18" fill="rgba(6,10,24,0.92)" stroke="rgba(148,163,184,0.35)" />
+        <g transform="translate(36 18)">
+          <rect x="0" y="0" width="88" height="84" rx="18" fill="rgba(10,16,32,0.9)" stroke="url(#haloGlow)" />
+          <path d="M24 14h40l-12 20 12 20H24l12-20z" fill="url(#sandFill)" stroke="rgba(148,163,184,0.35)" stroke-width="2" />
+          <circle cx="44" cy="12" r="10" fill="rgba(250,204,21,0.35)" stroke="#facc15" stroke-width="2" />
+          <circle cx="44" cy="72" r="14" fill="rgba(20,184,166,0.2)" stroke="rgba(20,184,166,0.75)" stroke-width="2" />
+          <g transform="translate(8 32)">
+            <circle cx="12" cy="0" r="6" fill="#facc15" stroke="rgba(17,24,39,0.9)" />
+            <circle cx="44" cy="0" r="6" fill="#38bdf8" stroke="rgba(17,24,39,0.9)" />
+            <circle cx="76" cy="0" r="6" fill="#ec4899" stroke="rgba(17,24,39,0.9)" />
+          </g>
+          <g transform="translate(18 54)">
+            <rect x="0" y="0" width="20" height="10" rx="5" fill="rgba(123,91,255,0.35)" />
+            <rect x="34" y="0" width="20" height="10" rx="5" fill="rgba(123,91,255,0.35)" />
+            <rect x="68" y="0" width="20" height="10" rx="5" fill="rgba(123,91,255,0.35)" />
+          </g>
+        </g>
+      </svg>
+    `,
+  },
+  {
     id: "velvet-syncopation",
     name: "Velvet Syncopation",
     description: "Three-lane rhythm rehearsal with the lounge trio's velvet slips.",

--- a/madia.new/public/secret/1989/halo-hustle/halo-hustle.css
+++ b/madia.new/public/secret/1989/halo-hustle/halo-hustle.css
@@ -1,0 +1,559 @@
+:root {
+  color-scheme: dark;
+  font-family: "Space Grotesk", "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --bg: #04060d;
+  --panel: rgba(8, 14, 28, 0.9);
+  --panel-soft: rgba(13, 21, 41, 0.75);
+  --border: rgba(123, 91, 255, 0.4);
+  --border-soft: rgba(123, 91, 255, 0.2);
+  --text: #f8fafc;
+  --muted: rgba(226, 232, 240, 0.75);
+  --accent: #7b5bff;
+  --accent-soft: rgba(123, 91, 255, 0.2);
+  --gold: #facc15;
+  --danger: #f87171;
+  --success: #34d399;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 15%, rgba(123, 91, 255, 0.22), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(20, 184, 166, 0.18), transparent 48%),
+    radial-gradient(circle at 55% 95%, rgba(250, 204, 21, 0.22), transparent 45%),
+    var(--bg);
+  color: var(--text);
+  padding-bottom: 4rem;
+}
+
+.scanlines {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.04),
+    rgba(255, 255, 255, 0.04) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  mix-blend-mode: soft-light;
+  opacity: 0.4;
+  z-index: 0;
+}
+
+.page-header {
+  position: relative;
+  padding: clamp(2rem, 6vw, 4rem) clamp(1.5rem, 5vw, 4.5rem) 2rem;
+  text-align: center;
+  z-index: 1;
+}
+
+.eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.page-header h1 {
+  margin: 0.75rem 0 0.5rem;
+  font-size: clamp(2.6rem, 8vw, 4.5rem);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  text-shadow: 0 10px 45px rgba(123, 91, 255, 0.6);
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+.page-layout {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  padding: 0 clamp(1.5rem, 5vw, 4.5rem);
+}
+
+@media (min-width: 960px) {
+  .page-layout {
+    grid-template-columns: minmax(260px, 360px) 1fr;
+  }
+}
+
+.briefing,
+.parlor {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 1.75rem;
+  padding: clamp(1.5rem, 3vw, 2.4rem);
+  box-shadow: 0 26px 48px -26px rgba(0, 0, 0, 0.85);
+}
+
+.briefing h2,
+.parlor h2,
+.parlor h3 {
+  margin-top: 0;
+}
+
+.callouts {
+  margin: 1rem 0;
+  padding-left: 1.2rem;
+  line-height: 1.55;
+  color: var(--muted);
+}
+
+.action-guide {
+  margin-top: 1.5rem;
+}
+
+.action-guide dl {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.action-guide dt {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.action-guide dd {
+  margin: 0.2rem 0 0;
+  color: var(--text);
+}
+
+.parlor-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.run-controls {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.action-button {
+  font: inherit;
+  border: 0;
+  padding: 0.65rem 1.3rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(123, 91, 255, 0.95), rgba(20, 184, 166, 0.9));
+  color: white;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.action-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.action-button:not(:disabled):hover,
+.action-button:not(:disabled):focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 40px -18px rgba(123, 91, 255, 0.85);
+}
+
+.action-button:focus-visible {
+  outline: 2px solid rgba(148, 163, 184, 0.8);
+  outline-offset: 3px;
+}
+
+.parlor-help {
+  margin: 1rem 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.status-panels {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 720px) {
+  .status-panels {
+    grid-template-columns: minmax(220px, 1fr) minmax(200px, 320px);
+    align-items: stretch;
+  }
+}
+
+.meter-panel {
+  background: var(--panel-soft);
+  border: 1px solid var(--border-soft);
+  border-radius: 1.25rem;
+  padding: 1.1rem;
+}
+
+.meter-labels {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.meter-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.meter-value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.meter {
+  height: 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.85);
+  overflow: hidden;
+}
+
+.meter-fill {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, rgba(123, 91, 255, 0.9), rgba(20, 184, 166, 0.9));
+  transition: width 240ms ease;
+}
+
+.summary-panel {
+  background: var(--panel-soft);
+  border: 1px solid var(--border-soft);
+  border-radius: 1.25rem;
+  padding: 1.1rem;
+}
+
+.summary-panel dl {
+  display: grid;
+  gap: 0.6rem;
+  margin: 0;
+}
+
+.summary-panel dt {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.summary-panel dd {
+  margin: 0.25rem 0 0;
+  font-size: 1.2rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.status-banner {
+  margin: 1.4rem 0 1rem;
+  padding: 0.85rem 1.2rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.75);
+  color: var(--muted);
+}
+
+.status-banner.is-success {
+  border-color: rgba(52, 211, 153, 0.45);
+  color: var(--success);
+}
+
+.status-banner.is-warning {
+  border-color: rgba(250, 204, 21, 0.45);
+  color: var(--gold);
+}
+
+.status-banner.is-danger {
+  border-color: rgba(248, 113, 113, 0.55);
+  color: var(--danger);
+}
+
+.betting-floor {
+  display: grid;
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+@media (min-width: 900px) {
+  .betting-floor {
+    grid-template-columns: repeat(3, minmax(200px, 1fr));
+  }
+}
+
+.table-card {
+  background: rgba(10, 16, 32, 0.92);
+  border: 1px solid rgba(120, 255, 255, 0.16);
+  border-radius: 1.5rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  min-height: 100%;
+}
+
+.table-card header h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  letter-spacing: 0.05em;
+}
+
+.table-difficulty {
+  margin: 0.2rem 0 0;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.table-card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.table-button {
+  align-self: flex-start;
+  font: inherit;
+  border: 1px solid rgba(123, 91, 255, 0.45);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text);
+  padding: 0.55rem 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: transform 140ms ease, background 140ms ease, box-shadow 140ms ease;
+}
+
+.table-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.table-button:not(:disabled):hover,
+.table-button:not(:disabled):focus-visible {
+  transform: translateY(-2px);
+  background: rgba(123, 91, 255, 0.18);
+  box-shadow: 0 12px 30px -18px rgba(123, 91, 255, 0.85);
+}
+
+.table-button:focus-visible {
+  outline: 2px solid rgba(123, 91, 255, 0.65);
+  outline-offset: 2px;
+}
+
+.puzzle-stage {
+  margin-top: 2rem;
+  background: rgba(11, 18, 34, 0.85);
+  border: 1px solid rgba(120, 255, 255, 0.18);
+  border-radius: 1.5rem;
+  padding: 1.2rem 1.4rem 1.6rem;
+}
+
+.puzzle-stage h3 {
+  margin-top: 0;
+}
+
+.puzzle-stage-body {
+  display: grid;
+  gap: 1rem;
+}
+
+.puzzle-stage p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.cup-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.cup-button {
+  font: inherit;
+  border: 0;
+  padding: 1rem 0.5rem;
+  border-radius: 1rem;
+  background: rgba(123, 91, 255, 0.18);
+  color: var(--text);
+  cursor: pointer;
+  position: relative;
+  transition: transform 140ms ease, box-shadow 140ms ease;
+}
+
+.cup-button::after {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border-radius: 0.75rem;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  opacity: 0.7;
+}
+
+.cup-button span {
+  display: block;
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.cup-button.is-highlighted {
+  background: rgba(250, 204, 21, 0.3);
+  box-shadow: 0 12px 30px -18px rgba(250, 204, 21, 0.9);
+}
+
+.cup-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.cup-button:not(:disabled):hover,
+.cup-button:not(:disabled):focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px -16px rgba(123, 91, 255, 0.8);
+}
+
+.lucky-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.die-button {
+  font: inherit;
+  border: 0;
+  padding: 1rem;
+  border-radius: 1.1rem;
+  background: rgba(20, 184, 166, 0.18);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 1.5rem;
+  font-weight: 600;
+  transition: transform 140ms ease, box-shadow 140ms ease;
+}
+
+.die-button.is-selected {
+  background: rgba(20, 184, 166, 0.35);
+  box-shadow: 0 14px 34px -20px rgba(20, 184, 166, 0.85);
+}
+
+.die-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.die-button:not(:disabled):hover,
+.die-button:not(:disabled):focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 34px -18px rgba(20, 184, 166, 0.8);
+}
+
+.sequence-display {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  font-size: 1.8rem;
+  margin: 0.5rem 0 0;
+}
+
+.sequence-display span {
+  padding: 0.35rem 0.6rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.85);
+}
+
+.sequence-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  justify-content: center;
+}
+
+.sequence-button {
+  font: inherit;
+  border: 1px solid rgba(123, 91, 255, 0.45);
+  background: rgba(123, 91, 255, 0.15);
+  color: var(--text);
+  border-radius: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  font-size: 1.4rem;
+  cursor: pointer;
+  transition: transform 140ms ease, box-shadow 140ms ease;
+}
+
+.sequence-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.sequence-button:not(:disabled):hover,
+.sequence-button:not(:disabled):focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 34px -18px rgba(123, 91, 255, 0.85);
+}
+
+.sequence-progress {
+  margin-top: 0.75rem;
+  text-align: center;
+  color: var(--muted);
+}
+
+.event-log {
+  margin-top: 2rem;
+  background: rgba(11, 18, 34, 0.9);
+  border: 1px solid rgba(120, 255, 255, 0.16);
+  border-radius: 1.5rem;
+  padding: 1.1rem 1.4rem 1.6rem;
+}
+
+.event-log h3 {
+  margin-top: 0;
+}
+
+#event-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.5rem;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.page-footer {
+  margin: 2.5rem auto 0;
+  max-width: 720px;
+  padding: 0 1.5rem;
+  color: rgba(226, 232, 240, 0.7);
+  text-align: center;
+  line-height: 1.6;
+}

--- a/madia.new/public/secret/1989/halo-hustle/halo-hustle.js
+++ b/madia.new/public/secret/1989/halo-hustle/halo-hustle.js
@@ -1,0 +1,474 @@
+const MAX_TIME = 80;
+const STARTING_TIME = 60;
+const CHIP_TIME_VALUE = 4;
+const HIGH_STAKES_PENALTY = 5;
+const LOG_LIMIT = 8;
+
+const timeBar = document.getElementById("time-remaining");
+const timeFill = document.getElementById("time-fill");
+const timeLabel = document.getElementById("time-remaining-label");
+const lifeChipTotal = document.getElementById("life-chip-total");
+const currentStreakLabel = document.getElementById("current-streak");
+const pendingChipsLabel = document.getElementById("pending-chips");
+const statusBanner = document.getElementById("status-banner");
+const startButton = document.getElementById("start-run");
+const stopButton = document.getElementById("stop-run");
+const depositButton = document.getElementById("deposit-chips");
+const puzzleStage = document.getElementById("puzzle-stage");
+const puzzleInstructions = document.getElementById("puzzle-instructions");
+const eventList = document.getElementById("event-list");
+const tableButtons = Array.from(document.querySelectorAll(".table-button"));
+
+let runActive = false;
+let timerId = null;
+let timeSand = STARTING_TIME;
+let lifeChips = 0;
+let pendingChips = 0;
+let streak = 1;
+let activeCleanup = null;
+
+startButton.addEventListener("click", () => {
+  if (runActive) {
+    return;
+  }
+  beginRun();
+});
+
+stopButton.addEventListener("click", () => {
+  if (!runActive) {
+    return;
+  }
+  endRun("Run aborted. The house resets the deck.", "warning");
+});
+
+depositButton.addEventListener("click", () => {
+  if (!runActive || pendingChips === 0) {
+    return;
+  }
+  depositChips();
+});
+
+tableButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    if (!runActive) {
+      updateStatus("Start a run to unlock the tables.", "warning");
+      return;
+    }
+    launchTable(button.dataset.table);
+  });
+});
+
+function beginRun() {
+  runActive = true;
+  timeSand = STARTING_TIME;
+  lifeChips = 0;
+  pendingChips = 0;
+  streak = 1;
+  updateTime();
+  updateChipDisplays();
+  updateStatus("Run started. Keep the hourglass breathing.", "success");
+  puzzleInstructions.textContent = "Pick a table to cue up its betting puzzle.";
+  puzzleStage.innerHTML = "";
+  eventList.innerHTML = "";
+  tableButtons.forEach((button) => {
+    button.disabled = false;
+  });
+  startButton.disabled = true;
+  stopButton.disabled = false;
+  depositButton.disabled = true;
+  if (timerId) {
+    window.clearInterval(timerId);
+  }
+  timerId = window.setInterval(() => {
+    tick();
+  }, 1000);
+}
+
+function endRun(message, tone) {
+  runActive = false;
+  if (timerId) {
+    window.clearInterval(timerId);
+    timerId = null;
+  }
+  tableButtons.forEach((button) => {
+    button.disabled = true;
+  });
+  stopButton.disabled = true;
+  startButton.disabled = false;
+  depositButton.disabled = pendingChips === 0;
+  setActivePuzzle(null);
+  updateStatus(message, tone);
+  logEvent(message);
+}
+
+function tick() {
+  if (!runActive) {
+    return;
+  }
+  timeSand = Math.max(0, timeSand - 1);
+  updateTime();
+  if (timeSand === 0) {
+    endRun("The Time-Sand ran dry. Charlie snaps back upstairs.", "danger");
+  }
+}
+
+function updateTime() {
+  timeLabel.textContent = `${timeSand}s`;
+  timeBar.setAttribute("aria-valuenow", String(timeSand));
+  const pct = (timeSand / MAX_TIME) * 100;
+  timeFill.style.width = `${Math.max(0, Math.min(100, pct))}%`;
+}
+
+function updateChipDisplays() {
+  lifeChipTotal.textContent = String(lifeChips);
+  currentStreakLabel.textContent = String(streak);
+  pendingChipsLabel.textContent = String(pendingChips);
+  depositButton.disabled = !runActive || pendingChips === 0;
+}
+
+function updateStatus(message, tone = "neutral") {
+  statusBanner.textContent = message;
+  statusBanner.classList.remove("is-success", "is-warning", "is-danger");
+  if (tone === "success") {
+    statusBanner.classList.add("is-success");
+  } else if (tone === "warning") {
+    statusBanner.classList.add("is-warning");
+  } else if (tone === "danger") {
+    statusBanner.classList.add("is-danger");
+  }
+}
+
+function depositChips() {
+  if (pendingChips === 0) {
+    return;
+  }
+  const restored = pendingChips * CHIP_TIME_VALUE;
+  timeSand = Math.min(MAX_TIME, timeSand + restored);
+  lifeChips += pendingChips;
+  logEvent(`Deposited ${pendingChips} Life Chip${pendingChips === 1 ? "" : "s"}. Restored ${restored} seconds.`);
+  pendingChips = 0;
+  updateTime();
+  updateChipDisplays();
+  updateStatus("Clock topped off. Line up the next wager.", "success");
+}
+
+function launchTable(tableId) {
+  switch (tableId) {
+    case "halo-cups":
+      runHaloCups();
+      break;
+    case "lucky-sum":
+      runLuckySum();
+      break;
+    case "seraph-sequence":
+      runSeraphSequence();
+      break;
+    default:
+      break;
+  }
+}
+
+function runHaloCups() {
+  setActivePuzzle(() => {});
+  puzzleStage.innerHTML = "";
+  const intro = document.createElement("p");
+  intro.textContent = "Watch the cups glow. When they dim, pick the one hiding the chip.";
+  puzzleStage.append(intro);
+  updateStatus("Halos primed. Eyes on the glow.");
+
+  const cupGrid = document.createElement("div");
+  cupGrid.className = "cup-grid";
+  puzzleStage.append(cupGrid);
+
+  const cups = ["A", "B", "C"];
+  const correctIndex = Math.floor(Math.random() * cups.length);
+  const timeouts = [];
+
+  cups.forEach((label, index) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "cup-button";
+    button.disabled = true;
+    button.innerHTML = `<span>${label}</span>`;
+    if (index === correctIndex) {
+      button.classList.add("is-highlighted");
+    }
+    cupGrid.append(button);
+    button.addEventListener("click", () => {
+      if (!runActive) {
+        return;
+      }
+      const success = index === correctIndex;
+      finishPuzzle(success, {
+        table: "Halo Cups",
+        penalty: success ? 0 : 1,
+        message: success ? "Halo Cups hit!" : "Missed the halo.",
+      });
+    });
+  });
+
+  timeouts.push(
+    window.setTimeout(() => {
+      cupGrid.querySelectorAll(".cup-button").forEach((element) => {
+        element.classList.remove("is-highlighted");
+        element.disabled = false;
+      });
+      updateStatus("Cups set. Pick the hiding spot.");
+    }, 1300)
+  );
+
+  setActivePuzzle(() => {
+    timeouts.forEach((id) => window.clearTimeout(id));
+    cupGrid.querySelectorAll("button").forEach((button) => {
+      button.disabled = true;
+    });
+  });
+}
+
+function runLuckySum() {
+  setActivePuzzle(() => {});
+  puzzleStage.innerHTML = "";
+  const target = Math.floor(Math.random() * 6) + 6;
+  const numbers = generateLuckyNumbers(target);
+  const intro = document.createElement("p");
+  intro.textContent = `Select the two dice that add to ${target}.`;
+  puzzleStage.append(intro);
+  updateStatus(`Lucky Sum is calling ${target}. Tag the pair.`);
+
+  const grid = document.createElement("div");
+  grid.className = "lucky-grid";
+  puzzleStage.append(grid);
+
+  let firstPick = null;
+  const correctPair = numbers.solution;
+
+  numbers.values.forEach((value, index) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "die-button";
+    button.textContent = String(value);
+    button.disabled = false;
+    grid.append(button);
+
+    button.addEventListener("click", () => {
+      if (!runActive || button.disabled) {
+        return;
+      }
+      if (firstPick === null) {
+        firstPick = index;
+        button.classList.add("is-selected");
+      } else if (firstPick === index) {
+        firstPick = null;
+        button.classList.remove("is-selected");
+      } else {
+        const success =
+          (firstPick === correctPair[0] && index === correctPair[1]) ||
+          (firstPick === correctPair[1] && index === correctPair[0]);
+        grid.querySelectorAll("button").forEach((die) => {
+          die.disabled = true;
+        });
+        finishPuzzle(success, {
+          table: "Lucky Sum",
+          penalty: success ? 0 : 2,
+          message: success ? `Lucky Sum cleared for ${target}.` : "Bust on the felt.",
+        });
+      }
+    });
+  });
+
+  setActivePuzzle(() => {
+    grid.querySelectorAll("button").forEach((button) => {
+      button.disabled = true;
+    });
+  });
+}
+
+function generateLuckyNumbers(target) {
+  const dice = [];
+  let firstValue = Math.floor(Math.random() * 5) + 2;
+  let secondValue = target - firstValue;
+  if (secondValue < 1 || secondValue > 9) {
+    secondValue = Math.max(1, Math.min(9, target - 3));
+    firstValue = target - secondValue;
+  }
+  dice.push({ value: firstValue, key: "solution-0" });
+  dice.push({ value: secondValue, key: "solution-1" });
+  while (dice.length < 4) {
+    dice.push({ value: Math.floor(Math.random() * 9) + 1, key: `filler-${dice.length}` });
+  }
+  dice.sort(() => Math.random() - 0.5);
+  const values = dice.map((die) => die.value);
+  const solution = dice.reduce((acc, die, index) => {
+    if (die.key.startsWith("solution")) {
+      acc.push(index);
+    }
+    return acc;
+  }, []);
+  return {
+    values,
+    solution,
+  };
+}
+
+function runSeraphSequence() {
+  setActivePuzzle(() => {});
+  puzzleStage.innerHTML = "";
+  applyTimeCost(HIGH_STAKES_PENALTY);
+
+  const intro = document.createElement("p");
+  intro.textContent = "Memorize the suit order. When the glow fades, replay it exactly.";
+  puzzleStage.append(intro);
+  updateStatus("Seraph Sequence is flashing. Burn the pattern into memory.");
+
+  const symbols = ["♠", "♡", "♢", "♣"];
+  const length = 5;
+  const sequence = Array.from({ length }, () => symbols[Math.floor(Math.random() * symbols.length)]);
+
+  const display = document.createElement("div");
+  display.className = "sequence-display";
+  sequence.forEach((symbol) => {
+    const span = document.createElement("span");
+    span.textContent = symbol;
+    display.append(span);
+  });
+  puzzleStage.append(display);
+
+  const progress = document.createElement("p");
+  progress.className = "sequence-progress";
+  progress.textContent = "Watch closely...";
+  puzzleStage.append(progress);
+
+  const controls = document.createElement("div");
+  controls.className = "sequence-controls";
+  puzzleStage.append(controls);
+
+  const buttons = symbols.map((symbol) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "sequence-button";
+    button.textContent = symbol;
+    button.disabled = true;
+    controls.append(button);
+    return button;
+  });
+
+  let revealTimeout = null;
+  let allowInput = false;
+  let pointer = 0;
+
+  const beginInput = () => {
+    display.querySelectorAll("span").forEach((span) => {
+      span.textContent = "?";
+    });
+    buttons.forEach((button) => {
+      button.disabled = false;
+    });
+    allowInput = true;
+    progress.textContent = "Replay the sequence.";
+  };
+
+  revealTimeout = window.setTimeout(beginInput, 3000);
+
+  const handleInput = (symbol) => {
+    if (!allowInput) {
+      return;
+    }
+    const span = display.children[pointer];
+    span.textContent = symbol;
+    if (sequence[pointer] === symbol) {
+      pointer += 1;
+      if (pointer >= sequence.length) {
+        buttons.forEach((button) => {
+          button.disabled = true;
+        });
+        finishPuzzle(true, {
+          table: "Seraph Sequence",
+          chips: streak + 2,
+          message: "Seraph Sequence slammed a jackpot!",
+        });
+      }
+    } else {
+      buttons.forEach((button) => {
+        button.disabled = true;
+      });
+      finishPuzzle(false, {
+        table: "Seraph Sequence",
+        penalty: 3,
+        message: "Sequence collapsed. The house cackles.",
+      });
+    }
+  };
+
+  buttons.forEach((button) => {
+    button.addEventListener("click", () => {
+      handleInput(button.textContent ?? "");
+    });
+  });
+
+  setActivePuzzle(() => {
+    if (revealTimeout) {
+      window.clearTimeout(revealTimeout);
+    }
+    buttons.forEach((button) => {
+      button.disabled = true;
+    });
+  });
+}
+
+function applyTimeCost(amount) {
+  if (!runActive || amount <= 0) {
+    return;
+  }
+  timeSand = Math.max(0, timeSand - amount);
+  updateTime();
+  logEvent(`High-stakes wager burned ${amount} seconds.`);
+  if (timeSand === 0) {
+    endRun("The Time-Sand ran dry. Charlie snaps back upstairs.", "danger");
+  }
+}
+
+function finishPuzzle(success, { table, penalty = 0, chips, message }) {
+  if (!runActive) {
+    return;
+  }
+  if (success) {
+    const payout = typeof chips === "number" ? chips : streak;
+    pendingChips += payout;
+    streak += 1;
+    updateChipDisplays();
+    logEvent(`${table} paid out ${payout} Life Chip${payout === 1 ? "" : "s"}. Streak is ${streak - 1}.`);
+    updateStatus(message ?? "Puzzle cleared. Drop those chips soon!", "success");
+  } else {
+    streak = 1;
+    updateChipDisplays();
+    if (penalty > 0) {
+      timeSand = Math.max(0, timeSand - penalty);
+      updateTime();
+      logEvent(`${table} bust cost ${penalty} seconds.`);
+    } else {
+      logEvent(`${table} bust.`);
+    }
+    updateStatus(message ?? "Bust. The streak resets.", penalty > 0 ? "danger" : "warning");
+    if (timeSand === 0) {
+      endRun("The Time-Sand ran dry. Charlie snaps back upstairs.", "danger");
+    }
+  }
+  depositButton.disabled = !runActive || pendingChips === 0;
+  setActivePuzzle(() => {});
+}
+
+function setActivePuzzle(cleanup) {
+  if (activeCleanup) {
+    activeCleanup();
+  }
+  activeCleanup = cleanup;
+}
+
+function logEvent(message) {
+  const item = document.createElement("li");
+  item.textContent = message;
+  eventList.prepend(item);
+  while (eventList.children.length > LOG_LIMIT) {
+    eventList.removeChild(eventList.lastElementChild);
+  }
+}

--- a/madia.new/public/secret/1989/halo-hustle/index.html
+++ b/madia.new/public/secret/1989/halo-hustle/index.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Halo Hustle</title>
+    <link rel="stylesheet" href="halo-hustle.css" />
+  </head>
+  <body>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 43 · 1989 Arcade</p>
+      <h1>Halo Hustle</h1>
+      <p class="subtitle">
+        Smuggle Life Chips back into the Clock of Life before the last grain of sand slips away.
+      </p>
+    </header>
+    <main class="page-layout">
+      <section class="briefing" aria-labelledby="briefing-title">
+        <h2 id="briefing-title">Parlor Briefing</h2>
+        <p>
+          Charlie&rsquo;s bolted the pearly gate and ducked into the neon parlor, clutching the Clock of Life that leaks Time-Sand by
+          the second. The house has stacked three betting tables with pocket puzzles. Crack them in motion, scoop the Life Chips,
+          and pour them back into the clock before it shatters.
+        </p>
+        <ul class="callouts">
+          <li><strong>Clock of Life:</strong> The hourglass drains in real time. Keep its meter above zero.</li>
+          <li><strong>Betting tables:</strong> Each puzzle feeds chips equal to your streak. Busting wipes the run-up.</li>
+          <li><strong>High stakes:</strong> Long odds chew through sand while you play, but their jackpots can save the night.</li>
+          <li><strong>Chip drop:</strong> Deposit winnings fast to refill the clock before the sand runs dry.</li>
+        </ul>
+        <section class="action-guide" aria-labelledby="action-guide-title">
+          <h3 id="action-guide-title">Actions</h3>
+          <dl>
+            <div>
+              <dt>Start Run</dt>
+              <dd>Kick off the countdown. Tables unlock and the Clock of Life begins to empty.</dd>
+            </div>
+            <div>
+              <dt>Deal Quick Odds</dt>
+              <dd>Fast puzzles that barely nick the clock. Nail them to build your streak.</dd>
+            </div>
+            <div>
+              <dt>Deal High Odds</dt>
+              <dd>Risky tables slow you down in exchange for bigger chip drops. Choose when to gamble.</dd>
+            </div>
+            <div>
+              <dt>Deposit Life Chips</dt>
+              <dd>Pour banked chips back into the clock. Each chip restores four seconds of sand.</dd>
+            </div>
+          </dl>
+        </section>
+      </section>
+      <section class="parlor" aria-labelledby="parlor-title">
+        <div class="parlor-header">
+          <h2 id="parlor-title">Clock of Life Simulator</h2>
+          <div class="run-controls">
+            <button type="button" class="action-button" id="start-run">Start Run</button>
+            <button type="button" class="action-button" id="stop-run" disabled>Stop Run</button>
+            <button type="button" class="action-button" id="deposit-chips" disabled>Deposit Life Chips</button>
+          </div>
+        </div>
+        <p class="parlor-help">
+          Select a table to play its betting puzzle. Winning grows your streak and banks Life Chips&mdash;just don&rsquo;t let the Time-Sand
+          run out before you pour them back into the clock.
+        </p>
+        <div class="status-panels" role="group" aria-label="Run status">
+          <div class="meter-panel">
+            <div class="meter-labels">
+              <span class="meter-title">Time-Sand</span>
+              <span class="meter-value" id="time-remaining-label">60s</span>
+            </div>
+            <div
+              class="meter"
+              role="progressbar"
+              aria-valuemin="0"
+              aria-valuemax="80"
+              aria-valuenow="60"
+              id="time-remaining"
+            >
+              <div class="meter-fill" id="time-fill" style="width: 75%"></div>
+            </div>
+          </div>
+          <div class="summary-panel">
+            <dl>
+              <div>
+                <dt>Banked Life Chips</dt>
+                <dd id="life-chip-total">0</dd>
+              </div>
+              <div>
+                <dt>Streak</dt>
+                <dd id="current-streak">1</dd>
+              </div>
+              <div>
+                <dt>Chips Ready to Drop</dt>
+                <dd id="pending-chips">0</dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+        <div class="status-banner" id="status-banner" role="status" aria-live="polite">
+          Waiting on the first run.
+        </div>
+        <section class="betting-floor" aria-label="Betting tables">
+          <article class="table-card" data-table="halo-cups">
+            <header>
+              <h3>Halo Cups</h3>
+              <p class="table-difficulty">Quick Odds</p>
+            </header>
+            <p>
+              Track the glowing chip as the cups glide. Remember where it lands and tap the right cup before the sand hits bottom.
+            </p>
+            <button type="button" class="table-button" data-table="halo-cups" disabled>Deal Quick Odds</button>
+          </article>
+          <article class="table-card" data-table="lucky-sum">
+            <header>
+              <h3>Lucky Sum</h3>
+              <p class="table-difficulty">Quick Odds</p>
+            </header>
+            <p>
+              Four neon dice light up the felt. Tag the two that add to the called number without hesitating.
+            </p>
+            <button type="button" class="table-button" data-table="lucky-sum" disabled>Deal Quick Odds</button>
+          </article>
+          <article class="table-card" data-table="seraph-sequence">
+            <header>
+              <h3>Seraph Sequence</h3>
+              <p class="table-difficulty">High Stakes</p>
+            </header>
+            <p>
+              The house flashes a haloed suit order. Memorize it, stomach the sand drain, then replay the sequence exactly.
+            </p>
+            <button type="button" class="table-button" data-table="seraph-sequence" disabled>Deal High Odds</button>
+          </article>
+        </section>
+        <section class="puzzle-stage" aria-labelledby="puzzle-stage-title">
+          <h3 id="puzzle-stage-title">Betting Puzzle</h3>
+          <p id="puzzle-instructions">Choose a table to load its puzzle.</p>
+          <div id="puzzle-stage" class="puzzle-stage-body"></div>
+        </section>
+        <section class="event-log" aria-labelledby="event-log-title">
+          <h3 id="event-log-title">Event Log</h3>
+          <ul id="event-list"></ul>
+        </section>
+      </section>
+    </main>
+    <footer class="page-footer">
+      <p>
+        Tip: Keep a steady streak on the quick tables, then gamble on a Seraph Sequence when the clock is topped off. Deposit the
+        haul before chasing the next score.
+      </p>
+    </footer>
+    <script type="module" src="halo-hustle.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add the Halo Hustle cabinet with interactive Time-Sand, streak, and chip mechanics
- build retro parlor styling for the new betting tables and status displays
- register the new level in the 1989 arcade catalog

## Testing
- Manual verification in browser (start run, solve Halo Cups, deposit chips)


------
https://chatgpt.com/codex/tasks/task_e_68dee6e9ed688328a41424ebf944d8fa