### PR TITLE
Add Level 35 Cul-de-sac Curiosity to 1989 arcade

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -126,6 +126,54 @@ const games = [
     `,
   },
   {
+    id: "culdesac-curiosity",
+    name: "Cul-de-sac Curiosity",
+    description: "Swap gossip to earn dig tokens while paranoia creeps toward a suburban outburst.",
+    url: "./culdesac-curiosity/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Cul-de-sac Curiosity preview">
+        <defs>
+          <linearGradient id="curiositySky" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(56,189,248,0.85)" />
+            <stop offset="100%" stop-color="rgba(15,23,42,0.9)" />
+          </linearGradient>
+          <linearGradient id="basementGlow" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="rgba(192,132,252,0.65)" />
+            <stop offset="100%" stop-color="rgba(56,189,248,0.4)" />
+          </linearGradient>
+          <linearGradient id="paranoiaMeter" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stop-color="rgba(248,113,113,0.9)" />
+            <stop offset="100%" stop-color="rgba(251,191,36,0.9)" />
+          </linearGradient>
+        </defs>
+        <rect x="8" y="8" width="144" height="104" rx="18" fill="rgba(6,10,22,0.92)" stroke="rgba(148,163,184,0.35)" />
+        <rect x="20" y="20" width="120" height="48" rx="14" fill="url(#curiositySky)" stroke="rgba(148,163,184,0.28)" />
+        <g transform="translate(38 28)">
+          <polygon points="24,0 48,18 0,18" fill="rgba(226,232,240,0.85)" stroke="rgba(148,163,184,0.35)" />
+          <rect x="6" y="18" width="36" height="20" rx="6" fill="rgba(15,23,42,0.85)" stroke="rgba(148,163,184,0.35)" />
+          <rect x="14" y="24" width="8" height="10" fill="rgba(56,189,248,0.75)" />
+          <rect x="28" y="24" width="8" height="10" fill="rgba(249,115,22,0.75)" />
+        </g>
+        <g transform="translate(20 70)">
+          <rect x="0" y="0" width="120" height="34" rx="10" fill="rgba(9,13,28,0.9)" stroke="rgba(148,163,184,0.28)" />
+          <rect x="10" y="8" width="32" height="18" rx="6" fill="rgba(226,232,240,0.1)" stroke="rgba(148,163,184,0.25)" />
+          <rect x="50" y="8" width="32" height="18" rx="6" fill="rgba(226,232,240,0.1)" stroke="rgba(148,163,184,0.25)" />
+          <rect x="90" y="8" width="20" height="18" rx="6" fill="rgba(226,232,240,0.1)" stroke="rgba(148,163,184,0.25)" />
+          <rect x="12" y="10" width="12" height="14" rx="4" fill="rgba(248,250,252,0.85)" />
+          <rect x="54" y="10" width="12" height="14" rx="4" fill="rgba(251,191,36,0.75)" />
+          <rect x="94" y="10" width="12" height="14" rx="4" fill="rgba(192,132,252,0.75)" />
+        </g>
+        <rect x="28" y="92" width="104" height="10" rx="5" fill="rgba(15,23,42,0.8)" stroke="rgba(148,163,184,0.25)" />
+        <rect x="30" y="94" width="70" height="6" rx="3" fill="url(#paranoiaMeter)" />
+        <g transform="translate(110 28)">
+          <rect x="0" y="0" width="22" height="40" rx="8" fill="rgba(15,23,42,0.85)" stroke="rgba(148,163,184,0.28)" />
+          <rect x="4" y="26" width="14" height="10" rx="4" fill="url(#basementGlow)" />
+          <circle cx="11" cy="12" r="6" fill="rgba(192,132,252,0.8)" stroke="rgba(248,250,252,0.6)" stroke-width="1.5" />
+        </g>
+      </svg>
+    `,
+  },
+  {
     id: "argumentum",
     name: "Argumentum",
 

--- a/madia.new/public/secret/1989/culdesac-curiosity/culdesac-curiosity.css
+++ b/madia.new/public/secret/1989/culdesac-curiosity/culdesac-curiosity.css
@@ -1,0 +1,498 @@
+:root {
+  color-scheme: dark;
+  --bg: #04050f;
+  --panel: rgba(9, 12, 26, 0.9);
+  --border: rgba(148, 163, 184, 0.28);
+  --accent: #38bdf8;
+  --accent-soft: rgba(56, 189, 248, 0.18);
+  --warning: #f97316;
+  --danger: #ef4444;
+  --mystery: #c084fc;
+  --bone: #e2e8f0;
+  --dirt: #94a3b8;
+  --muted: rgba(148, 163, 184, 0.74);
+  font-family: "IBM Plex Sans", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+body {
+  background: radial-gradient(circle at 12% 18%, rgba(56, 189, 248, 0.15), transparent 55%),
+    radial-gradient(circle at 80% 12%, rgba(192, 132, 252, 0.12), transparent 62%), var(--bg);
+  color: #e2e8f0;
+  margin: 0;
+  min-height: 100vh;
+}
+
+.scanlines::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(to bottom, rgba(4, 6, 18, 0) 0, rgba(4, 6, 18, 0) 2px, rgba(4, 6, 18, 0.1) 4px);
+  mix-blend-mode: soft-light;
+  opacity: 0.55;
+}
+
+.page-header {
+  padding: 3rem 5vw 2.4rem;
+  text-align: center;
+}
+
+.eyebrow {
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.page-header h1 {
+  margin: 0.75rem 0 0.5rem;
+  font-size: clamp(2.4rem, 4vw, 3.4rem);
+}
+
+.subtitle {
+  margin: 0 auto;
+  max-width: 760px;
+  color: rgba(226, 232, 240, 0.82);
+  font-size: 1.05rem;
+  line-height: 1.55;
+}
+
+.page-layout {
+  display: grid;
+  gap: 2.25rem;
+  grid-template-columns: minmax(280px, 360px) minmax(520px, 1fr);
+  padding: 0 5vw 3.5rem;
+}
+
+.briefing,
+.arena {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 1.85rem;
+  box-shadow: 0 26px 60px rgba(2, 6, 18, 0.52);
+}
+
+.briefing p {
+  line-height: 1.65;
+}
+
+.callouts {
+  margin: 1.2rem 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.callouts li {
+  line-height: 1.55;
+}
+
+.controls dl {
+  display: grid;
+  gap: 1rem;
+}
+
+.controls dt {
+  font-weight: 600;
+  margin-bottom: 0.2rem;
+}
+
+.controls dd {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.arena-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.3rem;
+}
+
+.arena-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.action-button {
+  background: rgba(15, 23, 42, 0.82);
+  color: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  border-radius: 12px;
+  padding: 0.48rem 1rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
+}
+
+.action-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.action-button:not(:disabled):hover {
+  background: rgba(56, 189, 248, 0.16);
+  border-color: rgba(56, 189, 248, 0.42);
+  transform: translateY(-1px);
+}
+
+.status-bar {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 14px;
+  padding: 0.8rem 1.1rem;
+  margin-bottom: 1.35rem;
+  min-height: 54px;
+  display: flex;
+  align-items: center;
+  font-size: 0.95rem;
+}
+
+.gauges {
+  display: grid;
+  gap: 1.05rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-bottom: 1.35rem;
+}
+
+.meter {
+  background: rgba(10, 16, 34, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+}
+
+.meter-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.6rem;
+}
+
+.meter-reading {
+  font-variant-numeric: tabular-nums;
+  color: rgba(248, 250, 252, 0.86);
+}
+
+.meter-track {
+  position: relative;
+  background: rgba(15, 23, 42, 0.78);
+  border-radius: 999px;
+  height: 12px;
+  overflow: hidden;
+}
+
+.meter-fill {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  border-radius: inherit;
+  transition: width 200ms ease;
+}
+
+.meter-paranoia {
+  background: linear-gradient(90deg, rgba(239, 68, 68, 0.9), rgba(248, 113, 113, 0.9));
+}
+
+.meter-tokens .meter-fill {
+  background: linear-gradient(90deg, rgba(56, 189, 248, 0.85), rgba(14, 165, 233, 0.9));
+}
+
+.meter-curiosity {
+  background: linear-gradient(90deg, rgba(192, 132, 252, 0.9), rgba(59, 130, 246, 0.85));
+}
+
+.boards {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
+.gossip-board,
+.dig-site {
+  background: rgba(8, 12, 26, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 16px;
+  padding: 1.15rem;
+  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.08);
+}
+
+.board-caption {
+  margin: 0.4rem 0 1rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.board-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 6px;
+  background: rgba(5, 9, 20, 0.75);
+  border: 1px solid rgba(56, 189, 248, 0.18);
+  border-radius: 12px;
+  padding: 8px;
+}
+
+.tile-button {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1;
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  font-size: 0;
+  background: rgba(15, 23, 42, 0.85);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.26);
+  transition: transform 120ms ease, box-shadow 160ms ease;
+}
+
+.tile-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.tile-button.selected {
+  box-shadow: inset 0 0 0 2px rgba(56, 189, 248, 0.7);
+  transform: translateY(-2px);
+}
+
+.tile-sigil {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 1.4rem;
+}
+
+.tile-button.binoculars {
+  background: radial-gradient(circle at 28% 28%, rgba(56, 189, 248, 0.35), transparent 60%), rgba(15, 23, 42, 0.9);
+}
+
+.tile-button.walkie {
+  background: radial-gradient(circle at 70% 25%, rgba(249, 115, 22, 0.35), transparent 65%), rgba(15, 23, 42, 0.9);
+}
+
+.tile-button.mail {
+  background: radial-gradient(circle at 24% 65%, rgba(250, 204, 21, 0.3), transparent 60%), rgba(15, 23, 42, 0.9);
+}
+
+.tile-button.shovel {
+  background: radial-gradient(circle at 60% 70%, rgba(74, 222, 128, 0.32), transparent 60%), rgba(15, 23, 42, 0.9);
+}
+
+.tile-button.crow {
+  background: radial-gradient(circle at 50% 30%, rgba(147, 51, 234, 0.3), transparent 60%), rgba(15, 23, 42, 0.9);
+}
+
+.tile-button.clearing {
+  opacity: 0;
+  transform: scale(0.6);
+  transition: opacity 160ms ease, transform 160ms ease;
+}
+
+.dig-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(60px, 1fr));
+  gap: 10px;
+}
+
+.dig-cell {
+  position: relative;
+  padding: 0;
+  aspect-ratio: 1;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(13, 19, 34, 0.9);
+  color: #f8fafc;
+  cursor: pointer;
+  transition: transform 140ms ease, border-color 160ms ease;
+}
+
+.dig-cell:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.dig-cell:not(:disabled):hover {
+  transform: translateY(-2px);
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.dig-cell .cell-content {
+  display: grid;
+  place-items: center;
+  height: 100%;
+  font-size: 1rem;
+  line-height: 1.3;
+  padding: 0.4rem;
+  text-align: center;
+}
+
+.dig-cell.bone .cell-content {
+  color: var(--bone);
+}
+
+.dig-cell.mystery .cell-content {
+  color: var(--mystery);
+}
+
+.dig-cell.dirt .cell-content {
+  color: var(--dirt);
+}
+
+.dig-cell.hidden {
+  background: rgba(9, 13, 28, 0.85);
+  border-style: dashed;
+  cursor: default;
+}
+
+.dig-cell.hidden .cell-content {
+  color: rgba(148, 163, 184, 0.3);
+}
+
+.dig-cell.cleared {
+  background: rgba(56, 189, 248, 0.08);
+  border-color: rgba(56, 189, 248, 0.35);
+}
+
+.dig-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 0.9rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+}
+
+.legend-item::before {
+  content: "";
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+}
+
+.legend-item.bone::before {
+  background: var(--bone);
+}
+
+.legend-item.mystery::before {
+  background: var(--mystery);
+}
+
+.legend-item.dirt::before {
+  background: var(--dirt);
+}
+
+.log {
+  margin-top: 1.75rem;
+}
+
+.log ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+  max-height: 220px;
+  overflow-y: auto;
+  font-size: 0.9rem;
+}
+
+.log li {
+  padding: 0.55rem 0.75rem;
+  background: rgba(10, 16, 30, 0.78);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 10px;
+  line-height: 1.4;
+}
+
+.page-footer {
+  padding: 0 5vw 3rem;
+  color: rgba(226, 232, 240, 0.75);
+  text-align: center;
+  line-height: 1.5;
+}
+
+.snoop-overlay,
+.failure-overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(4, 7, 16, 0.82);
+  z-index: 20;
+}
+
+.snoop-overlay[hidden],
+.failure-overlay[hidden] {
+  display: none;
+}
+
+.snoop-frame,
+.failure-frame {
+  background: rgba(9, 13, 28, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 18px;
+  padding: 1.6rem;
+  width: min(420px, 90vw);
+  text-align: center;
+  box-shadow: 0 30px 70px rgba(2, 6, 18, 0.55);
+}
+
+.snoop-frame h2 {
+  margin-top: 0;
+}
+
+#snoop-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 1.4rem;
+  display: grid;
+  gap: 0.5rem;
+  text-align: left;
+}
+
+#snoop-list li {
+  padding: 0.45rem 0.75rem;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(56, 189, 248, 0.24);
+  font-size: 0.95rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.failure-frame h2 {
+  margin-top: 0;
+  margin-bottom: 0.4rem;
+  color: var(--danger);
+}
+
+@media (max-width: 1024px) {
+  .page-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .board-grid {
+    grid-template-columns: repeat(6, 1fr);
+  }
+}

--- a/madia.new/public/secret/1989/culdesac-curiosity/culdesac-curiosity.js
+++ b/madia.new/public/secret/1989/culdesac-curiosity/culdesac-curiosity.js
@@ -1,0 +1,653 @@
+const boardElement = document.getElementById("gossip-grid");
+const statusBar = document.getElementById("status-bar");
+const logList = document.getElementById("log-entries");
+const paranoiaFill = document.getElementById("paranoia-fill");
+const paranoiaReading = document.getElementById("paranoia-reading");
+const tokenFill = document.getElementById("token-fill");
+const tokenReading = document.getElementById("token-reading");
+const curiosityFill = document.getElementById("curiosity-fill");
+const curiosityReading = document.getElementById("curiosity-reading");
+const digGrid = document.getElementById("dig-grid");
+const snoopButton = document.getElementById("snoop-button");
+const resetButton = document.getElementById("reset-button");
+const snoopOverlay = document.getElementById("snoop-overlay");
+const snoopList = document.getElementById("snoop-list");
+const closeSnoopButton = document.getElementById("close-snoop");
+const failureOverlay = document.getElementById("failure-overlay");
+const failureResetButton = document.getElementById("failure-reset");
+
+const BOARD_SIZE = 7;
+const TOKEN_TYPES = ["binoculars", "walkie", "mail", "shovel", "crow"];
+const TOKEN_ICONS = {
+  binoculars: "🔭",
+  walkie: "📻",
+  mail: "✉️",
+  shovel: "⛏️",
+  crow: "🐦",
+};
+
+const DIG_VISIBLE_ROWS = 4;
+const DIG_COLUMNS = 3;
+const DIG_COST = {
+  bone: 3,
+  mystery: 2,
+  dirt: 1,
+};
+const DIG_PARANOIA = {
+  bone: 6,
+  mystery: 5,
+  dirt: 4,
+};
+const DIG_PARANOIA_REASON = {
+  bone: "Bone clearing rattles the block",
+  mystery: "Prying mystery box lids",
+  dirt: "Dirt scoop echoes",
+};
+const PARANOIA_DRIFT_INTERVAL = 4000;
+const PARANOIA_DRIFT_AMOUNT = 1;
+const MAX_TOKENS_DISPLAY = 24;
+const CURIOSITY_GOAL = 3;
+
+const DIG_BLUEPRINT = [
+  {
+    layers: [
+      { type: "bone" },
+      { type: "dirt" },
+      { type: "bone" },
+      { type: "mystery" },
+      { type: "dirt" },
+      { type: "mystery" },
+    ],
+  },
+  {
+    layers: [
+      { type: "dirt" },
+      { type: "bone" },
+      { type: "bone" },
+      { type: "mystery" },
+      { type: "dirt" },
+      { type: "bone" },
+    ],
+  },
+  {
+    layers: [
+      { type: "bone" },
+      { type: "dirt" },
+      { type: "mystery" },
+      { type: "bone" },
+      { type: "mystery" },
+      { type: "dirt" },
+    ],
+  },
+];
+
+let board = [];
+let tileElements = [];
+let selectedTile = null;
+let resolvingBoard = false;
+let paranoia = 0;
+let tokens = 0;
+let curiosity = 0;
+let paranoiaTimer = null;
+let gameActive = true;
+let digColumns = [];
+
+function randomType() {
+  const index = Math.floor(Math.random() * TOKEN_TYPES.length);
+  return TOKEN_TYPES[index];
+}
+
+function createToken(type) {
+  return { type, icon: TOKEN_ICONS[type] };
+}
+
+function wouldCreateMatch(row, col, type) {
+  // check horizontal
+  let matchLeft = 0;
+  for (let i = 1; i <= 2; i += 1) {
+    if (col - i < 0) {
+      break;
+    }
+    if (board[row][col - i]?.type === type) {
+      matchLeft += 1;
+    } else {
+      break;
+    }
+  }
+  let matchRight = 0;
+  for (let i = 1; i <= 2; i += 1) {
+    if (col + i >= BOARD_SIZE) {
+      break;
+    }
+    if (board[row][col + i]?.type === type) {
+      matchRight += 1;
+    } else {
+      break;
+    }
+  }
+  if (matchLeft + matchRight >= 2) {
+    return true;
+  }
+  let matchUp = 0;
+  for (let i = 1; i <= 2; i += 1) {
+    if (row - i < 0) {
+      break;
+    }
+    if (board[row - i][col]?.type === type) {
+      matchUp += 1;
+    } else {
+      break;
+    }
+  }
+  let matchDown = 0;
+  for (let i = 1; i <= 2; i += 1) {
+    if (row + i >= BOARD_SIZE) {
+      break;
+    }
+    if (board[row + i][col]?.type === type) {
+      matchDown += 1;
+    } else {
+      break;
+    }
+  }
+  return matchUp + matchDown >= 2;
+}
+
+function fillBoard() {
+  board = Array.from({ length: BOARD_SIZE }, () => Array(BOARD_SIZE).fill(null));
+  for (let row = 0; row < BOARD_SIZE; row += 1) {
+    for (let col = 0; col < BOARD_SIZE; col += 1) {
+      let type = randomType();
+      while (wouldCreateMatch(row, col, type)) {
+        type = randomType();
+      }
+      board[row][col] = createToken(type);
+    }
+  }
+}
+
+function buildBoardElement() {
+  boardElement.innerHTML = "";
+  tileElements = Array.from({ length: BOARD_SIZE }, () => Array(BOARD_SIZE).fill(null));
+  for (let row = 0; row < BOARD_SIZE; row += 1) {
+    for (let col = 0; col < BOARD_SIZE; col += 1) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.classList.add("tile-button");
+      button.dataset.row = String(row);
+      button.dataset.col = String(col);
+      button.setAttribute("aria-label", "Rumor tile");
+      boardElement.appendChild(button);
+      tileElements[row][col] = button;
+    }
+  }
+}
+
+function renderTile(row, col) {
+  const token = board[row][col];
+  const button = tileElements[row][col];
+  button.className = "tile-button";
+  button.dataset.row = String(row);
+  button.dataset.col = String(col);
+  button.innerHTML = "";
+  if (token) {
+    button.classList.add(token.type);
+    const span = document.createElement("span");
+    span.classList.add("tile-sigil");
+    span.textContent = token.icon;
+    button.appendChild(span);
+    button.setAttribute("aria-label", `${token.type} rumor tile`);
+    button.disabled = !gameActive;
+  } else {
+    button.classList.add("clearing");
+    button.disabled = true;
+  }
+}
+
+function renderBoard() {
+  for (let row = 0; row < BOARD_SIZE; row += 1) {
+    for (let col = 0; col < BOARD_SIZE; col += 1) {
+      renderTile(row, col);
+    }
+  }
+}
+
+function findMatches() {
+  const matched = new Set();
+  // rows
+  for (let row = 0; row < BOARD_SIZE; row += 1) {
+    let runType = null;
+    let runStart = 0;
+    let runLength = 0;
+    for (let col = 0; col < BOARD_SIZE; col += 1) {
+      const token = board[row][col];
+      if (!token) {
+        runType = null;
+        runLength = 0;
+        runStart = col + 1;
+        continue;
+      }
+      if (token.type === runType) {
+        runLength += 1;
+      } else {
+        if (runLength >= 3) {
+          for (let i = 0; i < runLength; i += 1) {
+            matched.add(`${row},${runStart + i}`);
+          }
+        }
+        runType = token.type;
+        runStart = col;
+        runLength = 1;
+      }
+    }
+    if (runLength >= 3) {
+      for (let i = 0; i < runLength; i += 1) {
+        matched.add(`${row},${runStart + i}`);
+      }
+    }
+  }
+  // columns
+  for (let col = 0; col < BOARD_SIZE; col += 1) {
+    let runType = null;
+    let runStart = 0;
+    let runLength = 0;
+    for (let row = 0; row < BOARD_SIZE; row += 1) {
+      const token = board[row][col];
+      if (!token) {
+        runType = null;
+        runLength = 0;
+        runStart = row + 1;
+        continue;
+      }
+      if (token.type === runType) {
+        runLength += 1;
+      } else {
+        if (runLength >= 3) {
+          for (let i = 0; i < runLength; i += 1) {
+            matched.add(`${runStart + i},${col}`);
+          }
+        }
+        runType = token.type;
+        runStart = row;
+        runLength = 1;
+      }
+    }
+    if (runLength >= 3) {
+      for (let i = 0; i < runLength; i += 1) {
+        matched.add(`${runStart + i},${col}`);
+      }
+    }
+  }
+  return matched;
+}
+
+function collapseBoard() {
+  for (let col = 0; col < BOARD_SIZE; col += 1) {
+    const stack = [];
+    for (let row = BOARD_SIZE - 1; row >= 0; row -= 1) {
+      if (board[row][col]) {
+        stack.push(board[row][col]);
+      }
+    }
+    for (let row = BOARD_SIZE - 1; row >= 0; row -= 1) {
+      const token = stack.shift();
+      board[row][col] = token ?? null;
+    }
+    for (let row = 0; row < BOARD_SIZE; row += 1) {
+      if (!board[row][col]) {
+        let type = randomType();
+        while (wouldCreateMatch(row, col, type)) {
+          type = randomType();
+        }
+        board[row][col] = createToken(type);
+      }
+    }
+  }
+}
+
+function clearSelection() {
+  if (selectedTile) {
+    const { row, col } = selectedTile;
+    tileElements[row][col].classList.remove("selected");
+  }
+  selectedTile = null;
+}
+
+function setStatus(message) {
+  statusBar.textContent = message;
+}
+
+function logEvent(message) {
+  const item = document.createElement("li");
+  item.textContent = message;
+  logList.prepend(item);
+  while (logList.children.length > 12) {
+    logList.removeChild(logList.lastElementChild);
+  }
+}
+
+function updateParanoiaUI() {
+  paranoiaFill.style.width = `${Math.min(paranoia, 100)}%`;
+  paranoiaReading.textContent = `${Math.round(paranoia)}%`;
+}
+
+function adjustParanoia(amount, reason) {
+  if (!gameActive && amount >= 0) {
+    return;
+  }
+  const previous = paranoia;
+  paranoia = Math.max(0, Math.min(100, paranoia + amount));
+  updateParanoiaUI();
+  if (amount > 0 && reason) {
+    logEvent(`${reason} (+${amount}% paranoia)`);
+  }
+  if (paranoia >= 100) {
+    triggerFailure();
+  } else if (amount < 0 && paranoia !== previous) {
+    logEvent(`Neighborhood calms (-${previous - paranoia}% paranoia)`);
+  }
+}
+
+function updateTokensUI() {
+  tokenReading.textContent = String(tokens);
+  const ratio = Math.min(tokens / MAX_TOKENS_DISPLAY, 1);
+  tokenFill.style.width = `${ratio * 100}%`;
+}
+
+function updateCuriosityUI() {
+  curiosityReading.textContent = `${curiosity} / ${CURIOSITY_GOAL}`;
+  const ratio = Math.min(curiosity / CURIOSITY_GOAL, 1);
+  curiosityFill.style.width = `${ratio * 100}%`;
+}
+
+function triggerFailure() {
+  gameActive = false;
+  clearInterval(paranoiaTimer);
+  paranoiaTimer = null;
+  setStatus("Outburst! The neighbors call the cops. Reset to try again.");
+  snoopOverlay.hidden = true;
+  failureOverlay.hidden = false;
+}
+
+function checkVictory() {
+  if (curiosity >= CURIOSITY_GOAL) {
+    gameActive = false;
+    clearInterval(paranoiaTimer);
+    paranoiaTimer = null;
+    setStatus("Mystery solved. Deliver the evidence before the Klopeks notice.");
+    logEvent("Curiosity meter filled—victory!");
+  }
+}
+
+function resolveMatchesLoop(initialMatches) {
+  return new Promise((resolve) => {
+    let totalCleared = 0;
+    let chain = 0;
+    function step(matches) {
+      if (!matches || matches.size === 0) {
+        resolve(totalCleared);
+        return;
+      }
+      chain += 1;
+      const clearedPositions = Array.from(matches).map((key) => {
+        const [row, col] = key.split(",").map(Number);
+        return { row, col };
+      });
+      clearedPositions.forEach(({ row, col }) => {
+        board[row][col] = null;
+      });
+      totalCleared += clearedPositions.length;
+      setStatus(`Rumor cascade x${chain}! ${clearedPositions.length} neighbors convinced.`);
+      logEvent(`Cleared ${clearedPositions.length} tiles in chain ${chain}.`);
+      collapseBoard();
+      renderBoard();
+      setTimeout(() => {
+        const nextMatches = findMatches();
+        step(nextMatches);
+      }, 220);
+    }
+    step(initialMatches);
+  });
+}
+
+function areAdjacent(a, b) {
+  return (Math.abs(a.row - b.row) === 1 && a.col === b.col) || (Math.abs(a.col - b.col) === 1 && a.row === b.row);
+}
+
+async function attemptSwap(first, second) {
+  if (resolvingBoard || !gameActive) {
+    return;
+  }
+  resolvingBoard = true;
+  const firstToken = board[first.row][first.col];
+  const secondToken = board[second.row][second.col];
+  board[first.row][first.col] = secondToken;
+  board[second.row][second.col] = firstToken;
+  renderTile(first.row, first.col);
+  renderTile(second.row, second.col);
+  const matches = findMatches();
+  if (matches.size === 0) {
+    board[first.row][first.col] = firstToken;
+    board[second.row][second.col] = secondToken;
+    renderTile(first.row, first.col);
+    renderTile(second.row, second.col);
+    setStatus("No match. The neighborhood side-eyes your theory.");
+    adjustParanoia(4, "Failed swap");
+    resolvingBoard = false;
+    return;
+  }
+  adjustParanoia(3, "Rumor swap agitates the block");
+  const cleared = await resolveMatchesLoop(matches);
+  tokens += cleared;
+  updateTokensUI();
+  if (cleared > 0) {
+    logEvent(`Stockpiled ${cleared} dig tokens from gossip.`);
+  }
+  resolvingBoard = false;
+}
+
+function cloneDigBlueprint() {
+  return DIG_BLUEPRINT.map((column) => ({
+    layers: column.layers.map((layer) => ({ ...layer })),
+    cursor: 0,
+  }));
+}
+
+function layerAt(columnIndex, depthOffset) {
+  const column = digColumns[columnIndex];
+  if (!column) {
+    return null;
+  }
+  const index = column.cursor + depthOffset;
+  return column.layers[index] ?? null;
+}
+
+function renderDigSite() {
+  digGrid.innerHTML = "";
+  for (let row = 0; row < DIG_VISIBLE_ROWS; row += 1) {
+    for (let col = 0; col < DIG_COLUMNS; col += 1) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.classList.add("dig-cell");
+      button.dataset.column = String(col);
+      const layer = layerAt(col, row);
+      if (!layer) {
+        button.classList.add("cleared");
+        button.disabled = true;
+        const span = document.createElement("span");
+        span.classList.add("cell-content");
+        span.textContent = "Cleared";
+        button.appendChild(span);
+      } else if (row === 0) {
+        button.classList.add(layer.type);
+        const span = document.createElement("span");
+        span.classList.add("cell-content");
+        span.innerHTML = formatLayerLabel(layer.type);
+        button.appendChild(span);
+        button.disabled = !gameActive;
+        button.setAttribute("aria-label", `${layer.type} tile, costs ${DIG_COST[layer.type]} tokens`);
+        if (gameActive) {
+          button.addEventListener("click", () => {
+            handleDig(col);
+          });
+        }
+      } else {
+        button.classList.add("hidden");
+        button.disabled = true;
+        const span = document.createElement("span");
+        span.classList.add("cell-content");
+        span.textContent = "???";
+        button.appendChild(span);
+      }
+      digGrid.appendChild(button);
+    }
+  }
+}
+
+function formatLayerLabel(type) {
+  if (type === "bone") {
+    return "🦴<br />Bone";
+  }
+  if (type === "mystery") {
+    return "🎁<br />Mystery";
+  }
+  return "🪤<br />Dirt";
+}
+
+function handleDig(columnIndex) {
+  if (!gameActive) {
+    return;
+  }
+  const column = digColumns[columnIndex];
+  const layer = layerAt(columnIndex, 0);
+  if (!layer) {
+    return;
+  }
+  const cost = DIG_COST[layer.type];
+  if (tokens < cost) {
+    setStatus("Not enough dig tokens. Stir more gossip first.");
+    adjustParanoia(2, "Basement hesitation");
+    return;
+  }
+  tokens -= cost;
+  updateTokensUI();
+  adjustParanoia(DIG_PARANOIA[layer.type], DIG_PARANOIA_REASON[layer.type]);
+  column.cursor += 1;
+  if (layer.type === "mystery") {
+    curiosity += 1;
+    updateCuriosityUI();
+    adjustParanoia(-12, "Mystery box soothes the street");
+    logEvent("Mystery box cracked—curiosity meter rises.");
+  } else if (layer.type === "bone") {
+    logEvent("Bone pile cleared from the dig site.");
+  } else {
+    logEvent("Cleared packed dirt from the trench.");
+  }
+  renderDigSite();
+  checkVictory();
+}
+
+function capitalize(text) {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+function handleTileClick(event) {
+  const button = event.target.closest(".tile-button");
+  if (!button || !gameActive || resolvingBoard) {
+    return;
+  }
+  const row = Number(button.dataset.row);
+  const col = Number(button.dataset.col);
+  if (Number.isNaN(row) || Number.isNaN(col)) {
+    return;
+  }
+  if (!selectedTile) {
+    selectedTile = { row, col };
+    button.classList.add("selected");
+    setStatus("Pick a neighbor to swap.");
+    return;
+  }
+  if (selectedTile.row === row && selectedTile.col === col) {
+    button.classList.remove("selected");
+    selectedTile = null;
+    setStatus("Swap cancelled.");
+    return;
+  }
+  const secondTile = { row, col };
+  if (!areAdjacent(selectedTile, secondTile)) {
+    tileElements[selectedTile.row][selectedTile.col].classList.remove("selected");
+    selectedTile = secondTile;
+    button.classList.add("selected");
+    setStatus("Choose an adjacent tile to swap.");
+    return;
+  }
+  const firstTile = selectedTile;
+  clearSelection();
+  attemptSwap(firstTile, secondTile);
+}
+
+function startParanoiaDrift() {
+  clearInterval(paranoiaTimer);
+  paranoiaTimer = setInterval(() => {
+    adjustParanoia(PARANOIA_DRIFT_AMOUNT, null);
+  }, PARANOIA_DRIFT_INTERVAL);
+}
+
+function showSnoop() {
+  if (!gameActive || snoopOverlay.hidden === false) {
+    return;
+  }
+  snoopList.innerHTML = "";
+  const labels = ["Column A", "Column B", "Column C"];
+  digColumns.forEach((column, index) => {
+    const upcoming = column.layers.slice(column.cursor + 1, column.cursor + 4);
+    const item = document.createElement("li");
+    if (upcoming.length === 0) {
+      item.textContent = `${labels[index]}: No further finds.`;
+    } else {
+      const descriptors = upcoming.map((layer) => capitalize(layer.type));
+      item.textContent = `${labels[index]}: ${descriptors.join(", ")}`;
+    }
+    snoopList.appendChild(item);
+  });
+  snoopOverlay.hidden = false;
+  adjustParanoia(6, "Basement snooping raises suspicions");
+  logEvent("Snooping reveal shows upcoming layers.");
+}
+
+function hideSnoop() {
+  snoopOverlay.hidden = true;
+}
+
+function resetGame() {
+  clearInterval(paranoiaTimer);
+  paranoiaTimer = null;
+  gameActive = true;
+  resolvingBoard = false;
+  paranoia = 0;
+  tokens = 0;
+  curiosity = 0;
+  selectedTile = null;
+  updateParanoiaUI();
+  updateTokensUI();
+  updateCuriosityUI();
+  fillBoard();
+  buildBoardElement();
+  renderBoard();
+  digColumns = cloneDigBlueprint();
+  renderDigSite();
+  logList.innerHTML = "";
+  setStatus("Swap tiles to gather gossip and earn dig tokens.");
+  logEvent("Investigation reset. Neighborhood watch reconvenes.");
+  startParanoiaDrift();
+  failureOverlay.hidden = true;
+  snoopOverlay.hidden = true;
+}
+
+boardElement.addEventListener("click", handleTileClick);
+snoopButton.addEventListener("click", showSnoop);
+closeSnoopButton.addEventListener("click", hideSnoop);
+failureResetButton.addEventListener("click", resetGame);
+resetButton.addEventListener("click", resetGame);
+
+resetGame();

--- a/madia.new/public/secret/1989/culdesac-curiosity/index.html
+++ b/madia.new/public/secret/1989/culdesac-curiosity/index.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cul-de-sac Curiosity</title>
+    <link rel="stylesheet" href="culdesac-curiosity.css" />
+  </head>
+  <body>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 35 · 1989 Arcade</p>
+      <h1>Cul-de-sac Curiosity</h1>
+      <p class="subtitle">
+        Neighborly swaps fuel digging expeditions beneath the Klopek house. Gossip too hard and your paranoia boils over.
+      </p>
+    </header>
+    <main class="page-layout">
+      <section class="briefing" aria-labelledby="briefing-title">
+        <h2 id="briefing-title">Neighborhood Briefing</h2>
+        <p>
+          The block is convinced something terrible is buried under 669 Hickory. Keep the suburban grapevine churning with match
+          combos, bank dig tokens, then descend into the basement dig site to pry out what the Klopeks have hidden. Every action
+          makes the cul-de-sac more anxious—if paranoia erupts into an outburst, the operation collapses.
+        </p>
+        <ul class="callouts">
+          <li>
+            <strong>Suburban grid:</strong> Swap adjacent tiles to align three or more matching neighbors. Cleared tiles add dig
+            tokens and drop fresh rumors into play.
+          </li>
+          <li>
+            <strong>Dig site:</strong> Spend tokens to break bones blocking progress and crack open mystery boxes. Fill the
+            curiosity meter before paranoia tops out.
+          </li>
+          <li>
+            <strong>Paranoia meter:</strong> Rises slowly over time and faster with hasty moves. Let it max and you trigger a
+            public outburst—mission failed.
+          </li>
+          <li>
+            <strong>Snooping actuation:</strong> Peek at upcoming basement placements to plan smarter digs, but expect the nerves
+            to spike when you do.
+          </li>
+        </ul>
+        <section class="controls" aria-labelledby="controls-title">
+          <h3 id="controls-title">Controls</h3>
+          <dl>
+            <div>
+              <dt>Select rumor tile</dt>
+              <dd>Click a tile, then an orthogonally adjacent neighbor to attempt a swap.</dd>
+            </div>
+            <div>
+              <dt>Dig basement tile</dt>
+              <dd>
+                Click a revealed dig site tile to spend the shown cost. Bones consume three tokens, dirt costs one, and mystery
+                boxes need two.
+              </dd>
+            </div>
+            <div>
+              <dt>Snoop ahead</dt>
+              <dd>
+                Press <strong>Snoop Basement</strong> to reveal the next wave of bones and boxes for a few beats at the cost of
+                extra paranoia.
+              </dd>
+            </div>
+            <div>
+              <dt>Reset investigation</dt>
+              <dd>Use <strong>Reset</strong> to restart the level if the block spirals into panic.</dd>
+            </div>
+          </dl>
+        </section>
+      </section>
+      <section class="arena" aria-labelledby="arena-title">
+        <div class="arena-header">
+          <h2 id="arena-title">Hickory Street Watch</h2>
+          <div class="arena-controls" role="group" aria-label="Action controls">
+            <button type="button" class="action-button" id="snoop-button">Snoop Basement</button>
+            <button type="button" class="action-button" id="reset-button">Reset</button>
+          </div>
+        </div>
+        <div class="status-bar" id="status-bar" role="status" aria-live="polite">
+          Swap tiles to gather gossip and earn dig tokens.
+        </div>
+        <section class="gauges" aria-label="Meters">
+          <div class="meter" aria-labelledby="paranoia-label">
+            <header class="meter-header">
+              <h3 id="paranoia-label">Paranoia</h3>
+              <span class="meter-reading" id="paranoia-reading">0%</span>
+            </header>
+            <div class="meter-track" aria-hidden="true">
+              <div class="meter-fill meter-paranoia" id="paranoia-fill"></div>
+            </div>
+          </div>
+          <div class="meter" aria-labelledby="tokens-label">
+            <header class="meter-header">
+              <h3 id="tokens-label">Dig Tokens</h3>
+              <span class="meter-reading" id="token-reading">0</span>
+            </header>
+            <div class="meter-track meter-tokens" aria-hidden="true">
+              <div class="meter-fill" id="token-fill"></div>
+            </div>
+          </div>
+          <div class="meter" aria-labelledby="curiosity-label">
+            <header class="meter-header">
+              <h3 id="curiosity-label">Curiosity Meter</h3>
+              <span class="meter-reading" id="curiosity-reading">0 / 3</span>
+            </header>
+            <div class="meter-track meter-curiosity" aria-hidden="true">
+              <div class="meter-fill meter-curiosity" id="curiosity-fill"></div>
+            </div>
+          </div>
+        </section>
+        <div class="boards">
+          <section class="gossip-board" aria-labelledby="gossip-title">
+            <h3 id="gossip-title">Suburban Grid</h3>
+            <p class="board-caption">Matches earn dig tokens. Failed swaps still spook the block.</p>
+            <div class="board-grid" id="gossip-grid" role="grid" aria-label="Gossip grid"></div>
+          </section>
+          <section class="dig-site" aria-labelledby="dig-title">
+            <h3 id="dig-title">Klopek Basement Dig Site</h3>
+            <p class="board-caption">
+              Spend dig tokens to clear tiles. Bones are blockers, mystery boxes fuel the curiosity meter.
+            </p>
+            <div class="dig-grid" id="dig-grid" role="grid" aria-label="Dig site"></div>
+            <div class="dig-legend">
+              <span class="legend-item bone">Bone · 3 tokens</span>
+              <span class="legend-item mystery">Mystery Box · 2 tokens</span>
+              <span class="legend-item dirt">Dirt · 1 token</span>
+            </div>
+          </section>
+        </div>
+        <section class="log" aria-labelledby="log-title">
+          <h3 id="log-title">Neighborhood Log</h3>
+          <ul id="log-entries"></ul>
+        </section>
+      </section>
+    </main>
+    <footer class="page-footer">
+      <p>
+        Tip: The neighbors spook fast. Let gossip cascade to stockpile tokens before breaking into deep layers, and only snoop
+        when a bone wall is about to surface.
+      </p>
+    </footer>
+    <div class="snoop-overlay" id="snoop-overlay" hidden role="dialog" aria-modal="true" aria-labelledby="snoop-title">
+      <div class="snoop-frame">
+        <h2 id="snoop-title">Upcoming Basement Finds</h2>
+        <p>Next placements after the current layer clears:</p>
+        <ul id="snoop-list"></ul>
+        <button type="button" class="action-button" id="close-snoop">Close Preview</button>
+      </div>
+    </div>
+    <div class="failure-overlay" id="failure-overlay" hidden role="alertdialog" aria-modal="true">
+      <div class="failure-frame">
+        <h2>Outburst!</h2>
+        <p>The cul-de-sac erupts and the Klopeks slam their doors. Reset to try again.</p>
+        <button type="button" class="action-button" id="failure-reset">Reset Investigation</button>
+      </div>
+    </div>
+    <script type="module" src="culdesac-curiosity.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add the Level 35 "Cul-de-sac Curiosity" cabinet with match-three gossip and basement digging play
- implement paranoia, token, and curiosity meters plus snooping previews for upcoming dig layers
- register the new cabinet in the 1989 arcade catalog with bespoke thumbnail art

## Testing
- Manual QA: Loaded http://127.0.0.1:5000/secret/1989/culdesac-curiosity/ and exercised swaps, dig actions, snooping, and reset


------
https://chatgpt.com/codex/tasks/task_e_68deed1f0398832884523246cc8eb1b8