### PR TITLE
Fix Augmentum naming in 1989 arcade list

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -174,8 +174,8 @@ const games = [
     `,
   },
   {
-    id: "argumentum",
-    name: "Argumentum",
+    id: "augmentum",
+    name: "Augmentum",
 
     description: "Synth-grid puzzle fusion hidden deep in the archives.",
     url: "../augmentum/index.html",


### PR DESCRIPTION
## Summary
- correct the Augmentum cabinet entry in the 1989 arcade list so the id and display name use the proper spelling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df0e75d620832895484d42bd8974e8