### PR TITLE
chore: rename level 42 heatwave block party

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -4,6 +4,50 @@
  */
 const games = [
   {
+    id: "heatwave-block-party",
+    name: "Heatwave Block Party",
+    description: "Route cooling fans to vent grievances before the block boils over.",
+    url: "./heatwave-block-party/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Heatwave Block Party preview">
+        <defs>
+          <linearGradient id="heatWave" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#f97316" />
+            <stop offset="100%" stop-color="#38bdf8" />
+          </linearGradient>
+          <linearGradient id="nightSky" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(15,23,42,0.85)" />
+            <stop offset="100%" stop-color="rgba(5,8,20,0.92)" />
+          </linearGradient>
+        </defs>
+        <rect x="8" y="10" width="144" height="100" rx="18" fill="url(#nightSky)" stroke="rgba(148,163,184,0.35)" />
+        <g transform="translate(26 26)">
+          <rect x="0" y="0" width="48" height="68" rx="12" fill="rgba(15,23,42,0.7)" stroke="rgba(148,163,184,0.35)" />
+          <rect x="10" y="12" width="28" height="44" rx="10" fill="rgba(30,41,59,0.9)" stroke="rgba(56,189,248,0.55)" />
+          <rect x="10" y="44" width="28" height="12" rx="6" fill="rgba(249,115,22,0.75)" />
+          <rect x="10" y="28" width="28" height="12" rx="6" fill="rgba(234,179,8,0.7)" />
+          <rect x="10" y="12" width="28" height="12" rx="6" fill="rgba(56,189,248,0.75)" />
+          <rect x="6" y="58" width="36" height="6" rx="3" fill="rgba(15,23,42,0.9)" stroke="rgba(148,163,184,0.3)" />
+        </g>
+        <g transform="translate(92 34)">
+          <rect x="0" y="12" width="38" height="50" rx="10" fill="rgba(20,27,45,0.86)" stroke="rgba(148,163,184,0.4)" />
+          <rect x="8" y="0" width="22" height="12" rx="4" fill="rgba(56,189,248,0.4)" stroke="rgba(148,163,184,0.35)" />
+          <rect x="6" y="12" width="26" height="30" fill="rgba(15,23,42,0.75)" stroke="rgba(148,163,184,0.45)" />
+          <line x1="6" y1="16" x2="32" y2="16" stroke="rgba(56,189,248,0.3)" stroke-width="2" />
+          <line x1="6" y1="24" x2="32" y2="24" stroke="rgba(56,189,248,0.3)" stroke-width="2" />
+          <line x1="6" y1="32" x2="32" y2="32" stroke="rgba(56,189,248,0.3)" stroke-width="2" />
+          <rect x="4" y="42" width="30" height="14" rx="6" fill="rgba(249,115,22,0.75)" stroke="rgba(249,115,22,0.9)" />
+        </g>
+        <g transform="translate(28 20)">
+          <path d="M0 72 C24 60 56 28 96 18" fill="none" stroke="url(#heatWave)" stroke-width="6" stroke-linecap="round" />
+          <circle cx="96" cy="18" r="8" fill="#f97316" stroke="rgba(248,250,252,0.6)" stroke-width="2" />
+          <circle cx="48" cy="48" r="6" fill="#38bdf8" stroke="rgba(148,163,184,0.45)" stroke-width="2" />
+          <circle cx="26" cy="68" r="5" fill="#7b5bff" stroke="rgba(148,163,184,0.45)" stroke-width="2" />
+        </g>
+      </svg>
+    `,
+  },
+  {
     id: "cable-clash",
     name: "The Cable Clash",
     description: "Route the cobalt line across the ring while juking roaming rivals.",

--- a/madia.new/public/secret/1989/heatwave-block-party/heatwave-block-party.css
+++ b/madia.new/public/secret/1989/heatwave-block-party/heatwave-block-party.css
@@ -1,0 +1,410 @@
+:root {
+  color-scheme: dark;
+  --bg: #04060f;
+  --panel: rgba(10, 16, 32, 0.86);
+  --border: rgba(148, 163, 184, 0.32);
+  --accent: #f97316;
+  --accent-soft: rgba(249, 115, 22, 0.35);
+  --cool: #38bdf8;
+  --danger: #ef4444;
+  --muted: rgba(148, 163, 184, 0.72);
+  --success: #34d399;
+  font-family: "IBM Plex Sans", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+body {
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.12), transparent 65%), var(--bg);
+  color: #e2e8f0;
+  margin: 0;
+  min-height: 100vh;
+}
+
+.scanlines::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(2, 6, 23, 0) 0,
+    rgba(2, 6, 23, 0) 2px,
+    rgba(2, 6, 23, 0.12) 4px
+  );
+  mix-blend-mode: soft-light;
+  opacity: 0.5;
+}
+
+.page-header {
+  padding: 3rem 5vw 2rem;
+  text-align: center;
+}
+
+.eyebrow {
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.page-header h1 {
+  margin: 0.6rem 0 0.4rem;
+  font-size: clamp(2.4rem, 4vw, 3.4rem);
+}
+
+.subtitle {
+  margin: 0 auto;
+  max-width: 720px;
+  color: rgba(226, 232, 240, 0.8);
+  font-size: 1.05rem;
+}
+
+.page-layout {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(260px, 360px) minmax(480px, 1fr);
+  padding: 0 5vw 3rem;
+}
+
+.briefing,
+.arena {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 1.75rem;
+  box-shadow: 0 28px 70px rgba(8, 11, 24, 0.45);
+}
+
+.briefing p {
+  line-height: 1.6;
+}
+
+.callouts {
+  margin: 1.2rem 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.callouts li {
+  line-height: 1.5;
+}
+
+.controls dl {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.controls dt {
+  font-weight: 600;
+  margin-bottom: 0.15rem;
+}
+
+.controls dd {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.arena-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.arena-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.action-button {
+  background: rgba(15, 23, 42, 0.8);
+  color: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 12px;
+  padding: 0.45rem 0.9rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
+}
+
+.action-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.action-button:not(:disabled):hover {
+  background: rgba(56, 189, 248, 0.12);
+  border-color: rgba(56, 189, 248, 0.4);
+  transform: translateY(-1px);
+}
+
+.status-bar {
+  background: rgba(15, 23, 42, 0.66);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1.25rem;
+  min-height: 52px;
+  display: flex;
+  align-items: center;
+  font-size: 0.95rem;
+}
+
+.gauges {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-bottom: 1.5rem;
+}
+
+.meter,
+.timer {
+  background: rgba(9, 13, 25, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 14px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.meter-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.meter-reading {
+  font-variant-numeric: tabular-nums;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.meter-track {
+  position: relative;
+  height: 18px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.86);
+  overflow: hidden;
+}
+
+.meter-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--cool), #7b5bff);
+  transition: width 220ms ease;
+}
+
+.meter-fill.danger {
+  background: linear-gradient(90deg, rgba(239, 68, 68, 0.7), rgba(234, 179, 8, 0.85));
+}
+
+.meter-outburst {
+  background: linear-gradient(90deg, rgba(249, 115, 22, 0.5), var(--accent));
+}
+
+.meter-critical {
+  position: absolute;
+  right: 12%;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: rgba(239, 68, 68, 0.65);
+}
+
+.timer-reading {
+  font-size: 1.8rem;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.lock-banner {
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.45);
+  color: rgba(248, 113, 113, 0.92);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1.25rem;
+  text-align: center;
+  font-weight: 600;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(60px, 1fr));
+  gap: 0.6rem;
+  background: rgba(8, 12, 24, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 16px;
+  padding: 1rem;
+}
+
+.board-tile {
+  position: relative;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.78);
+  border-radius: 14px;
+  min-height: 76px;
+  padding: 0.65rem;
+  display: grid;
+  gap: 0.4rem;
+  justify-items: center;
+  color: rgba(226, 232, 240, 0.82);
+  cursor: default;
+  transition: border-color 140ms ease, background 140ms ease, transform 140ms ease;
+}
+
+.board-tile.selectable {
+  cursor: pointer;
+}
+
+.board-tile.selectable:hover {
+  border-color: rgba(56, 189, 248, 0.45);
+  background: rgba(30, 41, 59, 0.88);
+}
+
+.board-tile.selected {
+  border-color: rgba(56, 189, 248, 0.8);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.35);
+  transform: translateY(-1px);
+}
+
+.board-tile[data-type="hydrant"] {
+  background: rgba(24, 16, 32, 0.82);
+  border-color: rgba(239, 68, 68, 0.45);
+}
+
+.board-tile[data-type="trash-can"] {
+  border-color: rgba(249, 115, 22, 0.55);
+  background: rgba(249, 115, 22, 0.18);
+}
+
+.board-tile[data-type="vent"] {
+  border-color: rgba(56, 189, 248, 0.55);
+  background: rgba(56, 189, 248, 0.16);
+}
+
+.tile-label {
+  font-size: 0.8rem;
+  text-align: center;
+  line-height: 1.3;
+}
+
+.grievance-badge {
+  min-width: 36px;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(249, 115, 22, 0.22);
+  border: 1px solid rgba(249, 115, 22, 0.5);
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.board-tile[data-grievance="0"] .grievance-badge {
+  display: none;
+}
+
+.legend ul {
+  margin: 0.75rem 0 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.legend-swatch {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  margin-right: 0.6rem;
+  vertical-align: middle;
+}
+
+.legend-swatch.vent {
+  background: rgba(56, 189, 248, 0.6);
+}
+
+.legend-swatch.trash {
+  background: rgba(249, 115, 22, 0.6);
+}
+
+.legend-swatch.hydrant {
+  background: rgba(239, 68, 68, 0.6);
+}
+
+.legend-swatch.grievance {
+  background: rgba(249, 115, 22, 0.25);
+  border: 1px solid rgba(249, 115, 22, 0.7);
+}
+
+.log {
+  margin-top: 1.5rem;
+}
+
+#log-entries {
+  list-style: none;
+  margin: 0.8rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.log-entry {
+  background: rgba(15, 23, 42, 0.75);
+  border-radius: 10px;
+  padding: 0.55rem 0.75rem;
+  font-size: 0.85rem;
+  border-left: 3px solid rgba(148, 163, 184, 0.3);
+}
+
+.log-entry.success {
+  border-left-color: var(--success);
+}
+
+.log-entry.warning {
+  border-left-color: var(--accent);
+}
+
+.log-entry.danger {
+  border-left-color: var(--danger);
+}
+
+.page-footer {
+  text-align: center;
+  padding: 2rem 5vw 4rem;
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.95rem;
+}
+
+@media (max-width: 1080px) {
+  .page-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .arena {
+    order: -1;
+  }
+}
+
+@media (max-width: 640px) {
+  .arena-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .arena-controls {
+    justify-content: center;
+  }
+
+  .board {
+    grid-template-columns: repeat(5, minmax(48px, 1fr));
+    gap: 0.45rem;
+  }
+}

--- a/madia.new/public/secret/1989/heatwave-block-party/heatwave-block-party.js
+++ b/madia.new/public/secret/1989/heatwave-block-party/heatwave-block-party.js
@@ -1,0 +1,484 @@
+const GRID_SIZE = 5;
+const LEVEL_DURATION_MS = 90_000;
+const TEMPERATURE_MAX = 100;
+const CRITICAL_THRESHOLD = 88;
+const BASE_TEMP_RISE_PER_SECOND = 0.55;
+const GRIEVANCE_TEMP_RISE_PER_SECOND = 0.85;
+const ROUTE_MAX_LENGTH = 4;
+const GRIEVANCE_SPAWN_INTERVAL_MS = 4_200;
+const OUTBURST_MAX = 100;
+const OUTBURST_WAIT_PENALTY = 8;
+const OUTBURST_BLOCK_PENALTY = 12;
+const OUTBURST_COOL_BONUS = -8;
+const ROUTE_COOL_BASE = 6;
+const ROUTE_COOL_PER_EXTRA = 2;
+const TRASH_CAN_LOCK_MS = 6_000;
+const STARTING_TEMPERATURE = 46;
+
+const boardTemplate = [
+  { id: "dj-rooftop", label: "DJ Booth Roof", type: "vent", passable: true, initialGrievance: 0 },
+  { id: "stoop-a", label: "Brownstone Stoop", type: "stoop", passable: true, initialGrievance: 1 },
+  { id: "block-party", label: "Block Party Stage", type: "street", passable: true, initialGrievance: 1 },
+  { id: "mural", label: "Bedford Mural", type: "street", passable: true, initialGrievance: 0 },
+  { id: "hydrant-north", label: "Burst Hydrant", type: "hydrant", passable: false, initialGrievance: 0 },
+  { id: "pizza-window", label: "Slice Shop Window", type: "stoop", passable: true, initialGrievance: 0 },
+  { id: "crosswalk", label: "Crosswalk Beat", type: "street", passable: true, initialGrievance: 1 },
+  { id: "newsstand", label: "Newsstand Corner", type: "street", passable: true, initialGrievance: 0 },
+  { id: "stoop-b", label: "Front Stoop", type: "stoop", passable: true, initialGrievance: 0 },
+  { id: "hydrant-east", label: "Barricaded Hydrant", type: "hydrant", passable: false, initialGrievance: 0 },
+  { id: "bodega", label: "Slice Shop Queue", type: "street", passable: true, initialGrievance: 1 },
+  { id: "open-avenue", label: "Open Avenue", type: "street", passable: true, initialGrievance: 0 },
+  { id: "trash-can", label: "Trash Can Stack", type: "trash-can", passable: true, initialGrievance: 2 },
+  { id: "park-bench", label: "Community Bench", type: "street", passable: true, initialGrievance: 0 },
+  { id: "stoop-c", label: "Window Watch", type: "stoop", passable: true, initialGrievance: 0 },
+  { id: "garden", label: "Community Garden", type: "street", passable: true, initialGrievance: 1 },
+  { id: "alley", label: "Shaded Alley", type: "street", passable: true, initialGrievance: 0 },
+  { id: "roadblock", label: "Police Barricade", type: "hydrant", passable: false, initialGrievance: 0 },
+  { id: "record-shop", label: "Record Shop Queue", type: "street", passable: true, initialGrievance: 0 },
+  { id: "vent-south", label: "Backlot Vent", type: "vent", passable: true, initialGrievance: 0 },
+  { id: "hydrant-south", label: "Ruined Hydrant", type: "hydrant", passable: false, initialGrievance: 0 },
+  { id: "alley-south", label: "Alley Shortcut", type: "street", passable: true, initialGrievance: 1 },
+  { id: "stoop-d", label: "Community Steps", type: "stoop", passable: true, initialGrievance: 0 },
+  { id: "block-crowd", label: "Block Crowd", type: "street", passable: true, initialGrievance: 0 },
+  { id: "radio-van", label: "Radio Van", type: "street", passable: true, initialGrievance: 0 },
+];
+
+const startDayButton = document.getElementById("start-day");
+const resetDayButton = document.getElementById("reset-day");
+const holdPositionButton = document.getElementById("hold-position");
+const routeFanButton = document.getElementById("route-fan");
+const commitRouteButton = document.getElementById("commit-route");
+const cancelRouteButton = document.getElementById("cancel-route");
+const trashCanButton = document.getElementById("trash-can-toss");
+const statusBar = document.getElementById("status-bar");
+const temperatureFill = document.getElementById("temperature-fill");
+const temperatureReading = document.getElementById("temperature-reading");
+const outburstFill = document.getElementById("outburst-fill");
+const outburstReading = document.getElementById("outburst-reading");
+const timerRemaining = document.getElementById("timer-remaining");
+const boardElement = document.getElementById("board");
+const lockBanner = document.getElementById("lock-banner");
+const logEntries = document.getElementById("log-entries");
+
+const tileElements = [];
+
+const state = {
+  playing: false,
+  selection: [],
+  selecting: false,
+  temperature: STARTING_TEMPERATURE,
+  outburst: 0,
+  timerEnd: 0,
+  lastTick: 0,
+  lockedUntil: 0,
+  locked: false,
+  tickTimer: 0,
+  spawnTimer: 0,
+  cells: [],
+};
+
+initializeBoard();
+resetState();
+
+startDayButton.addEventListener("click", startDay);
+resetDayButton.addEventListener("click", () => {
+  resetState();
+  logEvent("Day reset. Fresh morning breeze returns.", "warning");
+  updateStatus("Day reset. Press Start Day to resume the watch.");
+});
+holdPositionButton.addEventListener("click", holdPosition);
+routeFanButton.addEventListener("click", enterRouteMode);
+commitRouteButton.addEventListener("click", commitRoute);
+cancelRouteButton.addEventListener("click", exitRouteMode);
+trashCanButton.addEventListener("click", trashCanToss);
+boardElement.addEventListener("click", handleTileClick);
+
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState === "hidden" && state.playing) {
+    updateStatus("Heat keeps rising even while you look away.");
+  }
+});
+
+function initializeBoard() {
+  boardElement.innerHTML = "";
+  tileElements.length = 0;
+  boardTemplate.forEach((cell, index) => {
+    const tile = document.createElement("button");
+    tile.type = "button";
+    tile.className = "board-tile";
+    tile.dataset.index = String(index);
+    tile.dataset.type = cell.type;
+    tile.dataset.grievance = "0";
+    tile.setAttribute("role", "gridcell");
+    tile.setAttribute("aria-label", `${cell.label}. No grievances.`);
+    tile.innerHTML = `
+      <span class="tile-label">${cell.label}</span>
+      <span class="grievance-badge">0</span>
+    `;
+    boardElement.append(tile);
+    tileElements.push(tile);
+  });
+}
+
+function resetState() {
+  clearInterval(state.tickTimer);
+  clearInterval(state.spawnTimer);
+  state.playing = false;
+  state.selecting = false;
+  state.selection = [];
+  state.temperature = STARTING_TEMPERATURE;
+  state.outburst = 0;
+  state.timerEnd = 0;
+  state.lastTick = 0;
+  state.locked = false;
+  state.lockedUntil = 0;
+  state.tickTimer = 0;
+  state.spawnTimer = 0;
+  state.cells = boardTemplate.map((cell) => ({
+    ...cell,
+    grievance: cell.initialGrievance,
+  }));
+  logEntries.innerHTML = "";
+  updateBoard();
+  updateGauges();
+  updateTimerDisplay(LEVEL_DURATION_MS);
+  updateStatus("Press Start Day to begin the heat watch.");
+  updateButtons();
+  updateLockBanner();
+}
+
+function startDay() {
+  if (state.playing) {
+    return;
+  }
+  resetState();
+  state.playing = true;
+  state.timerEnd = Date.now() + LEVEL_DURATION_MS;
+  state.lastTick = Date.now();
+  state.tickTimer = window.setInterval(handleTick, 1_000);
+  state.spawnTimer = window.setInterval(spawnGrievances, GRIEVANCE_SPAWN_INTERVAL_MS);
+  updateStatus("Heat wave rolling. Route cooling air to keep temp contained.");
+  logEvent("Heat wave rolling. Fan routes now active.", "success");
+  updateButtons();
+}
+
+function holdPosition() {
+  if (!state.playing || state.locked) {
+    return;
+  }
+  changeTemperature(1.5);
+  adjustOutburst(OUTBURST_WAIT_PENALTY);
+  updateStatus("Holding position. The block sweats and pressure builds.");
+  logEvent("Hold position. Pressure creeps up while the heat sticks.", "warning");
+}
+
+function enterRouteMode() {
+  if (!state.playing || state.locked) {
+    return;
+  }
+  state.selecting = true;
+  state.selection = [];
+  updateStatus("Route mode active. Click up to four connected tiles to sweep cooling air.");
+  updateTileHighlights();
+  updateButtons();
+}
+
+function commitRoute() {
+  if (!state.selecting || state.selection.length === 0 || state.locked) {
+    updateStatus("Select connected tiles before committing the route.");
+    return;
+  }
+  let blocked = false;
+  let cleared = 0;
+  state.selection.forEach((index) => {
+    const cell = state.cells[index];
+    if (!cell.passable) {
+      blocked = true;
+      return;
+    }
+    if (cell.grievance > 0) {
+      cell.grievance -= 1;
+      cleared += 1;
+    }
+  });
+  if (blocked) {
+    adjustOutburst(OUTBURST_BLOCK_PENALTY);
+    logEvent("Cooling route hits a barricade—pressure surges.", "danger");
+  }
+  if (cleared > 0) {
+    const reduction = ROUTE_COOL_BASE + (cleared - 1) * ROUTE_COOL_PER_EXTRA;
+    changeTemperature(-reduction);
+    adjustOutburst(OUTBURST_COOL_BONUS);
+    updateStatus(`Cooling fan clears ${cleared} grievance block${cleared > 1 ? "s" : ""}.`);
+    logEvent(`Cooling fan clears ${cleared} grievance block${cleared > 1 ? "s" : ""}.`, "success");
+  } else if (!blocked) {
+    adjustOutburst(OUTBURST_WAIT_PENALTY);
+    updateStatus("The route swept clean stoops. No relief, pressure grows.");
+    logEvent("Cooling route misses grievances—tensions simmer.", "warning");
+  }
+  exitRouteMode();
+  updateBoard();
+  updateGauges();
+}
+
+function exitRouteMode() {
+  state.selecting = false;
+  state.selection.forEach((index) => {
+    const tile = tileElements[index];
+    if (tile) {
+      tile.classList.remove("selected");
+      tile.setAttribute("aria-selected", "false");
+    }
+  });
+  state.selection = [];
+  updateTileHighlights();
+  updateButtons();
+}
+
+function handleTileClick(event) {
+  const tile = event.target.closest(".board-tile");
+  if (!tile) {
+    return;
+  }
+  const index = Number.parseInt(tile.dataset.index ?? "-1", 10);
+  if (Number.isNaN(index)) {
+    return;
+  }
+  if (!state.playing) {
+    updateStatus("Heat cycle hasn't started yet. Press Start Day.");
+    return;
+  }
+  if (state.locked) {
+    updateStatus("Board locked—cooling controls offline during the outburst aftermath.");
+    return;
+  }
+  if (!state.selecting) {
+    updateStatus("Enter Route Mode to chart a cooling path.");
+    return;
+  }
+  const cell = state.cells[index];
+  if (!cell.passable) {
+    adjustOutburst(OUTBURST_BLOCK_PENALTY / 2);
+    updateStatus("Hydrant blocks the airflow—the crew bristles.");
+    logEvent("Hydrant blocks the attempted route.", "warning");
+    return;
+  }
+  if (state.selection.length > 0) {
+    const lastIndex = state.selection[state.selection.length - 1];
+    if (!areNeighbors(lastIndex, index)) {
+      updateStatus("Routes must stay connected. Choose a tile adjacent to your last pick.");
+      return;
+    }
+  }
+  if (state.selection.includes(index)) {
+    updateStatus("Tile already in the path. Pick a different neighbor.");
+    return;
+  }
+  if (state.selection.length >= ROUTE_MAX_LENGTH) {
+    updateStatus("Route maxed out. Commit or cancel before adding more.");
+    return;
+  }
+  state.selection.push(index);
+  tile.classList.add("selected");
+  tile.setAttribute("aria-selected", "true");
+  updateButtons();
+}
+
+function areNeighbors(a, b) {
+  const rowA = Math.floor(a / GRID_SIZE);
+  const colA = a % GRID_SIZE;
+  const rowB = Math.floor(b / GRID_SIZE);
+  const colB = b % GRID_SIZE;
+  return Math.abs(rowA - rowB) + Math.abs(colA - colB) === 1;
+}
+
+function trashCanToss() {
+  if (!state.playing || state.outburst < OUTBURST_MAX || state.locked) {
+    return;
+  }
+  exitRouteMode();
+  changeTemperature(-26);
+  state.outburst = 0;
+  state.locked = true;
+  state.lockedUntil = Date.now() + TRASH_CAN_LOCK_MS;
+  updateStatus("Trash can arcs—heat crashes but chaos locks the board.");
+  logEvent("Trash can toss erupts, cooling the block but freezing controls.", "warning");
+  updateGauges();
+  updateButtons();
+  updateLockBanner();
+}
+
+function handleTick() {
+  if (!state.playing) {
+    return;
+  }
+  const now = Date.now();
+  const secondsElapsed = (now - state.lastTick) / 1_000;
+  state.lastTick = now;
+  if (state.locked && now >= state.lockedUntil) {
+    state.locked = false;
+    updateStatus("Crew regroups. Cooling controls back online.");
+    logEvent("Cooling controls restored after the outburst.", "success");
+    updateButtons();
+    updateLockBanner();
+  }
+  const grievances = totalGrievances();
+  const tempRise = BASE_TEMP_RISE_PER_SECOND * secondsElapsed + GRIEVANCE_TEMP_RISE_PER_SECOND * grievances * secondsElapsed;
+  changeTemperature(tempRise);
+  const remaining = Math.max(state.timerEnd - now, 0);
+  updateTimerDisplay(remaining);
+  updateGauges();
+  if (state.temperature >= TEMPERATURE_MAX) {
+    endDay(false, "Temperature hits the boiling point. The block erupts.");
+    return;
+  }
+  if (remaining <= 0) {
+    endDay(true, "Day cools without boiling over. Peace holds on the block.");
+  }
+}
+
+function spawnGrievances() {
+  if (!state.playing) {
+    return;
+  }
+  const candidates = state.cells
+    .map((cell, index) => ({ cell, index }))
+    .filter(({ cell }) => cell.passable);
+  if (candidates.length === 0) {
+    return;
+  }
+  const spawnCount = state.temperature > CRITICAL_THRESHOLD ? 3 : 2;
+  const pool = [...candidates];
+  const chosen = new Set();
+  while (pool.length > 0 && chosen.size < spawnCount) {
+    const choiceIndex = Math.floor(Math.random() * pool.length);
+    const [{ index }] = pool.splice(choiceIndex, 1);
+    chosen.add(index);
+  }
+  if (chosen.size === 0) {
+    return;
+  }
+  chosen.forEach((index) => {
+    const cell = state.cells[index];
+    cell.grievance = Math.min(cell.grievance + 1, 3);
+  });
+  updateBoard();
+  const message = `${chosen.size} grievance block${chosen.size > 1 ? "s" : ""} flare in the heat.`;
+  logEvent(message, state.locked ? "danger" : "warning");
+  updateStatus("New grievances flare up—keep the fans moving.");
+}
+
+function totalGrievances() {
+  return state.cells.reduce((sum, cell) => sum + cell.grievance, 0);
+}
+
+function changeTemperature(delta) {
+  state.temperature = Math.max(0, Math.min(TEMPERATURE_MAX, state.temperature + delta));
+}
+
+function adjustOutburst(amount) {
+  const wasMaxed = state.outburst >= OUTBURST_MAX;
+  const next = Math.max(0, Math.min(OUTBURST_MAX, state.outburst + amount));
+  state.outburst = next;
+  if (state.outburst >= OUTBURST_MAX && !wasMaxed) {
+    updateStatus("Outburst meter primed. Trash can toss ready when you call it.");
+    logEvent("Outburst meter maxed—trash can toss armed.", "warning");
+  }
+  updateButtons();
+  updateGauges();
+}
+
+function updateBoard() {
+  state.cells.forEach((cell, index) => {
+    const tile = tileElements[index];
+    if (!tile) {
+      return;
+    }
+    tile.dataset.grievance = String(cell.grievance);
+    tile.dataset.type = cell.type;
+    const badge = tile.querySelector(".grievance-badge");
+    if (badge) {
+      badge.textContent = `${cell.grievance}`;
+    }
+    const grievanceText = cell.grievance === 0 ? "No grievances" : `${cell.grievance} grievance block${cell.grievance > 1 ? "s" : ""}`;
+    tile.setAttribute("aria-label", `${cell.label}. ${grievanceText}.`);
+  });
+  updateTileHighlights();
+}
+
+function updateTileHighlights() {
+  tileElements.forEach((tile, index) => {
+    const cell = state.cells[index];
+    if (state.selecting && cell.passable && !state.locked) {
+      tile.classList.add("selectable");
+    } else {
+      tile.classList.remove("selectable");
+    }
+    if (!state.selecting) {
+      tile.classList.remove("selected");
+      tile.setAttribute("aria-selected", "false");
+    }
+  });
+}
+
+function updateGauges() {
+  const temperaturePercent = Math.round((state.temperature / TEMPERATURE_MAX) * 100);
+  temperatureFill.style.width = `${temperaturePercent}%`;
+  temperatureReading.textContent = `${temperaturePercent}%`;
+  temperatureFill.classList.toggle("danger", state.temperature >= CRITICAL_THRESHOLD);
+  const outburstPercent = Math.round((state.outburst / OUTBURST_MAX) * 100);
+  outburstFill.style.width = `${outburstPercent}%`;
+  outburstReading.textContent = `${outburstPercent}%`;
+}
+
+function updateTimerDisplay(remainingMs) {
+  const minutes = Math.floor(remainingMs / 60_000);
+  const seconds = Math.floor((remainingMs % 60_000) / 1_000);
+  const paddedSeconds = String(seconds).padStart(2, "0");
+  timerRemaining.textContent = `${String(minutes).padStart(2, "0")}:${paddedSeconds}`;
+}
+
+function updateStatus(message) {
+  statusBar.textContent = message;
+}
+
+function logEvent(message, variant = "info") {
+  const entry = document.createElement("li");
+  entry.className = `log-entry ${variant}`;
+  entry.textContent = message;
+  logEntries.prepend(entry);
+  while (logEntries.children.length > 12) {
+    logEntries.removeChild(logEntries.lastElementChild);
+  }
+}
+
+function updateButtons() {
+  startDayButton.disabled = state.playing;
+  resetDayButton.disabled = false;
+  holdPositionButton.disabled = !state.playing || state.locked;
+  routeFanButton.disabled = !state.playing || state.locked;
+  commitRouteButton.disabled = !state.selecting || state.selection.length === 0 || state.locked;
+  cancelRouteButton.disabled = !state.selecting;
+  trashCanButton.disabled = !state.playing || state.outburst < OUTBURST_MAX || state.locked;
+}
+
+function updateLockBanner() {
+  lockBanner.hidden = !state.locked;
+}
+
+function endDay(success, message) {
+  if (!state.playing) {
+    return;
+  }
+  clearInterval(state.tickTimer);
+  clearInterval(state.spawnTimer);
+  state.playing = false;
+  state.selecting = false;
+  state.selection = [];
+  state.locked = false;
+  state.lockedUntil = 0;
+  updateStatus(message);
+  logEvent(message, success ? "success" : "danger");
+  updateButtons();
+  updateLockBanner();
+}

--- a/madia.new/public/secret/1989/heatwave-block-party/index.html
+++ b/madia.new/public/secret/1989/heatwave-block-party/index.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Heatwave Block Party</title>
+    <link rel="stylesheet" href="heatwave-block-party.css" />
+  </head>
+  <body>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 42 · 1989 Arcade</p>
+      <h1>Heatwave Block Party</h1>
+      <p class="subtitle">
+        Ride out the heat wave by venting grievances, routing cooling fans, and timing the final trash can toss.
+      </p>
+    </header>
+    <main class="page-layout">
+      <section class="briefing" aria-labelledby="briefing-title">
+        <h2 id="briefing-title">Neighborhood Briefing</h2>
+        <p>
+          Temperatures climb all day across Bedford-Stuy and frustrations keep stacking up. Keep the block calm by sweeping
+          cooling air over building fronts before grievances ignite. Manage the Outburst meter so the trash can toss lands when
+          you actually need it.
+        </p>
+        <ul class="callouts">
+          <li>
+            <strong>Temperature gauge:</strong> Climbs steadily and spikes with each unresolved grievance block. Cross the
+            critical mark and the neighborhood boils over.
+          </li>
+          <li>
+            <strong>Cooling fan routes:</strong> Enter <em>Route Mode</em> then click up to four connected tiles to sweep away
+            grievances. Each cooled block drops the gauge and calms the street.
+          </li>
+          <li>
+            <strong>Outburst meter:</strong> Waiting out jams or hitting barricades fills it. Once maxed, unleash the trash can
+            toss to smash the heat—but the chaos locks board controls briefly.
+          </li>
+          <li><strong>Victory:</strong> Keep the temperature below the critical point until the day timer expires.</li>
+        </ul>
+        <section class="controls" aria-labelledby="controls-title">
+          <h3 id="controls-title">Controls</h3>
+          <dl>
+            <div>
+              <dt>Start day</dt>
+              <dd>Press <strong>Start Day</strong> to kick off the timeline and heat cycles.</dd>
+            </div>
+            <div>
+              <dt>Route cooling fan</dt>
+              <dd>
+                Press <strong>Route Fan</strong>, click connected tiles, then select <strong>Commit Route</strong> to clear
+                grievances.
+              </dd>
+            </div>
+            <div>
+              <dt>Hold position</dt>
+              <dd>Use <strong>Hold Position</strong> when you need to wait. It cools nothing but raises Outburst pressure.</dd>
+            </div>
+            <div>
+              <dt>Trash can toss</dt>
+              <dd>
+                Available only with a full Outburst meter. Instantly drops temperature but locks the board for a few seconds.
+              </dd>
+            </div>
+          </dl>
+        </section>
+      </section>
+      <section class="arena" aria-labelledby="arena-title">
+        <div class="arena-header">
+          <h2 id="arena-title">Bedford-Stuy Streets</h2>
+          <div class="arena-controls" role="group" aria-label="Action controls">
+            <button type="button" class="action-button" id="start-day">Start Day</button>
+            <button type="button" class="action-button" id="reset-day" disabled>Reset</button>
+            <button type="button" class="action-button" id="hold-position" disabled>Hold Position</button>
+            <button type="button" class="action-button" id="route-fan" disabled>Route Fan</button>
+            <button type="button" class="action-button" id="commit-route" disabled>Commit Route</button>
+            <button type="button" class="action-button" id="cancel-route" disabled>Cancel Route</button>
+            <button type="button" class="action-button" id="trash-can-toss" disabled>Trash Can Toss</button>
+          </div>
+        </div>
+        <div class="status-bar" id="status-bar" role="status" aria-live="polite">
+          Press Start Day to begin the heat watch.
+        </div>
+        <div class="gauges">
+          <section class="meter" aria-labelledby="temperature-label">
+            <header class="meter-header">
+              <h3 id="temperature-label">Temperature Gauge</h3>
+              <span class="meter-reading" id="temperature-reading">0%</span>
+            </header>
+            <div class="meter-track" aria-hidden="true">
+              <div class="meter-fill" id="temperature-fill"></div>
+              <div class="meter-critical"></div>
+            </div>
+          </section>
+          <section class="meter" aria-labelledby="outburst-label">
+            <header class="meter-header">
+              <h3 id="outburst-label">Outburst Meter</h3>
+              <span class="meter-reading" id="outburst-reading">0%</span>
+            </header>
+            <div class="meter-track" aria-hidden="true">
+              <div class="meter-fill meter-outburst" id="outburst-fill"></div>
+            </div>
+          </section>
+          <section class="timer" aria-labelledby="timer-label">
+            <h3 id="timer-label">Day Timer</h3>
+            <p id="timer-remaining" class="timer-reading">01:30</p>
+          </section>
+        </div>
+        <div class="lock-banner" id="lock-banner" hidden aria-live="assertive">
+          Board locked—cooling fans grounded while tensions flare.
+        </div>
+        <div class="board" id="board" role="grid" aria-label="Cooling grid"></div>
+        <section class="legend" aria-labelledby="legend-title">
+          <h3 id="legend-title">Legend</h3>
+          <ul>
+            <li><span class="legend-swatch vent"></span> Rooftop vent (fan start)</li>
+            <li><span class="legend-swatch trash"></span> Trash can release</li>
+            <li><span class="legend-swatch hydrant"></span> Blocked hydrant</li>
+            <li><span class="legend-swatch grievance"></span> Grievance block</li>
+          </ul>
+        </section>
+        <section class="log" aria-labelledby="log-title">
+          <h3 id="log-title">Street Log</h3>
+          <ul id="log-entries"></ul>
+        </section>
+      </section>
+    </main>
+    <footer class="page-footer">
+      <p>
+        Tip: A controlled trash can toss buys breathing room, but the freeze on fan routes means grievances can pile up fast.
+        Time it for a thick cluster, not a passing spark.
+      </p>
+    </footer>
+    <script type="module" src="heatwave-block-party.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- retitle the level 42 cabinet entry and assets as "Heatwave Block Party"
- adjust the slice shop board label to keep film references oblique

## Testing
- Not run (static content only)


------
https://chatgpt.com/codex/tasks/task_e_68dee76c10348328b7a900a9717d6170