### PR TITLE
Add shared particle overlays to the 1989 arcade

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -1,3 +1,7 @@
+import { mountParticleField } from "./particles.js";
+
+mountParticleField({ density: 0.0001 });
+
 /**
  * Register launchable cabinets here. You can also import { registerGame }
  * elsewhere and call it at runtime for dynamic catalogs.

--- a/madia.new/public/secret/1989/amore-express/amore-express.js
+++ b/madia.new/public/secret/1989/amore-express/amore-express.js
@@ -1,3 +1,7 @@
+import { mountParticleField } from "../particles.js";
+
+mountParticleField();
+
 const boardSize = 6;
 const shop = { row: 2, col: 0, label: "Hub", name: "Amore Slices dispatch" };
 const houses = [

--- a/madia.new/public/secret/1989/blaze/blaze.js
+++ b/madia.new/public/secret/1989/blaze/blaze.js
@@ -1,3 +1,7 @@
+import { mountParticleField } from "../particles.js";
+
+mountParticleField();
+
 const boardElement = document.getElementById("board");
 const statusBar = document.getElementById("status-bar");
 const capitalMeter = document.getElementById("capital-meter");

--- a/madia.new/public/secret/1989/cable-clash/cable-clash.js
+++ b/madia.new/public/secret/1989/cable-clash/cable-clash.js
@@ -1,3 +1,7 @@
+import { mountParticleField } from "../particles.js";
+
+mountParticleField();
+
 const boardElement = document.getElementById("board");
 const statusBar = document.getElementById("status-bar");
 const logList = document.getElementById("log-entries");

--- a/madia.new/public/secret/1989/captains-echo/captains-echo.js
+++ b/madia.new/public/secret/1989/captains-echo/captains-echo.js
@@ -1,3 +1,7 @@
+import { mountParticleField } from "../particles.js";
+
+mountParticleField();
+
 const students = [
   {
     id: "neil",

--- a/madia.new/public/secret/1989/cooler-chaos/cooler-chaos.js
+++ b/madia.new/public/secret/1989/cooler-chaos/cooler-chaos.js
@@ -1,3 +1,7 @@
+import { mountParticleField } from "../particles.js";
+
+mountParticleField();
+
 const GRID_ROWS = 8;
 const GRID_COLS = 8;
 const TICK_MS = 1200;

--- a/madia.new/public/secret/1989/culdesac-curiosity/culdesac-curiosity.js
+++ b/madia.new/public/secret/1989/culdesac-curiosity/culdesac-curiosity.js
@@ -1,3 +1,7 @@
+import { mountParticleField } from "../particles.js";
+
+mountParticleField();
+
 const boardElement = document.getElementById("gossip-grid");
 const statusBar = document.getElementById("status-bar");
 const logList = document.getElementById("log-entries");

--- a/madia.new/public/secret/1989/dream-team-breakout/dream-team-breakout.js
+++ b/madia.new/public/secret/1989/dream-team-breakout/dream-team-breakout.js
@@ -1,3 +1,7 @@
+import { mountParticleField } from "../particles.js";
+
+mountParticleField();
+
 const TURN_COUNT = 6;
 const SANITY_MAX = 3;
 const wildcardDeck = ["S", "E", "S", "E", "S", "E"];

--- a/madia.new/public/secret/1989/gates-of-eastside/gates-of-eastside.js
+++ b/madia.new/public/secret/1989/gates-of-eastside/gates-of-eastside.js
@@ -1,3 +1,7 @@
+import { mountParticleField } from "../particles.js";
+
+mountParticleField();
+
 const ROWS = 5;
 const COLS = 6;
 const CHAOS_LIMIT = 18;

--- a/madia.new/public/secret/1989/halo-hustle/halo-hustle.js
+++ b/madia.new/public/secret/1989/halo-hustle/halo-hustle.js
@@ -1,3 +1,7 @@
+import { mountParticleField } from "../particles.js";
+
+mountParticleField();
+
 const MAX_TIME = 80;
 const STARTING_TIME = 60;
 const CHIP_TIME_VALUE = 4;

--- a/madia.new/public/secret/1989/heatwave-block-party/heatwave-block-party.js
+++ b/madia.new/public/secret/1989/heatwave-block-party/heatwave-block-party.js
@@ -1,3 +1,7 @@
+import { mountParticleField } from "../particles.js";
+
+mountParticleField();
+
 const GRID_SIZE = 5;
 const LEVEL_DURATION_MS = 90_000;
 const TEMPERATURE_MAX = 100;

--- a/madia.new/public/secret/1989/kodiak-covenant/kodiak-covenant.js
+++ b/madia.new/public/secret/1989/kodiak-covenant/kodiak-covenant.js
@@ -1,3 +1,7 @@
+import { mountParticleField } from "../particles.js";
+
+mountParticleField();
+
 const TURN_COUNT = 9;
 const PROTECTION_WINDOW = 2;
 const GRID_WIDTH = 6;

--- a/madia.new/public/secret/1989/particles.js
+++ b/madia.new/public/secret/1989/particles.js
@@ -1,0 +1,236 @@
+const STYLE_ID = "particle-field-style";
+const BODY_REF_ATTR = "data-particle-field";
+
+const DEFAULT_COLOR_VARS = [
+  "--accent",
+  "--accent-strong",
+  "--accent-secondary",
+  "--primary",
+  "--primary-glow",
+  "--highlight",
+  "--glow",
+  "--neon",
+  "--cta",
+];
+
+const DEFAULT_COLORS = ["#38bdf8", "#f97316", "#facc15"];
+
+function ensureStyles(container) {
+  if (!document.getElementById(STYLE_ID)) {
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = `
+      .with-particle-field {
+        position: relative;
+        isolation: isolate;
+      }
+      .with-particle-field .particle-field-canvas {
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+        mix-blend-mode: screen;
+        opacity: 0.85;
+      }
+      .with-particle-field > *:not(.particle-field-canvas) {
+        position: relative;
+        z-index: 1;
+      }
+      .with-particle-field .scanlines {
+        z-index: 2;
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  if (!container.hasAttribute(BODY_REF_ATTR)) {
+    container.setAttribute(BODY_REF_ATTR, "1");
+    container.classList.add("with-particle-field");
+  } else {
+    const current = Number.parseInt(container.getAttribute(BODY_REF_ATTR) ?? "0", 10);
+    container.setAttribute(BODY_REF_ATTR, String(current + 1));
+  }
+}
+
+function cleanupStyles(container) {
+  const current = Number.parseInt(container.getAttribute(BODY_REF_ATTR) ?? "0", 10);
+  if (Number.isNaN(current) || current <= 1) {
+    container.removeAttribute(BODY_REF_ATTR);
+    container.classList.remove("with-particle-field");
+  } else {
+    container.setAttribute(BODY_REF_ATTR, String(current - 1));
+  }
+}
+
+function resolvePalette(colors) {
+  if (Array.isArray(colors) && colors.length > 0) {
+    return colors;
+  }
+
+  const computed = getComputedStyle(document.documentElement);
+  const palette = [];
+  for (const variable of DEFAULT_COLOR_VARS) {
+    const value = computed.getPropertyValue(variable).trim();
+    if (value) {
+      palette.push(value);
+    }
+  }
+
+  if (palette.length === 0) {
+    return DEFAULT_COLORS.slice();
+  }
+
+  return Array.from(new Set(palette));
+}
+
+function createParticle(width, height, palette) {
+  const angle = Math.random() * Math.PI * 2;
+  const baseSpeed = 0.018 + Math.random() * 0.06;
+  return {
+    x: Math.random() * width,
+    y: Math.random() * height,
+    vx: Math.cos(angle) * baseSpeed,
+    vy: Math.sin(angle) * baseSpeed,
+    sway: (Math.random() - 0.5) * 0.002,
+    radius: 0.6 + Math.random() * 2.2,
+    life: 0,
+    ttl: 260 + Math.random() * 360,
+    color: palette[Math.floor(Math.random() * palette.length)],
+    alpha: 0.35 + Math.random() * 0.45,
+  };
+}
+
+function updateParticle(particle, width, height, delta) {
+  particle.life += delta;
+  if (particle.life >= particle.ttl) {
+    return false;
+  }
+
+  particle.x += particle.vx * delta;
+  particle.y += particle.vy * delta;
+
+  particle.vx += (Math.random() - 0.5) * particle.sway * delta;
+  particle.vy += (Math.random() - 0.5) * particle.sway * delta;
+
+  if (particle.x < -20) {
+    particle.x = width + 20;
+  } else if (particle.x > width + 20) {
+    particle.x = -20;
+  }
+
+  if (particle.y < -20) {
+    particle.y = height + 20;
+  } else if (particle.y > height + 20) {
+    particle.y = -20;
+  }
+
+  return true;
+}
+
+function drawParticle(ctx, particle) {
+  const progress = particle.life / particle.ttl;
+  const fade = progress < 0.5 ? progress / 0.5 : (1 - progress) / 0.5;
+  ctx.globalAlpha = Math.max(0, Math.min(1, fade * particle.alpha));
+  ctx.fillStyle = particle.color;
+  ctx.beginPath();
+  ctx.arc(particle.x, particle.y, particle.radius, 0, Math.PI * 2);
+  ctx.fill();
+}
+
+export function mountParticleField(options = {}) {
+  const {
+    container = document.body,
+    colors,
+    density = 0.00012,
+  } = options;
+
+  ensureStyles(container);
+  const palette = resolvePalette(colors);
+
+  const canvas = document.createElement("canvas");
+  canvas.className = "particle-field-canvas";
+  canvas.setAttribute("aria-hidden", "true");
+  container.prepend(canvas);
+
+  const ctx = canvas.getContext("2d", { alpha: true });
+  if (!ctx) {
+    return () => {};
+  }
+
+  let width = window.innerWidth;
+  let height = window.innerHeight;
+  let animationId = null;
+  let lastTimestamp = performance.now();
+  const particles = [];
+
+  function resizeCanvas() {
+    width = window.innerWidth;
+    height = window.innerHeight;
+    const ratio = window.devicePixelRatio || 1;
+    canvas.width = width * ratio;
+    canvas.height = height * ratio;
+    canvas.style.width = "100%";
+    canvas.style.height = "100%";
+    if (typeof ctx.resetTransform === "function") {
+      ctx.resetTransform();
+    } else {
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+    }
+    ctx.scale(ratio, ratio);
+  }
+
+  function step(timestamp) {
+    const delta = Math.min((timestamp - lastTimestamp) / 16.6667, 3.5);
+    lastTimestamp = timestamp;
+
+    const targetCount = Math.round(width * height * density);
+    while (particles.length < targetCount) {
+      particles.push(createParticle(width, height, palette));
+    }
+    if (particles.length > targetCount) {
+      particles.splice(targetCount);
+    }
+
+    ctx.clearRect(0, 0, width, height);
+
+    for (let i = particles.length - 1; i >= 0; i -= 1) {
+      const particle = particles[i];
+      if (!updateParticle(particle, width, height, delta)) {
+        particles[i] = createParticle(width, height, palette);
+        continue;
+      }
+      drawParticle(ctx, particle);
+    }
+
+    animationId = window.requestAnimationFrame(step);
+  }
+
+  function handleVisibilityChange() {
+    if (document.hidden) {
+      if (animationId !== null) {
+        window.cancelAnimationFrame(animationId);
+        animationId = null;
+      }
+    } else if (animationId === null) {
+      lastTimestamp = performance.now();
+      animationId = window.requestAnimationFrame(step);
+    }
+  }
+
+  resizeCanvas();
+  animationId = window.requestAnimationFrame(step);
+
+  window.addEventListener("resize", resizeCanvas);
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+
+  return () => {
+    if (animationId !== null) {
+      window.cancelAnimationFrame(animationId);
+      animationId = null;
+    }
+    window.removeEventListener("resize", resizeCanvas);
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
+    canvas.remove();
+    cleanupStyles(container);
+  };
+}

--- a/madia.new/public/secret/1989/say-anything/say-anything.js
+++ b/madia.new/public/secret/1989/say-anything/say-anything.js
@@ -1,3 +1,7 @@
+import { mountParticleField } from "../particles.js";
+
+mountParticleField();
+
 const STARTING_FLOW = 72;
 const MAX_FLOW = 100;
 const SYNC_WINDOW_MS = 520;

--- a/madia.new/public/secret/1989/second-star-flight/second-star-flight.js
+++ b/madia.new/public/secret/1989/second-star-flight/second-star-flight.js
@@ -1,3 +1,7 @@
+import { mountParticleField } from "../particles.js";
+
+mountParticleField();
+
 const GRID_SIZE = 6;
 const SHADOW_COUNT = 7;
 const LIGHT_DURATION_MS = 8000;

--- a/madia.new/public/secret/1989/speed-zone/speed-zone.js
+++ b/madia.new/public/secret/1989/speed-zone/speed-zone.js
@@ -1,3 +1,7 @@
+import { mountParticleField } from "../particles.js";
+
+mountParticleField();
+
 const svgNS = "http://www.w3.org/2000/svg";
 
 const nodes = [

--- a/madia.new/public/secret/1989/velvet-syncopation/velvet-syncopation.js
+++ b/madia.new/public/secret/1989/velvet-syncopation/velvet-syncopation.js
@@ -1,3 +1,7 @@
+import { mountParticleField } from "../particles.js";
+
+mountParticleField();
+
 const chart = [
   { left: "KeyA", right: "KeyL" },
   { left: "KeyS", right: "KeyK" },

--- a/madia.new/public/secret/1989/vendetta-convoy/vendetta-convoy.js
+++ b/madia.new/public/secret/1989/vendetta-convoy/vendetta-convoy.js
@@ -1,3 +1,7 @@
+import { mountParticleField } from "../particles.js";
+
+mountParticleField();
+
 const BOARD_WIDTH = 8;
 const BOARD_HEIGHT = 14;
 const LANE_COLUMNS = [2, 3, 4, 5];


### PR DESCRIPTION
## Summary
- add a reusable particle field module for the 1989 arcade experience
- activate the effect on the hub and every 1989 cabinet by importing the shared module

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df0db5f76c83289c4875abcfba4061