### PR TITLE
feat: add vendetta convoy level

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -390,6 +390,58 @@ const games = [
     `,
   },
   {
+    id: "vendetta-convoy",
+    name: "Vendetta Convoy",
+    description: "Chain sabotage charges to shepherd the rogue tanker convoy past concealed explosives.",
+    url: "./vendetta-convoy/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Vendetta Convoy preview">
+        <defs>
+          <linearGradient id="convoySky" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(56,189,248,0.35)" />
+            <stop offset="100%" stop-color="rgba(15,23,42,0.9)" />
+          </linearGradient>
+          <linearGradient id="convoyLane" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#38bdf8" />
+            <stop offset="100%" stop-color="#a855f7" />
+          </linearGradient>
+        </defs>
+        <rect x="6" y="8" width="148" height="104" rx="18" fill="rgba(7,11,24,0.92)" stroke="rgba(148,163,184,0.35)" />
+        <rect x="16" y="18" width="128" height="84" rx="16" fill="url(#convoySky)" stroke="rgba(148,163,184,0.28)" />
+        <g transform="translate(30 28)">
+          <rect x="0" y="0" width="100" height="56" rx="12" fill="rgba(10,16,32,0.88)" stroke="rgba(56,189,248,0.35)" />
+          <rect x="8" y="6" width="84" height="44" rx="10" fill="rgba(15,23,42,0.85)" stroke="rgba(168,85,247,0.45)" />
+          <g stroke="rgba(56,189,248,0.25)" stroke-width="1.2">
+            ${Array.from({ length: 3 }, (_, i) => `<line x1="${18 + i * 24}" y1="6" x2="${18 + i * 24}" y2="50" />`).join("")}
+          </g>
+          <g>
+            ${[0, 1, 2, 3].map((i) => `<rect x="${6 + i * 20}" y="12" width="16" height="16" rx="4" fill="rgba(148,163,184,0.35)" stroke="rgba(148,163,184,0.4)" />`).join("")}
+            ${[0, 1, 2].map((i) => `<rect x="${12 + i * 24}" y="30" width="12" height="12" rx="3" fill="rgba(249,115,22,0.6)" stroke="rgba(249,115,22,0.65)" />`).join("")}
+          </g>
+          <g transform="translate(24 14)">
+            <rect x="0" y="16" width="36" height="20" rx="6" fill="rgba(56,189,248,0.72)" stroke="rgba(56,189,248,0.8)" />
+            <rect x="36" y="8" width="16" height="28" rx="6" fill="rgba(168,85,247,0.65)" stroke="rgba(168,85,247,0.75)" />
+            <rect x="52" y="16" width="20" height="20" rx="6" fill="rgba(34,197,94,0.55)" stroke="rgba(34,197,94,0.7)" />
+          </g>
+          <path d="M12 44 Q32 60 52 44 T92 44" fill="none" stroke="url(#convoyLane)" stroke-width="4" stroke-linecap="round" />
+          <g>
+            <circle cx="18" cy="44" r="6" fill="#38bdf8" stroke="rgba(255,255,255,0.4)" />
+            <circle cx="52" cy="44" r="6" fill="#a855f7" stroke="rgba(255,255,255,0.4)" />
+            <circle cx="86" cy="44" r="6" fill="#f97316" stroke="rgba(255,255,255,0.4)" />
+          </g>
+        </g>
+        <g transform="translate(22 20)" stroke="rgba(239,68,68,0.6)" stroke-width="2" stroke-dasharray="4 6">
+          <rect x="0" y="0" width="28" height="20" rx="6" fill="rgba(239,68,68,0.15)" />
+          <rect x="108" y="12" width="28" height="20" rx="6" fill="rgba(239,68,68,0.15)" />
+        </g>
+        <g transform="translate(30 84)">
+          <rect x="0" y="0" width="100" height="18" rx="8" fill="rgba(10,16,32,0.88)" stroke="rgba(56,189,248,0.35)" />
+          <rect x="6" y="4" width="88" height="10" rx="5" fill="rgba(56,189,248,0.35)" stroke="rgba(168,85,247,0.45)" />
+        </g>
+      </svg>
+    `,
+  },
+  {
     id: "prototype",
     name: "Prototype Cabinet",
     description: "Drop a new game folder in \"secret\" and point the cab here.",

--- a/madia.new/public/secret/1989/vendetta-convoy/index.html
+++ b/madia.new/public/secret/1989/vendetta-convoy/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vendetta Convoy</title>
+    <link rel="stylesheet" href="vendetta-convoy.css" />
+  </head>
+  <body>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 36 · 1989 Arcade</p>
+      <h1>Vendetta Convoy</h1>
+      <p class="subtitle">
+        Clear the cartel causeway one sabotage at a time, guiding the tanker convoy toward the cliffside rendezvous before the explosives reshuffle your odds.
+      </p>
+    </header>
+    <main class="page-layout">
+      <section class="briefing" aria-labelledby="briefing-title">
+        <h2 id="briefing-title">Stage Notes</h2>
+        <p>
+          Sanchez rebuilt his valley compound into a layered gauntlet. Surveillance tags every scrap of evidence along the tanker lane, but some crates hide pressure triggers wired to slam the convoy off-course. Chain rock charges in sequence to pry open the path without nudging the live explosives.
+        </p>
+        <ul class="callouts">
+          <li><strong>Evidence crates:</strong> Conceal the lane. Match three nearby rock charges to vaporise a crate.</li>
+          <li><strong>Concealed explosives:</strong> Indistinguishable until scanned. Detonating one scrambles every remaining tanker rig.</li>
+          <li><strong>Actuation meter:</strong> Represents the convoy’s throttle. Every sabotage or convoy advance drains the meter—Phoenix wipes refill it.</li>
+          <li><strong>Intel scans:</strong> Limited to three. Spend them to reveal whether a crate is clean or wired.</li>
+          <li><strong>Phoenix combo:</strong> Fill an entire tanker lane row to ignite a wipeout that purges nearby evidence and boosts the meter.</li>
+        </ul>
+        <section class="key-guide" aria-labelledby="key-guide-title">
+          <h3 id="key-guide-title">Key Bindings</h3>
+          <dl>
+            <div>
+              <dt>Select Rocks</dt>
+              <dd>Click three rock tiles that share an evidence crate.</dd>
+            </div>
+            <div>
+              <dt>Sabotage</dt>
+              <dd>Click a highlighted crate to trigger the charges.</dd>
+            </div>
+            <div>
+              <dt>Advance Tanker</dt>
+              <dd><span class="key-label">A</span> or the <span class="key-label">Advance Tanker</span> button.</dd>
+            </div>
+            <div>
+              <dt>Scan</dt>
+              <dd><span class="key-label">S</span> or the <span class="key-label">Spend Intel Scan</span> button.</dd>
+            </div>
+            <div>
+              <dt>Reset</dt>
+              <dd><span class="key-label">R</span> or the <span class="key-label">Reset</span> button.</dd>
+            </div>
+          </dl>
+        </section>
+        <section class="combo-guide" aria-labelledby="combo-guide-title">
+          <h3 id="combo-guide-title">Combo Intel</h3>
+          <p>
+            The <strong>Phoenix</strong> combo triggers when a tanker piece locks a full lane row. The wipeout cleanses adjacent evidence—explosive or otherwise—and restores convoy actuation for the next push.
+          </p>
+        </section>
+      </section>
+      <section class="simulator" aria-labelledby="simulator-title">
+        <div class="simulator-header">
+          <h2 id="simulator-title">Sabotage Console</h2>
+          <div class="simulator-controls">
+            <button type="button" class="action-button" id="start-operation">Start Operation</button>
+            <button type="button" class="action-button" id="advance-tanker">Advance Tanker</button>
+            <button type="button" class="action-button" id="intel-scan">Spend Intel Scan</button>
+            <button type="button" class="action-button" id="reset-operation">Reset</button>
+          </div>
+        </div>
+        <p class="simulator-help">
+          Sequence rock charges around crates to clear the tanker lane. Unknown crates may hide explosive countermeasures—trip one and every remaining tanker rig scrambles to a new drop point. Keep the actuation meter alive, track your remaining scans, and shepherd each tanker module to the canyon exit.
+        </p>
+        <div class="status-board" role="group" aria-label="Operation status">
+          <div class="status-tile">
+            <span class="status-label">Actuation</span>
+            <div class="status-meter" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" id="actuation-bar">
+              <div class="status-meter-fill" id="actuation-fill"></div>
+            </div>
+            <span class="status-value" id="actuation-text">0%</span>
+          </div>
+          <div class="status-tile">
+            <span class="status-label">Evidence Cleared</span>
+            <span class="status-value" id="evidence-count">0</span>
+          </div>
+          <div class="status-tile">
+            <span class="status-label">Scans Remaining</span>
+            <span class="status-value" id="scan-count">0</span>
+          </div>
+          <div class="status-tile">
+            <span class="status-label">Explosives Tripped</span>
+            <span class="status-value" id="explosive-count">0</span>
+          </div>
+          <div class="status-tile">
+            <span class="status-label">Phoenix Bursts</span>
+            <span class="status-value" id="phoenix-count">0</span>
+          </div>
+        </div>
+        <div class="compound-wrapper">
+          <div class="legend" aria-hidden="true">
+            <span class="legend-item tanker">Tanker Module</span>
+            <span class="legend-item evidence">Evidence (unknown)</span>
+            <span class="legend-item explosive">Revealed Explosive</span>
+            <span class="legend-item rock">Rock Charge</span>
+            <span class="legend-item cleared">Cleared Lane</span>
+          </div>
+          <div class="compound-grid" id="compound-grid" role="grid" aria-label="Sanchez compound grid"></div>
+          <aside class="queue-panel" aria-label="Tanker queue">
+            <h3>Tanker Queue</h3>
+            <div class="tanker-queue" id="tanker-queue"></div>
+          </aside>
+        </div>
+        <p class="operation-status" id="operation-status">Press Start Operation to begin the sabotage run.</p>
+        <section class="event-log" aria-labelledby="event-log-title">
+          <h3 id="event-log-title">Field Log</h3>
+          <ul id="event-log"></ul>
+        </section>
+      </section>
+    </main>
+    <footer class="page-footer">
+      <p>
+        Tip: Clear safe crates before gambling on a scan. The convoy only needs one Phoenix wipe to blitz the courtyard, but a stray explosive will reset your formation.
+      </p>
+    </footer>
+    <script type="module" src="vendetta-convoy.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/1989/vendetta-convoy/vendetta-convoy.css
+++ b/madia.new/public/secret/1989/vendetta-convoy/vendetta-convoy.css
@@ -1,0 +1,517 @@
+:root {
+  color-scheme: dark;
+  font-family: "Space Grotesk", "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --bg: #030712;
+  --panel: rgba(7, 12, 24, 0.93);
+  --border: rgba(56, 189, 248, 0.42);
+  --border-soft: rgba(56, 189, 248, 0.18);
+  --text: #f8fafc;
+  --muted: rgba(226, 232, 240, 0.74);
+  --rock: #f97316;
+  --evidence: rgba(148, 163, 184, 0.4);
+  --explosive: #ef4444;
+  --tanker: #38bdf8;
+  --tanker-shadow: rgba(56, 189, 248, 0.32);
+  --cleared: rgba(34, 197, 94, 0.35);
+  --cleared-border: rgba(34, 197, 94, 0.55);
+  --accent: #a855f7;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 14% 18%, rgba(56, 189, 248, 0.18), transparent 52%),
+    radial-gradient(circle at 82% 12%, rgba(168, 85, 247, 0.18), transparent 48%),
+    radial-gradient(circle at 50% 88%, rgba(239, 68, 68, 0.16), transparent 42%),
+    var(--bg);
+  color: var(--text);
+  padding-bottom: 4rem;
+}
+
+.scanlines {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.04),
+    rgba(255, 255, 255, 0.04) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+  mix-blend-mode: soft-light;
+  opacity: 0.32;
+  z-index: 0;
+}
+
+.page-header {
+  position: relative;
+  padding: clamp(2rem, 6vw, 4rem) clamp(1.5rem, 5vw, 4rem) 2rem;
+  text-align: center;
+  z-index: 1;
+}
+
+.eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.page-header h1 {
+  margin: 0.75rem 0 0.5rem;
+  font-size: clamp(2.4rem, 8vw, 4.8rem);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  text-shadow: 0 18px 48px rgba(56, 189, 248, 0.45);
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1.1rem;
+  max-width: 60ch;
+  margin-inline: auto;
+}
+
+.page-layout {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  padding: 0 clamp(1.5rem, 5vw, 4rem);
+}
+
+@media (min-width: 980px) {
+  .page-layout {
+    grid-template-columns: minmax(260px, 360px) 1fr;
+  }
+}
+
+.briefing,
+.simulator {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 1.6rem;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  box-shadow: 0 28px 48px -24px rgba(0, 0, 0, 0.85);
+}
+
+.briefing h2,
+.simulator h2,
+.simulator h3 {
+  margin-top: 0;
+}
+
+.callouts {
+  margin: 1rem 0;
+  padding-left: 1.2rem;
+  line-height: 1.55;
+  color: var(--muted);
+}
+
+.key-guide {
+  margin-top: 1.5rem;
+}
+
+.key-guide dl {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.key-guide dt {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text);
+}
+
+.key-guide dd {
+  margin: 0.3rem 0 0;
+  color: var(--muted);
+}
+
+.key-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.4rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  background: rgba(6, 14, 26, 0.8);
+  color: var(--text);
+  font-size: 0.82rem;
+  margin-right: 0.35rem;
+}
+
+.combo-guide {
+  margin-top: 1.75rem;
+  color: var(--muted);
+}
+
+.simulator-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.simulator-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.action-button {
+  appearance: none;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.55rem 1.2rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.82rem;
+  background: rgba(6, 14, 26, 0.7);
+  color: var(--text);
+  cursor: pointer;
+  transition: border-color 140ms ease, transform 140ms ease;
+}
+
+.action-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.action-button:not(:disabled):hover {
+  border-color: rgba(168, 85, 247, 0.68);
+  transform: translateY(-1px);
+}
+
+.simulator-help {
+  margin: 1rem 0 1.25rem;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.status-board {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.status-tile {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--border-soft);
+  border-radius: 1rem;
+  background: rgba(8, 16, 28, 0.8);
+}
+
+.status-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.status-value {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.status-meter {
+  position: relative;
+  width: 100%;
+  height: 0.7rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-soft);
+  background: rgba(10, 20, 36, 0.82);
+  overflow: hidden;
+}
+
+.status-meter-fill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(56, 189, 248, 0.7), rgba(34, 197, 94, 0.7));
+  transform-origin: left;
+  transform: scaleX(0);
+  transition: transform 200ms ease;
+}
+
+.compound-wrapper {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-soft);
+  background: rgba(7, 14, 28, 0.7);
+}
+
+.legend-item::before {
+  content: "";
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 0.2rem;
+  background: var(--border-soft);
+}
+
+.legend-item.tanker::before {
+  background: var(--tanker);
+  box-shadow: 0 0 8px var(--tanker-shadow);
+}
+
+.legend-item.evidence::before {
+  background: var(--evidence);
+}
+
+.legend-item.explosive::before {
+  background: var(--explosive);
+}
+
+.legend-item.rock::before {
+  background: var(--rock);
+}
+
+.legend-item.cleared::before {
+  background: var(--cleared);
+  box-shadow: 0 0 8px rgba(34, 197, 94, 0.25);
+}
+
+.compound-grid {
+  display: grid;
+  grid-template-columns: repeat(8, clamp(36px, 6vw, 52px));
+  gap: 0.35rem;
+  justify-content: center;
+}
+
+.compound-cell {
+  position: relative;
+  width: clamp(36px, 6vw, 52px);
+  height: clamp(36px, 6vw, 52px);
+  border-radius: 0.9rem;
+  border: 1px solid rgba(56, 189, 248, 0.14);
+  background: rgba(9, 15, 28, 0.76);
+  color: var(--text);
+  display: grid;
+  place-items: center;
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: border-color 140ms ease, transform 140ms ease, box-shadow 140ms ease;
+}
+
+.compound-cell:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.compound-cell.cell-rock {
+  background: radial-gradient(circle at 30% 30%, rgba(249, 115, 22, 0.8), rgba(249, 115, 22, 0.45));
+  border-color: rgba(249, 115, 22, 0.6);
+  box-shadow: 0 0 12px rgba(249, 115, 22, 0.25) inset;
+}
+
+.compound-cell.cell-rock.selected {
+  border-color: #facc15;
+  box-shadow: 0 0 16px rgba(250, 204, 21, 0.45) inset;
+}
+
+.compound-cell.cell-evidence {
+  background: rgba(148, 163, 184, 0.28);
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.compound-cell.cell-evidence.concealed {
+  background: rgba(99, 102, 241, 0.22);
+  border-color: rgba(129, 140, 248, 0.4);
+}
+
+.compound-cell.cell-explosive {
+  background: rgba(239, 68, 68, 0.32);
+  border-color: rgba(239, 68, 68, 0.55);
+  box-shadow: 0 0 14px rgba(239, 68, 68, 0.35) inset;
+}
+
+.compound-cell.cell-cleared {
+  background: rgba(34, 197, 94, 0.25);
+  border-color: var(--cleared-border);
+  box-shadow: 0 0 12px rgba(34, 197, 94, 0.28) inset;
+}
+
+.compound-cell.cell-actionable {
+  border-color: rgba(168, 85, 247, 0.65);
+  box-shadow: 0 0 16px rgba(168, 85, 247, 0.32);
+}
+
+.compound-cell.cell-tanker-settled {
+  background: linear-gradient(140deg, rgba(56, 189, 248, 0.85), rgba(34, 211, 238, 0.55));
+  border-color: rgba(56, 189, 248, 0.75);
+  box-shadow: 0 0 18px rgba(56, 189, 248, 0.36) inset;
+}
+
+.compound-cell.cell-tanker-active {
+  background: linear-gradient(140deg, rgba(168, 85, 247, 0.85), rgba(56, 189, 248, 0.65));
+  border-color: rgba(168, 85, 247, 0.7);
+  box-shadow: 0 0 20px rgba(168, 85, 247, 0.32) inset;
+  transform: translateY(-2px);
+}
+
+.queue-panel {
+  border: 1px solid var(--border-soft);
+  border-radius: 1.2rem;
+  padding: 1rem 1.1rem;
+  background: rgba(7, 14, 28, 0.78);
+}
+
+.queue-panel h3 {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+}
+
+.tanker-queue {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.queue-piece {
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  border-radius: 0.9rem;
+  padding: 0.6rem;
+  background: rgba(8, 16, 30, 0.82);
+  display: grid;
+  gap: 0.45rem;
+}
+
+.queue-piece.active {
+  border-color: rgba(168, 85, 247, 0.6);
+  box-shadow: 0 0 12px rgba(168, 85, 247, 0.28);
+}
+
+.queue-piece-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.queue-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 0.85rem);
+  gap: 0.2rem;
+  justify-content: start;
+}
+
+.queue-cell {
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 0.2rem;
+  background: rgba(56, 189, 248, 0.25);
+}
+
+.queue-cell.fill {
+  background: rgba(56, 189, 248, 0.8);
+  box-shadow: 0 0 8px rgba(56, 189, 248, 0.4);
+}
+
+.operation-status {
+  margin: 1.5rem 0 1rem;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.event-log {
+  margin-top: 1.5rem;
+}
+
+.event-log ul,
+.event-log li {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+#event-log {
+  display: grid;
+  gap: 0.6rem;
+  max-height: 240px;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.log-entry {
+  padding: 0.65rem 0.8rem;
+  border-radius: 0.8rem;
+  border: 1px solid rgba(56, 189, 248, 0.15);
+  background: rgba(8, 16, 28, 0.75);
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
+
+.log-entry.info {
+  border-color: rgba(56, 189, 248, 0.28);
+}
+
+.log-entry.success {
+  border-color: rgba(34, 197, 94, 0.45);
+  color: #bbf7d0;
+}
+
+.log-entry.warning {
+  border-color: rgba(250, 204, 21, 0.45);
+  color: #fef08a;
+}
+
+.log-entry.danger {
+  border-color: rgba(239, 68, 68, 0.5);
+  color: #fecdd3;
+}
+
+.page-footer {
+  text-align: center;
+  margin: 3rem auto 0;
+  max-width: 70ch;
+  color: var(--muted);
+  padding: 0 1.5rem;
+}
+
+.page-footer p {
+  margin: 0;
+}
+
+@media (max-width: 720px) {
+  .compound-grid {
+    grid-template-columns: repeat(8, 42px);
+  }
+
+  .compound-cell {
+    width: 42px;
+    height: 42px;
+  }
+}

--- a/madia.new/public/secret/1989/vendetta-convoy/vendetta-convoy.js
+++ b/madia.new/public/secret/1989/vendetta-convoy/vendetta-convoy.js
@@ -1,0 +1,803 @@
+const BOARD_WIDTH = 8;
+const BOARD_HEIGHT = 14;
+const LANE_COLUMNS = [2, 3, 4, 5];
+
+const START_ACTUATION = 72;
+const ADVANCE_COST = 6;
+const SABOTAGE_COST = 5;
+const SCAN_COST = 8;
+const PHOENIX_REFILL = 12;
+const MAX_SCANS = 3;
+const MAX_LOG_ENTRIES = 32;
+
+const TANKER_SHAPES = [
+  [
+    { row: 0, col: 1 },
+    { row: 1, col: 0 },
+    { row: 1, col: 1 },
+    { row: 1, col: 2 },
+  ],
+  [
+    { row: 0, col: 1 },
+    { row: 1, col: 1 },
+    { row: 1, col: 2 },
+    { row: 2, col: 1 },
+  ],
+  [
+    { row: 1, col: 0 },
+    { row: 1, col: 1 },
+    { row: 1, col: 2 },
+    { row: 2, col: 1 },
+  ],
+  [
+    { row: 0, col: 1 },
+    { row: 1, col: 0 },
+    { row: 1, col: 1 },
+    { row: 2, col: 1 },
+  ],
+];
+
+const SAFE_EVIDENCE_POSITIONS = [
+  [2, 3],
+  [5, 2],
+  [8, 4],
+  [10, 3],
+];
+
+const EXPLOSIVE_POSITIONS = [
+  [3, 4],
+  [6, 3],
+  [9, 4],
+  [12, 3],
+];
+
+const ROCK_POSITIONS = dedupePositions([
+  [1, 3],
+  [2, 2],
+  [2, 4],
+  [3, 3],
+  [3, 5],
+  [4, 4],
+  [4, 2],
+  [5, 1],
+  [5, 3],
+  [6, 2],
+  [6, 4],
+  [7, 3],
+  [7, 4],
+  [8, 3],
+  [8, 5],
+  [9, 3],
+  [9, 5],
+  [10, 2],
+  [10, 4],
+  [11, 3],
+  [11, 4],
+  [12, 2],
+  [12, 4],
+  [13, 3],
+  [13, 4],
+]);
+
+const TOTAL_EVIDENCE = SAFE_EVIDENCE_POSITIONS.length + EXPLOSIVE_POSITIONS.length;
+
+const startOperationButton = document.getElementById("start-operation");
+const advanceTankerButton = document.getElementById("advance-tanker");
+const intelScanButton = document.getElementById("intel-scan");
+const resetOperationButton = document.getElementById("reset-operation");
+const compoundGrid = document.getElementById("compound-grid");
+const tankerQueueElement = document.getElementById("tanker-queue");
+const operationStatusElement = document.getElementById("operation-status");
+const eventLogElement = document.getElementById("event-log");
+const actuationFill = document.getElementById("actuation-fill");
+const actuationText = document.getElementById("actuation-text");
+const actuationBar = document.getElementById("actuation-bar");
+const evidenceCountElement = document.getElementById("evidence-count");
+const scanCountElement = document.getElementById("scan-count");
+const explosiveCountElement = document.getElementById("explosive-count");
+const phoenixCountElement = document.getElementById("phoenix-count");
+
+const cellElements = [];
+
+const state = {
+  board: [],
+  selectedRocks: [],
+  actionableTargets: new Set(),
+  tankerQueue: [],
+  settledCells: new Set(),
+  actuation: START_ACTUATION,
+  scans: MAX_SCANS,
+  evidenceCleared: 0,
+  explosionsTriggered: 0,
+  phoenixCount: 0,
+  operationActive: false,
+  logs: [],
+  pendingStatus: "Press Start Operation to begin the sabotage run.",
+};
+
+initializeGrid();
+resetState(false);
+renderAll();
+
+startOperationButton.addEventListener("click", () => {
+  resetState(true);
+  logEvent("Operation underway. Align the tanker modules and clear the lane.", "success");
+});
+
+advanceTankerButton.addEventListener("click", () => {
+  advanceTanker();
+});
+
+intelScanButton.addEventListener("click", () => {
+  spendScan();
+});
+
+resetOperationButton.addEventListener("click", () => {
+  resetState(false);
+  logEvent("Operation reset. Formation cleared and intel restored.", "warning");
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.defaultPrevented) {
+    return;
+  }
+  const target = event.target;
+  if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target instanceof HTMLSelectElement) {
+    return;
+  }
+  if (event.key === "a" || event.key === "A") {
+    event.preventDefault();
+    advanceTanker();
+  } else if (event.key === "s" || event.key === "S") {
+    event.preventDefault();
+    spendScan();
+  } else if (event.key === "r" || event.key === "R") {
+    event.preventDefault();
+    resetState(false);
+    logEvent("Operation reset. Formation cleared and intel restored.", "warning");
+  }
+});
+
+function initializeGrid() {
+  compoundGrid.innerHTML = "";
+  cellElements.length = 0;
+  for (let row = 0; row < BOARD_HEIGHT; row += 1) {
+    const rowElements = [];
+    for (let col = 0; col < BOARD_WIDTH; col += 1) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "compound-cell";
+      button.dataset.row = String(row);
+      button.dataset.col = String(col);
+      button.setAttribute("role", "gridcell");
+      button.addEventListener("click", handleCellClick);
+      compoundGrid.append(button);
+      rowElements.push(button);
+    }
+    cellElements.push(rowElements);
+  }
+}
+
+function resetState(activateOperation) {
+  state.board = buildBoard();
+  state.selectedRocks = [];
+  state.actionableTargets = new Set();
+  state.settledCells = new Set();
+  state.actuation = START_ACTUATION;
+  state.scans = MAX_SCANS;
+  state.evidenceCleared = 0;
+  state.explosionsTriggered = 0;
+  state.phoenixCount = 0;
+  state.logs = [];
+  state.operationActive = activateOperation;
+  state.pendingStatus = activateOperation
+    ? "Operation live. Clear crates without rattling the explosives."
+    : "Press Start Operation to begin the sabotage run.";
+
+  if (activateOperation) {
+    state.tankerQueue = [spawnPiece(false), spawnPiece(true), spawnPiece(true)].filter(Boolean);
+    if (state.tankerQueue.length === 0) {
+      state.operationActive = false;
+      state.pendingStatus = "No safe launch corridor. Operation aborted.";
+      logEvent("No launch corridor available. Reset and reassess the rock charges.", "danger");
+    }
+  } else {
+    state.tankerQueue = [];
+  }
+
+  renderAll();
+}
+
+function buildBoard() {
+  const board = Array.from({ length: BOARD_HEIGHT }, () =>
+    Array.from({ length: BOARD_WIDTH }, () => createCell("empty"))
+  );
+
+  SAFE_EVIDENCE_POSITIONS.forEach(([row, col]) => {
+    board[row][col] = createCell("evidence");
+  });
+
+  EXPLOSIVE_POSITIONS.forEach(([row, col]) => {
+    board[row][col] = createCell("explosive");
+  });
+
+  ROCK_POSITIONS.forEach(([row, col]) => {
+    if (isWithinBoard(row, col)) {
+      board[row][col] = createCell("rock");
+    }
+  });
+
+  return board;
+}
+
+function createCell(type) {
+  return {
+    type,
+    revealed: type !== "evidence" && type !== "explosive",
+  };
+}
+
+function spawnPiece(randomised) {
+  const piece = {
+    orientation: randomised ? randomInt(0, TANKER_SHAPES.length) : 0,
+    column: 2,
+    row: 0,
+  };
+
+  if (!positionPiece(piece)) {
+    return null;
+  }
+  return piece;
+}
+
+function positionPiece(piece) {
+  const orientations = [...Array(TANKER_SHAPES.length).keys()];
+  if (piece.orientation != null) {
+    orientations.splice(orientations.indexOf(piece.orientation), 1);
+    orientations.unshift(piece.orientation);
+  }
+
+  for (const orientation of orientations) {
+    const width = getPieceWidth(orientation);
+    const possibleColumns = shuffleArray(laneAlignedColumns(width));
+    for (const column of possibleColumns) {
+      if (canPlacePiece(orientation, 0, column)) {
+        piece.orientation = orientation;
+        piece.column = column;
+        piece.row = 0;
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function canPlacePiece(orientation, rowOffset, columnOffset) {
+  const offsets = TANKER_SHAPES[orientation];
+  return offsets.every((offset) => {
+    const row = rowOffset + offset.row;
+    const col = columnOffset + offset.col;
+    if (!isWithinBoard(row, col)) {
+      return false;
+    }
+    if (isBlockingCell(row, col)) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function getPieceCells(piece, rowOffset = piece.row, columnOffset = piece.column) {
+  const offsets = TANKER_SHAPES[piece.orientation];
+  return offsets.map((offset) => ({
+    row: rowOffset + offset.row,
+    col: columnOffset + offset.col,
+  }));
+}
+
+function getPieceWidth(orientation) {
+  const offsets = TANKER_SHAPES[orientation];
+  const maxCol = offsets.reduce((max, offset) => Math.max(max, offset.col), 0);
+  return maxCol + 1;
+}
+
+function isBlockingCell(row, col) {
+  if (state.settledCells.has(keyFrom(row, col))) {
+    return true;
+  }
+  const cell = state.board[row][col];
+  return cell.type === "rock" || cell.type === "evidence" || cell.type === "explosive";
+}
+
+function handleCellClick(event) {
+  const button = event.currentTarget;
+  const row = Number(button.dataset.row);
+  const col = Number(button.dataset.col);
+  const cell = state.board[row][col];
+
+  if (!state.operationActive) {
+    return;
+  }
+
+  if (cell.type === "rock") {
+    toggleRockSelection(row, col);
+    return;
+  }
+
+  if ((cell.type === "evidence" || cell.type === "explosive") && state.actionableTargets.has(keyFrom(row, col))) {
+    sabotageEvidence(row, col);
+  }
+}
+
+function toggleRockSelection(row, col) {
+  if (!state.operationActive) {
+    return;
+  }
+  const key = keyFrom(row, col);
+  const index = state.selectedRocks.indexOf(key);
+  if (index >= 0) {
+    state.selectedRocks.splice(index, 1);
+  } else {
+    if (state.selectedRocks.length === 3) {
+      state.selectedRocks.shift();
+    }
+    state.selectedRocks.push(key);
+  }
+  updateActionableTargets();
+  renderBoard();
+}
+
+function updateActionableTargets() {
+  state.actionableTargets = new Set();
+  if (!state.operationActive || state.selectedRocks.length !== 3) {
+    return;
+  }
+  const selectedCoords = state.selectedRocks.map(parseKey);
+  for (let row = 0; row < BOARD_HEIGHT; row += 1) {
+    for (let col = 0; col < BOARD_WIDTH; col += 1) {
+      const cell = state.board[row][col];
+      if (cell.type !== "evidence" && cell.type !== "explosive") {
+        continue;
+      }
+      const matches = selectedCoords.every(({ row: r, col: c }) => Math.abs(r - row) <= 1 && Math.abs(c - col) <= 1);
+      if (matches) {
+        state.actionableTargets.add(keyFrom(row, col));
+      }
+    }
+  }
+}
+
+function sabotageEvidence(row, col) {
+  if (!state.operationActive) {
+    return;
+  }
+  const cell = state.board[row][col];
+  if (cell.type !== "evidence" && cell.type !== "explosive") {
+    return;
+  }
+  const wasExplosive = cell.type === "explosive";
+
+  state.selectedRocks.forEach((key) => {
+    const { row: rockRow, col: rockCol } = parseKey(key);
+    const rockCell = state.board[rockRow][rockCol];
+    if (rockCell.type === "rock") {
+      rockCell.type = "cleared";
+      rockCell.revealed = true;
+    }
+  });
+  state.selectedRocks = [];
+  state.actionableTargets = new Set();
+
+  if (cell.type === "evidence" || cell.type === "explosive") {
+    cell.type = "cleared";
+    cell.revealed = true;
+    state.evidenceCleared += 1;
+  }
+
+  state.actuation = Math.max(0, state.actuation - SABOTAGE_COST);
+
+  if (wasExplosive) {
+    state.explosionsTriggered += 1;
+    logEvent("Concealed explosive detonated. Remaining tanker modules have been scattered.", "danger");
+    randomiseRemainingPieces();
+  } else {
+    logEvent("Evidence crate neutralised. Lane segment cleared.", "success");
+    state.pendingStatus = "Crate cleared. Lane opening up.";
+  }
+
+  renderAll();
+}
+
+function randomiseRemainingPieces() {
+  if (state.tankerQueue.length === 0) {
+    renderAll();
+    return;
+  }
+  let viable = true;
+  state.tankerQueue.forEach((piece) => {
+    const ok = randomisePiece(piece);
+    viable = viable && ok;
+  });
+  if (!viable) {
+    state.operationActive = false;
+    state.pendingStatus = "Explosion scattered the formation beyond recovery.";
+    logEvent("Explosion scattered the convoy beyond recovery. Reset to re-run the sabotage.", "danger");
+  } else {
+    state.pendingStatus = "Convoy scattered—realign before advancing again.";
+    logEvent("Convoy formation scrambled. Reorient the modules before advancing.", "warning");
+  }
+  renderAll();
+}
+
+function randomisePiece(piece) {
+  const orientations = shuffleArray([...Array(TANKER_SHAPES.length).keys()]);
+  for (const orientation of orientations) {
+    const width = getPieceWidth(orientation);
+    const possibleColumns = shuffleArray(laneAlignedColumns(width));
+    for (const column of possibleColumns) {
+      if (canPlacePiece(orientation, 0, column)) {
+        piece.orientation = orientation;
+        piece.column = column;
+        piece.row = 0;
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function advanceTanker() {
+  if (!state.operationActive || state.tankerQueue.length === 0) {
+    return;
+  }
+  if (state.actuation < ADVANCE_COST) {
+    logEvent("Actuation depleted. Trigger a Phoenix wipe or reset the operation.", "warning");
+    return;
+  }
+
+  const piece = state.tankerQueue[0];
+  const nextRow = piece.row + 1;
+  if (canPlacePiece(piece.orientation, nextRow, piece.column)) {
+    piece.row = nextRow;
+    state.actuation = Math.max(0, state.actuation - ADVANCE_COST);
+    state.pendingStatus = "Convoy module advanced. Keep the lane clear.";
+    renderAll();
+    return;
+  }
+
+  settleActivePiece();
+}
+
+function settleActivePiece() {
+  if (state.tankerQueue.length === 0) {
+    return;
+  }
+  const piece = state.tankerQueue.shift();
+  const cells = getPieceCells(piece);
+  cells.forEach(({ row, col }) => {
+    state.settledCells.add(keyFrom(row, col));
+  });
+  checkPhoenix(cells);
+  logEvent("Tanker module locked into position.", "info");
+
+  if (state.tankerQueue.length === 0) {
+    state.operationActive = false;
+    state.pendingStatus = "Convoy secured. Evidence trail purged.";
+    logEvent("All tanker modules delivered. Mission success.", "success");
+    renderAll();
+    return;
+  }
+
+  const nextPiece = state.tankerQueue[0];
+  if (!positionPiece(nextPiece)) {
+    state.operationActive = false;
+    state.pendingStatus = "Launch corridor blocked. Operation stalled.";
+    logEvent("Launch corridor blocked. Reset to retry the sabotage pattern.", "danger");
+  } else {
+    state.pendingStatus = "Next module primed. Clear remaining crates.";
+  }
+  renderAll();
+}
+
+function checkPhoenix(cells) {
+  const touchedRows = new Set(cells.map((cell) => cell.row));
+  touchedRows.forEach((row) => {
+    const filled = LANE_COLUMNS.every((col) => state.settledCells.has(keyFrom(row, col)));
+    if (filled) {
+      triggerPhoenix(row);
+    }
+  });
+}
+
+function triggerPhoenix(row) {
+  state.phoenixCount += 1;
+  state.actuation = Math.min(100, state.actuation + PHOENIX_REFILL);
+  const rowStart = Math.max(0, row - 1);
+  const rowEnd = Math.min(BOARD_HEIGHT - 1, row + 1);
+  const colStart = Math.max(0, Math.min(...LANE_COLUMNS) - 1);
+  const colEnd = Math.min(BOARD_WIDTH - 1, Math.max(...LANE_COLUMNS) + 1);
+  for (let r = rowStart; r <= rowEnd; r += 1) {
+    for (let c = colStart; c <= colEnd; c += 1) {
+      const cell = state.board[r][c];
+      if (cell.type === "evidence" || cell.type === "explosive") {
+        state.evidenceCleared += 1;
+        cell.type = "cleared";
+        cell.revealed = true;
+      }
+    }
+  }
+  logEvent("Phoenix combo! Nearby crates purged and actuation stabilised.", "success");
+}
+
+function spendScan() {
+  if (!state.operationActive) {
+    return;
+  }
+  if (state.scans <= 0) {
+    logEvent("No intel scans remaining.", "warning");
+    return;
+  }
+  if (state.actuation < SCAN_COST) {
+    logEvent("Actuation too low to power a scan.", "warning");
+    return;
+  }
+
+  const concealedCells = [];
+  for (let row = 0; row < BOARD_HEIGHT; row += 1) {
+    for (let col = 0; col < BOARD_WIDTH; col += 1) {
+      const cell = state.board[row][col];
+      if ((cell.type === "evidence" || cell.type === "explosive") && !cell.revealed) {
+        concealedCells.push({ row, col, type: cell.type });
+      }
+    }
+  }
+
+  if (concealedCells.length === 0) {
+    logEvent("All crates already identified.", "info");
+    return;
+  }
+
+  const revealed = concealedCells[randomInt(0, concealedCells.length)];
+  const cell = state.board[revealed.row][revealed.col];
+  cell.revealed = true;
+  state.scans -= 1;
+  state.actuation = Math.max(0, state.actuation - SCAN_COST);
+
+  if (revealed.type === "explosive") {
+    logEvent(`Scan complete: crate at row ${revealed.row + 1}, col ${revealed.col + 1} is wired.`, "warning");
+    state.pendingStatus = "Explosive identified. Avoid matching that crate.";
+  } else {
+    logEvent(`Scan complete: crate at row ${revealed.row + 1}, col ${revealed.col + 1} is clean evidence.`, "info");
+    state.pendingStatus = "Clean evidence spotted. Ready charges when able.";
+  }
+  renderAll();
+}
+
+function renderAll() {
+  renderBoard();
+  renderQueue();
+  renderStatus();
+  renderLog();
+  updateButtons();
+}
+
+function renderBoard() {
+  const activeCells = new Set();
+  if (state.operationActive && state.tankerQueue.length > 0) {
+    getPieceCells(state.tankerQueue[0]).forEach(({ row, col }) => {
+      activeCells.add(keyFrom(row, col));
+    });
+  }
+
+  for (let row = 0; row < BOARD_HEIGHT; row += 1) {
+    for (let col = 0; col < BOARD_WIDTH; col += 1) {
+      const cell = state.board[row][col];
+      const element = cellElements[row][col];
+      const classes = ["compound-cell"];
+
+      if (cell.type === "rock") {
+        classes.push("cell-rock");
+        if (state.selectedRocks.includes(keyFrom(row, col))) {
+          classes.push("selected");
+        }
+      } else if (cell.type === "evidence") {
+        classes.push("cell-evidence");
+        if (!cell.revealed) {
+          classes.push("concealed");
+        }
+      } else if (cell.type === "explosive") {
+        if (cell.revealed) {
+          classes.push("cell-explosive");
+        } else {
+          classes.push("cell-evidence", "concealed");
+        }
+      } else if (cell.type === "cleared") {
+        classes.push("cell-cleared");
+      }
+
+      const key = keyFrom(row, col);
+      if (state.actionableTargets.has(key)) {
+        classes.push("cell-actionable");
+      }
+      if (state.settledCells.has(key)) {
+        classes.push("cell-tanker-settled");
+      }
+      if (activeCells.has(key)) {
+        classes.push("cell-tanker-active");
+      }
+
+      element.className = classes.join(" ");
+      element.disabled = !state.operationActive;
+      element.setAttribute("aria-label", describeCell(row, col, cell, activeCells.has(key)));
+      element.textContent = getCellGlyph(cell, activeCells.has(key));
+    }
+  }
+}
+
+function renderQueue() {
+  tankerQueueElement.innerHTML = "";
+  state.tankerQueue.forEach((piece, index) => {
+    const article = document.createElement("article");
+    article.className = `queue-piece${index === 0 ? " active" : ""}`;
+    const header = document.createElement("div");
+    header.className = "queue-piece-header";
+    header.textContent = index === 0 ? "Active Module" : `Queued Module ${index}`;
+    article.append(header);
+
+    const grid = document.createElement("div");
+    grid.className = "queue-grid";
+    for (let r = 0; r < 3; r += 1) {
+      for (let c = 0; c < 3; c += 1) {
+        const cell = document.createElement("span");
+        cell.className = "queue-cell";
+        if (TANKER_SHAPES[piece.orientation].some((offset) => offset.row === r && offset.col === c)) {
+          cell.classList.add("fill");
+        }
+        grid.append(cell);
+      }
+    }
+    article.append(grid);
+    tankerQueueElement.append(article);
+  });
+}
+
+function renderStatus() {
+  const actuationPercent = Math.round((state.actuation / 100) * 100);
+  const ratio = Math.max(0, Math.min(1, state.actuation / 100));
+  actuationFill.style.transform = `scaleX(${ratio})`;
+  actuationText.textContent = `${actuationPercent}%`;
+  actuationBar.setAttribute("aria-valuenow", String(actuationPercent));
+  evidenceCountElement.textContent = `${state.evidenceCleared} / ${TOTAL_EVIDENCE}`;
+  scanCountElement.textContent = `${state.scans}`;
+  explosiveCountElement.textContent = `${state.explosionsTriggered}`;
+  phoenixCountElement.textContent = `${state.phoenixCount}`;
+  operationStatusElement.textContent = state.pendingStatus;
+}
+
+function renderLog() {
+  eventLogElement.innerHTML = "";
+  state.logs.slice(0, MAX_LOG_ENTRIES).forEach((entry) => {
+    const item = document.createElement("li");
+    item.className = `log-entry ${entry.tone}`;
+    item.textContent = entry.message;
+    eventLogElement.append(item);
+  });
+}
+
+function updateButtons() {
+  startOperationButton.disabled = state.operationActive;
+  advanceTankerButton.disabled = !state.operationActive || state.tankerQueue.length === 0;
+  intelScanButton.disabled = !state.operationActive || state.scans <= 0 || state.actuation < SCAN_COST;
+}
+
+function logEvent(message, tone = "info") {
+  state.logs.unshift({ message, tone });
+  if (state.logs.length > MAX_LOG_ENTRIES) {
+    state.logs.length = MAX_LOG_ENTRIES;
+  }
+  renderLog();
+}
+
+function describeCell(row, col, cell, isActive) {
+  if (state.settledCells.has(keyFrom(row, col))) {
+    return `Settled tanker plating at row ${row + 1}, column ${col + 1}.`;
+  }
+  if (isActive) {
+    return `Active tanker module at row ${row + 1}, column ${col + 1}.`;
+  }
+  if (cell.type === "rock") {
+    return `Rock charge at row ${row + 1}, column ${col + 1}.`;
+  }
+  if (cell.type === "cleared") {
+    return `Cleared lane tile at row ${row + 1}, column ${col + 1}.`;
+  }
+  if (cell.type === "evidence") {
+    return cell.revealed
+      ? `Identified evidence crate at row ${row + 1}, column ${col + 1}.`
+      : `Unknown crate at row ${row + 1}, column ${col + 1}.`;
+  }
+  if (cell.type === "explosive") {
+    return cell.revealed
+      ? `Known explosive crate at row ${row + 1}, column ${col + 1}.`
+      : `Unknown crate at row ${row + 1}, column ${col + 1}.`;
+  }
+  return `Empty tile at row ${row + 1}, column ${col + 1}.`;
+}
+
+function getCellGlyph(cell, isActive) {
+  if (isActive) {
+    return "⛽";
+  }
+  if (cell.type === "rock") {
+    return "⬣";
+  }
+  if (cell.type === "evidence") {
+    return cell.revealed ? "□" : "?";
+  }
+  if (cell.type === "explosive") {
+    return cell.revealed ? "✖" : "?";
+  }
+  if (cell.type === "cleared") {
+    return "·";
+  }
+  if (cell.type === "empty") {
+    return "";
+  }
+  return "";
+}
+
+function keyFrom(row, col) {
+  return `${row}-${col}`;
+}
+
+function parseKey(key) {
+  const [row, col] = key.split("-").map(Number);
+  return { row, col };
+}
+
+function dedupePositions(list) {
+  const seen = new Set();
+  const unique = [];
+  list.forEach(([row, col]) => {
+    const key = keyFrom(row, col);
+    if (!seen.has(key) && isWithinBoard(row, col)) {
+      seen.add(key);
+      unique.push([row, col]);
+    }
+  });
+  return unique;
+}
+
+function shuffleArray(values) {
+  const array = [...values];
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
+function randomInt(min, max) {
+  return Math.floor(Math.random() * (max - min)) + min;
+}
+
+function isWithinBoard(row, col) {
+  return row >= 0 && row < BOARD_HEIGHT && col >= 0 && col < BOARD_WIDTH;
+}
+
+function laneAlignedColumns(width) {
+  const laneMin = Math.min(...LANE_COLUMNS);
+  const laneMax = Math.max(...LANE_COLUMNS);
+  const minColumn = Math.max(0, laneMin - 1);
+  const maxColumn = Math.min(BOARD_WIDTH - width, laneMax - Math.max(0, width - 2));
+  const columns = [];
+  for (let col = minColumn; col <= maxColumn; col += 1) {
+    columns.push(col);
+  }
+  if (columns.length === 0) {
+    for (let col = 0; col <= BOARD_WIDTH - width; col += 1) {
+      columns.push(col);
+    }
+  }
+  return columns;
+}


### PR DESCRIPTION
## Summary
- add the Level 36 "Vendetta Convoy" cabinet with briefing content, simulator layout, and status displays
- implement sequential sabotage, explosive randomization, Phoenix combo, and tanker queue logic for the new level
- register the cabinet in the 1989 arcade catalog with a bespoke SVG thumbnail

## Testing
- python -m http.server 5000 (manual preview)


------
https://chatgpt.com/codex/tasks/task_e_68deed0ea750832893f6e4eccba95e07