### PR TITLE
Add Captain's Echo level 39 cabinet

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -266,6 +266,53 @@ const games = [
     `,
   },
   {
+    id: "captains-echo",
+    name: "Captain's Echo",
+    description: "Stage the four-beat desk salute before the dean snuffs the Carpe Diem spark.",
+    url: "./captains-echo/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Captain's Echo preview">
+        <defs>
+          <linearGradient id="echoGlow" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#38bdf8" />
+            <stop offset="100%" stop-color="#7b5bff" />
+          </linearGradient>
+          <linearGradient id="deskWood" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(249,115,22,0.6)" />
+            <stop offset="100%" stop-color="rgba(249,115,22,0.35)" />
+          </linearGradient>
+        </defs>
+        <rect x="6" y="6" width="148" height="108" rx="18" fill="rgba(5,8,20,0.92)" stroke="rgba(120,255,255,0.4)" />
+        <rect x="16" y="18" width="128" height="84" rx="16" fill="rgba(9,14,32,0.9)" stroke="rgba(120,255,255,0.25)" />
+        <path d="M16 68h128" stroke="rgba(120,255,255,0.18)" stroke-width="2" stroke-linecap="round" />
+        <g>
+          <circle cx="40" cy="32" r="12" fill="rgba(56,189,248,0.35)" stroke="rgba(56,189,248,0.6)" />
+          <circle cx="80" cy="30" r="10" fill="rgba(123,91,255,0.3)" stroke="rgba(123,91,255,0.6)" />
+          <circle cx="120" cy="34" r="12" fill="rgba(248,113,113,0.28)" stroke="rgba(248,113,113,0.6)" />
+        </g>
+        <g transform="translate(30 72)">
+          <rect x="0" y="0" width="30" height="18" rx="6" fill="url(#deskWood)" stroke="rgba(148,163,184,0.4)" />
+          <rect x="4" y="-8" width="22" height="10" rx="4" fill="rgba(56,189,248,0.2)" stroke="rgba(56,189,248,0.5)" />
+          <rect x="6" y="6" width="18" height="6" rx="2" fill="rgba(15,23,42,0.85)" />
+        </g>
+        <g transform="translate(65 72)">
+          <rect x="0" y="0" width="30" height="18" rx="6" fill="url(#deskWood)" stroke="rgba(148,163,184,0.4)" />
+          <rect x="4" y="-10" width="22" height="12" rx="5" fill="rgba(123,91,255,0.22)" stroke="rgba(123,91,255,0.55)" />
+          <rect x="6" y="6" width="18" height="6" rx="2" fill="rgba(15,23,42,0.85)" />
+        </g>
+        <g transform="translate(100 72)">
+          <rect x="0" y="0" width="30" height="18" rx="6" fill="url(#deskWood)" stroke="rgba(148,163,184,0.4)" />
+          <rect x="4" y="-6" width="22" height="8" rx="3" fill="rgba(248,113,113,0.22)" stroke="rgba(248,113,113,0.55)" />
+          <rect x="6" y="6" width="18" height="6" rx="2" fill="rgba(15,23,42,0.85)" />
+        </g>
+        <path d="M32 52 C48 48 64 48 80 52 C96 56 112 56 128 52" fill="none" stroke="url(#echoGlow)" stroke-width="3" stroke-linecap="round" stroke-dasharray="6 6" />
+        <circle cx="28" cy="92" r="4" fill="#38bdf8" />
+        <circle cx="64" cy="94" r="4" fill="#7b5bff" />
+        <circle cx="100" cy="92" r="4" fill="#f97316" />
+      </svg>
+    `,
+  },
+  {
     id: "prototype",
     name: "Prototype Cabinet",
     description: "Drop a new game folder in \"secret\" and point the cab here.",

--- a/madia.new/public/secret/1989/captains-echo/captains-echo.css
+++ b/madia.new/public/secret/1989/captains-echo/captains-echo.css
@@ -1,0 +1,467 @@
+:root {
+  color-scheme: dark;
+  font-family: "Space Grotesk", "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --bg: #040612;
+  --panel: rgba(10, 16, 32, 0.92);
+  --panel-soft: rgba(12, 19, 38, 0.78);
+  --border: rgba(120, 255, 255, 0.35);
+  --border-soft: rgba(120, 255, 255, 0.18);
+  --text: #f8fafc;
+  --muted: rgba(226, 232, 240, 0.75);
+  --accent: #38bdf8;
+  --accent-strong: #7b5bff;
+  --highlight: #f97316;
+  --success: #34d399;
+  --danger: #f87171;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 12% 8%, rgba(123, 91, 255, 0.18), transparent 55%),
+    radial-gradient(circle at 70% 0%, rgba(56, 189, 248, 0.16), transparent 45%),
+    radial-gradient(circle at 48% 84%, rgba(249, 115, 22, 0.12), transparent 40%),
+    var(--bg);
+  color: var(--text);
+  padding-bottom: 4rem;
+}
+
+.scanlines {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.04),
+    rgba(255, 255, 255, 0.04) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  mix-blend-mode: soft-light;
+  opacity: 0.35;
+  z-index: 0;
+}
+
+.page-header {
+  position: relative;
+  padding: clamp(2rem, 6vw, 4rem) clamp(1.25rem, 4vw, 4rem) 2rem;
+  text-align: center;
+  z-index: 1;
+}
+
+.eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.page-header h1 {
+  margin: 0.75rem 0 0.5rem;
+  font-size: clamp(2.5rem, 8vw, 4.25rem);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  text-shadow: 0 12px 36px rgba(56, 189, 248, 0.45);
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1.1rem;
+}
+
+.page-layout {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  padding: 0 clamp(1.25rem, 4vw, 4rem);
+}
+
+@media (min-width: 960px) {
+  .page-layout {
+    grid-template-columns: minmax(260px, 360px) 1fr;
+  }
+}
+
+.briefing,
+.simulator {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  box-shadow: 0 28px 48px -28px rgba(0, 0, 0, 0.9);
+}
+
+.briefing h2,
+.simulator h2,
+.simulator h3 {
+  margin-top: 0;
+}
+
+.briefing p {
+  line-height: 1.6;
+}
+
+.callouts {
+  margin: 1rem 0;
+  padding-left: 1.2rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.simulator-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.simulator-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.action-button {
+  border: 1px solid var(--border);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.24), rgba(123, 91, 255, 0.32));
+  color: var(--text);
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.action-button:hover,
+.action-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px -14px rgba(56, 189, 248, 0.8);
+  outline: none;
+}
+
+.simulator-help {
+  margin-top: 1.25rem;
+  margin-bottom: 1.75rem;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.status-panel {
+  display: grid;
+  gap: 1rem;
+  background: var(--panel-soft);
+  border: 1px solid var(--border-soft);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.75rem;
+}
+
+.meter-block {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.meter-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.meter {
+  position: relative;
+  flex: 1 1 200px;
+  height: 0.85rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.85);
+  overflow: hidden;
+}
+
+.meter-fill {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
+  border-radius: inherit;
+  transition: width 250ms ease;
+}
+
+.meter-value {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.95rem;
+}
+
+.target-callout {
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.target-callout.success {
+  color: var(--success);
+}
+
+.target-callout.warning {
+  color: var(--danger);
+}
+
+.layout-grid {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  margin-bottom: 2rem;
+}
+
+@media (min-width: 1040px) {
+  .layout-grid {
+    grid-template-columns: 1fr minmax(260px, 320px);
+    align-items: start;
+  }
+}
+
+.timeline,
+.roster {
+  background: rgba(7, 11, 26, 0.75);
+  border: 1px solid var(--border-soft);
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+}
+
+.timeline h3,
+.roster h3 {
+  margin-top: 0;
+}
+
+.timeline-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.timeline-slot {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.slot-label {
+  font-size: 0.9rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.slot-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+.slot-button {
+  flex: 1;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--text);
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: border-color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+}
+
+.slot-button:hover,
+.slot-button:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.28);
+  outline: none;
+}
+
+.slot-button.is-active {
+  border-color: var(--accent-strong);
+  box-shadow: 0 0 0 3px rgba(123, 91, 255, 0.32);
+  transform: translateY(-2px);
+}
+
+.slot-button.is-filled {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.12), rgba(123, 91, 255, 0.18));
+}
+
+.clear-button {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.8);
+  color: rgba(226, 232, 240, 0.7);
+  border-radius: 999px;
+  padding: 0.35rem 0.65rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: border-color 150ms ease, color 150ms ease, transform 150ms ease;
+}
+
+.clear-button:hover,
+.clear-button:focus-visible {
+  border-color: var(--highlight);
+  color: var(--highlight);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.roster-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.roster-card {
+  background: rgba(11, 18, 34, 0.92);
+  border: 1px solid var(--border-soft);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: grid;
+  gap: 0.5rem;
+  position: relative;
+}
+
+.roster-card.is-used {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2);
+}
+
+.roster-card h4 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.roster-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.roster-card .statline {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.assign-button {
+  justify-self: start;
+  border: 1px solid var(--border);
+  background: rgba(56, 189, 248, 0.18);
+  color: var(--text);
+  padding: 0.5rem 0.95rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.assign-button:hover,
+.assign-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 18px -14px rgba(56, 189, 248, 0.7);
+  outline: none;
+}
+
+.report {
+  background: rgba(7, 11, 26, 0.78);
+  border: 1px solid var(--border-soft);
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  margin-bottom: 2rem;
+}
+
+.report ul,
+.report li {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+#report-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.report-item {
+  background: rgba(11, 18, 34, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 0.9rem;
+  padding: 0.75rem 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+}
+
+.report-item.positive {
+  border-color: rgba(52, 211, 153, 0.45);
+  color: var(--success);
+}
+
+.report-item.negative {
+  border-color: rgba(248, 113, 113, 0.45);
+  color: var(--danger);
+}
+
+.report-item span {
+  font-variant-numeric: tabular-nums;
+}
+
+.event-log {
+  background: rgba(7, 11, 26, 0.78);
+  border: 1px solid var(--border-soft);
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+}
+
+.event-log ol {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.event-log li {
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.page-footer {
+  position: relative;
+  z-index: 1;
+  margin: 3rem auto 0;
+  max-width: 860px;
+  color: var(--muted);
+  padding: 0 1.5rem;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.page-footer em {
+  color: var(--accent);
+}

--- a/madia.new/public/secret/1989/captains-echo/captains-echo.js
+++ b/madia.new/public/secret/1989/captains-echo/captains-echo.js
@@ -1,0 +1,426 @@
+const students = [
+  {
+    id: "neil",
+    name: "Neil Perry",
+    short: "Neil",
+    base: 4,
+    statline: "+4 base · +2 if he opens",
+    description: "Ignites the salute when he opens the first beat. If someone else starts, the spark dims.",
+  },
+  {
+    id: "pitts",
+    name: "Pitts",
+    short: "Pitts",
+    base: 1,
+    statline: "+1 base · +2 in slot 2",
+    description: "Steadies the crowd when he slots second. Needs Meeks right after him to stay brave.",
+  },
+  {
+    id: "meeks",
+    name: "Meeks",
+    short: "Meeks",
+    base: 2,
+    statline: "+2 base · +3 in slot 3",
+    description: "Runs the projector and keeps the cadence locked, especially when he lands on beat three.",
+  },
+  {
+    id: "todd",
+    name: "Todd Anderson",
+    short: "Todd",
+    base: 2,
+    statline: "+2 base · +3 if after Neil · +1 if he closes",
+    description: "Won't rise until Neil cues him. Thrives as the closer; falters if he leaps too early.",
+  },
+  {
+    id: "charlie",
+    name: "Charlie Dalton",
+    short: "Charlie",
+    base: 3,
+    statline: "+3 base · +3 if right before Todd",
+    description: "Wild card with a sax solo. Primes Todd when he plays directly before the finale but sputters if forced to anchor.",
+  },
+  {
+    id: "knox",
+    name: "Knox Overstreet",
+    short: "Knox",
+    base: 2,
+    statline: "+2 base · +3 if Charlie hands him the mic",
+    description: "Romantic optimist who only speaks confidently if Charlie lines the moment up for him.",
+  },
+];
+
+const REQUIRED_STUDENTS = ["neil", "todd", "meeks"];
+const DISTRACTION_POOL = new Set(["charlie", "knox", "pitts"]);
+const TARGET_SCORE = 21;
+const METER_MAX = 24;
+
+const timelineList = document.getElementById("timeline-list");
+const rosterList = document.getElementById("roster-list");
+const meter = document.getElementById("meter");
+const meterFill = document.getElementById("meter-fill");
+const meterValue = document.getElementById("meter-value");
+const targetCallout = document.getElementById("target-callout");
+const reportList = document.getElementById("report-list");
+const eventLog = document.getElementById("event-log");
+const runButton = document.getElementById("run-plan");
+const resetButton = document.getElementById("reset-plan");
+const loadButton = document.getElementById("load-example");
+
+const studentMap = new Map(students.map((student) => [student.id, student]));
+const plan = new Array(4).fill(null);
+const slotButtons = [];
+let activeSlotIndex = 0;
+let evaluationCount = 0;
+
+function renderTimeline() {
+  for (let i = 0; i < plan.length; i += 1) {
+    const slotItem = document.createElement("li");
+    slotItem.className = "timeline-slot";
+
+    const label = document.createElement("span");
+    label.className = "slot-label";
+    label.textContent = `Beat ${i + 1}`;
+
+    const actions = document.createElement("div");
+    actions.className = "slot-actions";
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "slot-button";
+    button.dataset.slotIndex = String(i);
+    button.textContent = "Select a student";
+    button.addEventListener("click", () => {
+      setActiveSlot(i);
+    });
+
+    const clearButton = document.createElement("button");
+    clearButton.type = "button";
+    clearButton.className = "clear-button";
+    clearButton.dataset.slotIndex = String(i);
+    clearButton.textContent = "Clear";
+    clearButton.addEventListener("click", () => {
+      clearSlot(i);
+    });
+
+    actions.append(button, clearButton);
+    slotItem.append(label, actions);
+    timelineList.append(slotItem);
+    slotButtons.push(button);
+  }
+
+  setActiveSlot(0);
+}
+
+function renderRoster() {
+  students.forEach((student) => {
+    const card = document.createElement("li");
+    card.className = "roster-card";
+    card.dataset.studentId = student.id;
+
+    const name = document.createElement("h4");
+    name.textContent = student.name;
+
+    const statline = document.createElement("p");
+    statline.className = "statline";
+    statline.textContent = student.statline;
+
+    const description = document.createElement("p");
+    description.textContent = student.description;
+
+    const assignButton = document.createElement("button");
+    assignButton.type = "button";
+    assignButton.className = "assign-button";
+    assignButton.textContent = "Assign to beat";
+    assignButton.addEventListener("click", () => {
+      if (activeSlotIndex == null) {
+        setActiveSlot(0);
+      }
+      assignStudent(activeSlotIndex, student.id);
+    });
+
+    card.append(name, statline, description, assignButton);
+    rosterList.append(card);
+  });
+}
+
+function setActiveSlot(index) {
+  activeSlotIndex = index;
+  slotButtons.forEach((button, slot) => {
+    if (slot === index) {
+      button.classList.add("is-active");
+      button.focus({ preventScroll: true });
+    } else {
+      button.classList.remove("is-active");
+    }
+  });
+}
+
+function assignStudent(slotIndex, studentId) {
+  for (let i = 0; i < plan.length; i += 1) {
+    if (i !== slotIndex && plan[i] === studentId) {
+      plan[i] = null;
+    }
+  }
+  plan[slotIndex] = studentId;
+  setActiveSlot(slotIndex);
+  updateInterface();
+}
+
+function clearSlot(slotIndex) {
+  plan[slotIndex] = null;
+  updateInterface();
+}
+
+function updateInterface() {
+  const usedStudents = new Set(plan.filter(Boolean));
+  plan.forEach((studentId, index) => {
+    const button = slotButtons[index];
+    if (!studentId) {
+      button.textContent = "Select a student";
+      button.classList.remove("is-filled");
+      return;
+    }
+    const student = studentMap.get(studentId);
+    button.textContent = `${student.name}`;
+    button.classList.add("is-filled");
+  });
+
+  rosterList.querySelectorAll(".roster-card").forEach((card) => {
+    const { studentId } = card.dataset;
+    if (studentId && usedStudents.has(studentId)) {
+      card.classList.add("is-used");
+    } else {
+      card.classList.remove("is-used");
+    }
+  });
+}
+
+function resetReport() {
+  reportList.innerHTML = "";
+}
+
+function setMeter(score) {
+  const bounded = Math.max(0, Math.min(METER_MAX, score));
+  const percent = (bounded / METER_MAX) * 100;
+  meterFill.style.width = `${percent}%`;
+  meter.setAttribute("aria-valuenow", String(bounded));
+  meterValue.textContent = `${Math.round(bounded)} / ${METER_MAX}`;
+}
+
+function renderIssues(issues) {
+  resetReport();
+  issues.forEach((issue) => {
+    const item = document.createElement("li");
+    item.className = "report-item negative";
+    item.textContent = issue;
+    reportList.append(item);
+  });
+}
+
+function renderContributions(contributions) {
+  resetReport();
+  contributions.forEach((entry) => {
+    const item = document.createElement("li");
+    const classes = ["report-item"];
+    if (entry.value > 0) {
+      classes.push("positive");
+    } else if (entry.value < 0) {
+      classes.push("negative");
+    }
+    item.className = classes.join(" ");
+
+    const label = document.createElement("span");
+    label.textContent = entry.label;
+
+    const value = document.createElement("span");
+    value.textContent = entry.value > 0 ? `+${entry.value}` : String(entry.value);
+
+    item.append(label, value);
+    reportList.append(item);
+  });
+}
+
+function logEvent(message) {
+  evaluationCount += 1;
+  const item = document.createElement("li");
+  item.textContent = `Attempt ${evaluationCount}: ${message}`;
+  eventLog.append(item);
+  while (eventLog.children.length > 8) {
+    eventLog.removeChild(eventLog.firstElementChild);
+  }
+}
+
+function evaluatePlan() {
+  const issues = [];
+  const filled = plan.filter(Boolean);
+  if (filled.length < plan.length) {
+    issues.push("Assign four distinct students before running the recital.");
+  }
+
+  const duplicates = new Set();
+  const seen = new Set();
+  filled.forEach((id) => {
+    if (seen.has(id)) {
+      duplicates.add(studentMap.get(id).name);
+    }
+    seen.add(id);
+  });
+  if (duplicates.size > 0) {
+    issues.push(`No double-stands: ${Array.from(duplicates).join(", ")} appeared twice.`);
+  }
+
+  REQUIRED_STUDENTS.forEach((requiredId) => {
+    if (!filled.includes(requiredId)) {
+      issues.push(`${studentMap.get(requiredId).name} is required for the salute.`);
+    }
+  });
+
+  const hasDistractor = filled.some((id) => DISTRACTION_POOL.has(id));
+  if (!hasDistractor) {
+    issues.push("Bring at least one distractor (Charlie, Knox, or Pitts) to keep faculty eyes busy.");
+  }
+
+  const neilIndex = plan.indexOf("neil");
+  const toddIndex = plan.indexOf("todd");
+  if (toddIndex === 0) {
+    issues.push("Todd can't lead the chant—he freezes on beat one.");
+  }
+  if (neilIndex !== -1 && toddIndex !== -1 && neilIndex > toddIndex) {
+    issues.push("Neil must cue Todd before Todd stands.");
+  }
+
+  if (issues.length > 0) {
+    targetCallout.textContent = issues[0];
+    targetCallout.classList.remove("warning", "success");
+    targetCallout.classList.add("warning");
+    setMeter(0);
+    renderIssues(issues);
+    logEvent("Plan rejected—check the rumor board for issues.");
+    return;
+  }
+
+  const contributions = [];
+  let score = 0;
+  const positions = new Map();
+  plan.forEach((id, index) => {
+    positions.set(id, index);
+    const student = studentMap.get(id);
+    contributions.push({ label: `${student.name} shows up`, value: student.base });
+    score += student.base;
+  });
+
+  const add = (label, value) => {
+    if (value === 0) {
+      return;
+    }
+    contributions.push({ label, value });
+    score += value;
+  };
+
+  if (positions.get("neil") === 0) {
+    add("Neil lights the fuse from the front desk", 2);
+  }
+
+  if (positions.get("todd") > positions.get("neil")) {
+    add("Todd draws courage from Neil's cue", 3);
+  }
+  if (positions.get("todd") === plan.length - 1) {
+    add("Todd's closing vow", 1);
+  }
+  if (positions.get("todd") === 1) {
+    add("Todd steps too soon and stumbles", -2);
+  }
+
+  if (positions.get("meeks") === 2) {
+    add("Meeks keeps beat three humming", 3);
+  }
+  if (positions.get("meeks") === 1) {
+    add("Meeks loses his notes without the projector delay", -1);
+  }
+
+  if (positions.has("pitts")) {
+    const pittsPos = positions.get("pitts");
+    if (pittsPos === 1) {
+      add("Pitts steadies the second beat", 2);
+    }
+    if (pittsPos === plan.length - 1) {
+      add("Pitts wilts when forced to close", -3);
+    }
+    if (positions.get("meeks") === 2 && pittsPos === 1) {
+      add("Meeks catches the projector remote mid-beat", 3);
+    }
+  }
+
+  if (positions.has("charlie")) {
+    const charliePos = positions.get("charlie");
+    if (charliePos === plan.length - 1) {
+      add("Charlie is too impulsive to anchor", -2);
+    }
+    if (positions.get("todd") === charliePos + 1) {
+      add("Charlie primes Todd with a sax riff", 3);
+    }
+  }
+
+  if (positions.has("knox")) {
+    const knoxPos = positions.get("knox");
+    if (knoxPos === 0) {
+      add("Knox panics when forced to open", -2);
+    }
+    if (positions.has("charlie") && knoxPos === positions.get("charlie") + 1) {
+      add("Charlie hands Knox the mic", 3);
+    }
+  }
+
+  renderContributions(contributions);
+  setMeter(score);
+
+  targetCallout.classList.remove("warning", "success");
+  if (score >= TARGET_SCORE) {
+    targetCallout.textContent = `Success! Score ${score}—the hall erupts in applause.`;
+    targetCallout.classList.add("success");
+    logEvent(`Score ${score}. The salute holds.`);
+  } else {
+    const delta = TARGET_SCORE - score;
+    targetCallout.textContent = `Score ${score}. Need ${delta} more to lock the salute.`;
+    targetCallout.classList.add("warning");
+    logEvent(`Score ${score}. Short by ${delta}.`);
+  }
+}
+
+function resetPlan() {
+  for (let i = 0; i < plan.length; i += 1) {
+    plan[i] = null;
+  }
+  activeSlotIndex = 0;
+  setActiveSlot(0);
+  updateInterface();
+  resetReport();
+  setMeter(0);
+  targetCallout.textContent = "Queue a full plan to begin.";
+  targetCallout.classList.remove("warning", "success");
+}
+
+function loadFacultyPlan() {
+  const sample = ["neil", "charlie", "meeks", "todd"];
+  for (let i = 0; i < plan.length; i += 1) {
+    plan[i] = sample[i] ?? null;
+  }
+  updateInterface();
+  setActiveSlot(plan.length - 1);
+  targetCallout.textContent = "Faculty-approved plan loaded. Run the recital to see why it falls short.";
+  targetCallout.classList.remove("success");
+  targetCallout.classList.add("warning");
+  resetReport();
+  setMeter(0);
+}
+
+renderTimeline();
+renderRoster();
+updateInterface();
+
+runButton.addEventListener("click", evaluatePlan);
+resetButton.addEventListener("click", () => {
+  resetPlan();
+  logEvent("Board cleared. Ready for a new attempt.");
+});
+loadButton.addEventListener("click", loadFacultyPlan);

--- a/madia.new/public/secret/1989/captains-echo/index.html
+++ b/madia.new/public/secret/1989/captains-echo/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Captain's Echo</title>
+    <link rel="stylesheet" href="captains-echo.css" />
+  </head>
+  <body>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 39 · 1989 Arcade</p>
+      <h1>Captain's Echo</h1>
+      <p class="subtitle">
+        Orchestrate the four-beat salute so the Headmaster can't snuff the spark before the class rises.
+      </p>
+    </header>
+    <main class="page-layout">
+      <section class="briefing" aria-labelledby="briefing-title">
+        <h2 id="briefing-title">Assembly Whisper Network</h2>
+        <p>
+          The lantern has been passed and the desks are ready. Choose four conspirators to stand on cue, line them up across the
+          beats, and protect the <em>Carpe Diem</em> meter from the dean's glare. Every desk contributes a base surge, but the
+          real voltage comes from pairing the right students in the right moment.
+        </p>
+        <ul class="callouts">
+          <li><strong>Four beats:</strong> Slots must feature four distinct students—no double-stands tonight.</li>
+          <li>
+            <strong>Anchor trio:</strong> Neil, Todd, and Meeks are non-negotiable. One of Charlie, Knox, or Pitts must help to
+            keep the administration distracted.
+          </li>
+          <li>
+            <strong>Lead and close:</strong> Neil needs to light the fuse ahead of Todd, and Todd refuses to move until Neil cues
+            him.
+          </li>
+          <li>
+            <strong>Synergy sparks:</strong> Pitts only holds steady when Meeks steps up immediately after him, Charlie primes Todd
+            when he's right before him, and Knox needs Charlie to hand off the megaphone.
+          </li>
+          <li><strong>Goal:</strong> Push the meter to <strong>21</strong> or more to lock in the salute.</li>
+        </ul>
+        <p>
+          Each assignment updates the rumor board with what worked—or what spooked the dean. Iterate until the crowd explodes in
+          applause.
+        </p>
+      </section>
+      <section class="simulator" aria-labelledby="simulator-title">
+        <div class="simulator-header">
+          <h2 id="simulator-title">Desk Rebellion Planner</h2>
+          <div class="simulator-controls">
+            <button type="button" class="action-button" id="run-plan">Run Recital</button>
+            <button type="button" class="action-button" id="reset-plan">Reset</button>
+            <button type="button" class="action-button" id="load-example">Load Faculty Plan</button>
+          </div>
+        </div>
+        <p class="simulator-help">
+          Select a beat, tap a student card to assign them, then hit <em>Run Recital</em>. The rumor board breaks down every bonus
+          and penalty so you can adjust the lineup.
+        </p>
+        <section class="status-panel" aria-label="Meter status">
+          <div class="meter-block">
+            <span class="meter-label">Carpe Diem Meter</span>
+            <div class="meter" role="progressbar" aria-valuemin="0" aria-valuemax="24" aria-valuenow="0" id="meter">
+              <div class="meter-fill" id="meter-fill" style="width: 0%"></div>
+            </div>
+            <span class="meter-value" id="meter-value">0 / 24</span>
+          </div>
+          <div class="target-callout" id="target-callout">Queue a full plan to begin.</div>
+        </section>
+        <section class="layout-grid" aria-labelledby="timeline-title">
+          <div class="timeline" role="group" aria-labelledby="timeline-title">
+            <h3 id="timeline-title">Beat Timeline</h3>
+            <ol class="timeline-list" id="timeline-list"></ol>
+          </div>
+          <div class="roster" aria-labelledby="roster-title">
+            <h3 id="roster-title">Conspirator Roster</h3>
+            <ul class="roster-list" id="roster-list"></ul>
+          </div>
+        </section>
+        <section class="report" aria-labelledby="report-title">
+          <h3 id="report-title">Rumor Board</h3>
+          <ul id="report-list"></ul>
+        </section>
+        <section class="event-log" aria-labelledby="event-log-title">
+          <h3 id="event-log-title">Assembly Log</h3>
+          <ol id="event-log"></ol>
+        </section>
+      </section>
+    </main>
+    <footer class="page-footer">
+      <p>
+        Tip: Pitts steadies his voice when Meeks catches the projector remote right after him. Let Neil open, drop Pitts into the
+        second slot, slide Meeks to the third, anchor Todd at the finale, and watch the room stand as one.
+      </p>
+    </footer>
+    <script type="module" src="captains-echo.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add the Level 39 "Captain's Echo" cabinet to the 1989 arcade roster
- build a four-beat planning interface with scoring logic, rumor board, and assembly log for the new level
- style the page with bespoke neon classroom theming that matches the annex aesthetic

## Testing
- python -m http.server 5000

------
https://chatgpt.com/codex/tasks/task_e_68deea90df088328a7d50ac6bea51e66