### PR TITLE
Add animated interactions to 1989 arcade

### DIFF
--- a/madia.new/public/secret/1989/1989.css
+++ b/madia.new/public/secret/1989/1989.css
@@ -10,6 +10,9 @@
   --text: #f8fafc;
   --muted: rgba(226, 232, 240, 0.7);
   --danger: #f87171;
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in: cubic-bezier(0.76, 0, 0.24, 1);
+  --ease-snap: cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 * {
@@ -101,6 +104,10 @@ main {
   box-shadow: 0 25px 45px -20px rgba(0, 0, 0, 0.8);
   transition: transform 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
   overflow: hidden;
+  opacity: 0;
+  transform: translateY(14px) scale(0.98);
+  animation: card-enter 420ms var(--ease-out) forwards;
+  animation-delay: calc(var(--card-index, 0) * 70ms);
 }
 
 .game-card::before {
@@ -175,6 +182,8 @@ main {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   transition: transform 160ms ease, box-shadow 160ms ease;
+  position: relative;
+  will-change: transform, box-shadow;
 }
 
 .play-button:hover,
@@ -185,6 +194,12 @@ main {
 .fullscreen-button:focus-visible {
   transform: translateY(-2px);
   box-shadow: 0 15px 35px -15px rgba(123, 91, 255, 0.75);
+}
+
+.play-button.is-pressed,
+.back-button.is-pressed,
+.fullscreen-button.is-pressed {
+  animation: action-press 360ms var(--ease-snap);
 }
 
 .play-button:focus-visible,
@@ -220,6 +235,19 @@ main {
   display: grid;
   place-items: center;
   z-index: 10;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 280ms var(--ease-out);
+}
+
+.player-overlay.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.player-overlay.is-closing {
+  opacity: 0;
+  pointer-events: none;
 }
 
 .overlay-backdrop {
@@ -227,6 +255,7 @@ main {
   inset: 0;
   background: rgba(5, 6, 15, 0.85);
   backdrop-filter: blur(14px);
+  opacity: 0;
 }
 
 .overlay-frame {
@@ -240,18 +269,22 @@ main {
   display: grid;
   grid-template-rows: auto 1fr;
   overflow: hidden;
-  animation: overlay-in 180ms ease;
 }
 
-@keyframes overlay-in {
-  from {
-    transform: translateY(12px) scale(0.98);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0) scale(1);
-    opacity: 1;
-  }
+.player-overlay.is-visible .overlay-backdrop {
+  animation: overlay-backdrop-in 320ms var(--ease-out) forwards;
+}
+
+.player-overlay.is-closing .overlay-backdrop {
+  animation: overlay-backdrop-out 220ms var(--ease-in) forwards;
+}
+
+.player-overlay.is-visible .overlay-frame {
+  animation: overlay-in 320ms var(--ease-out) forwards;
+}
+
+.player-overlay.is-closing .overlay-frame {
+  animation: overlay-out 220ms var(--ease-in) forwards;
 }
 
 .overlay-header {
@@ -294,6 +327,84 @@ main {
   height: 100%;
   border: 0;
   background: rgba(2, 6, 23, 0.85);
+}
+
+@keyframes card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.96);
+  }
+  60% {
+    opacity: 1;
+    transform: translateY(-4px) scale(1.01);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes action-press {
+  0% {
+    transform: translateY(0) scale(1);
+    box-shadow: 0 0 0 rgba(123, 91, 255, 0);
+  }
+  40% {
+    transform: translateY(2px) scale(0.97);
+    box-shadow: 0 12px 28px -18px rgba(123, 91, 255, 0.85);
+  }
+  70% {
+    transform: translateY(-1px) scale(1.01);
+    box-shadow: 0 20px 36px -16px rgba(56, 189, 248, 0.55);
+  }
+  100% {
+    transform: translateY(0) scale(1);
+    box-shadow: 0 15px 35px -15px rgba(123, 91, 255, 0.75);
+  }
+}
+
+@keyframes overlay-in {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.96);
+  }
+  70% {
+    opacity: 1;
+    transform: translateY(-6px) scale(1.02);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes overlay-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(18px) scale(0.95);
+  }
+}
+
+@keyframes overlay-backdrop-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes overlay-backdrop-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- add staged entrance, button press, and overlay transitions across the 1989 arcade
- coordinate overlay visibility in JavaScript so close/open actions animate cleanly and restore focus

## Testing
- Manual - loaded http://127.0.0.1:5000/secret/1989/ and exercised play/fullscreen/back actions

------
https://chatgpt.com/codex/tasks/task_e_68df0da04cb48328bb1a1bb7d2eff264