### PR TITLE
Add shared accessibility affordances across the 1989 arcade

### DIFF
--- a/madia.new/public/secret/1989/amore-express/index.html
+++ b/madia.new/public/secret/1989/amore-express/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Amore Express</title>
+    <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="amore-express.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">
       <p class="eyebrow">Level 48 · 1989 Arcade</p>
@@ -15,7 +17,7 @@
         Stage piping-hot pies from Amore Slices to the cul-de-sac clientele without tangling a single scooter trail.
       </p>
     </header>
-    <main class="page-layout">
+    <main id="main-content" class="page-layout">
       <section class="briefing" aria-labelledby="briefing-title">
         <h2 id="briefing-title">Shift Briefing</h2>
         <p>

--- a/madia.new/public/secret/1989/blaze/index.html
+++ b/madia.new/public/secret/1989/blaze/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Paper Trail Blaze</title>
+    <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="blaze.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">
       <p class="eyebrow">Level 45 · 1989 Arcade</p>
@@ -15,7 +17,7 @@
         Shepherd the governor's bill through the capitol maze while siphoning scandal into cold archives.
       </p>
     </header>
-    <main class="page-layout">
+    <main id="main-content" class="page-layout">
       <section class="briefing" aria-labelledby="briefing-title">
         <h2 id="briefing-title">Legislative Briefing</h2>
         <p>

--- a/madia.new/public/secret/1989/cable-clash/index.html
+++ b/madia.new/public/secret/1989/cable-clash/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>The Cable Clash</title>
+    <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="cable-clash.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">
       <p class="eyebrow">Level 50 · 1989 Arcade</p>
@@ -15,7 +17,7 @@
         Thread live wire across the arena floor and outfox the network bruisers before they trash the main event.
       </p>
     </header>
-    <main class="page-layout">
+    <main id="main-content" class="page-layout">
       <section class="briefing" aria-labelledby="briefing-title">
         <h2 id="briefing-title">Arena Briefing</h2>
         <p>

--- a/madia.new/public/secret/1989/captains-echo/index.html
+++ b/madia.new/public/secret/1989/captains-echo/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Captain's Echo</title>
+    <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="captains-echo.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">
       <p class="eyebrow">Level 39 · 1989 Arcade</p>
@@ -15,7 +17,7 @@
         Orchestrate the four-beat salute so the Headmaster can't snuff the spark before the class rises.
       </p>
     </header>
-    <main class="page-layout">
+    <main id="main-content" class="page-layout">
       <section class="briefing" aria-labelledby="briefing-title">
         <h2 id="briefing-title">Assembly Whisper Network</h2>
         <p>

--- a/madia.new/public/secret/1989/common.css
+++ b/madia.new/public/secret/1989/common.css
@@ -1,0 +1,96 @@
+:root {
+  color-scheme: dark;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  --focus-ring: rgba(56, 189, 248, 0.85);
+  --focus-ring-offset: 3px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: inherit;
+  background-color: #020617;
+  color: #e2e8f0;
+}
+
+a {
+  color: #38bdf8;
+}
+
+a:hover,
+a:focus-visible {
+  color: #7dd3fc;
+}
+
+button,
+[role="button"],
+input,
+select,
+textarea {
+  font: inherit;
+  color: inherit;
+}
+
+button,
+[role="button"],
+input,
+select,
+textarea,
+a {
+  transition: outline-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+:focus-visible {
+  outline: 3px solid var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+}
+
+.skip-link {
+  position: absolute;
+  left: 50%;
+  top: 0.75rem;
+  transform: translate(-50%, -150%);
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.96);
+  color: #f8fafc;
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  box-shadow: 0 18px 38px rgba(2, 6, 23, 0.55);
+  transition: transform 0.2s ease, opacity 0.2s ease;
+  opacity: 0;
+  z-index: 200;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+  transform: translate(-50%, 0);
+  opacity: 1;
+}
+
+.action-button,
+.palette-button,
+.control-button,
+button {
+  cursor: pointer;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/madia.new/public/secret/1989/cooler-chaos/index.html
+++ b/madia.new/public/secret/1989/cooler-chaos/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cooler Chaos</title>
+    <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="cooler-chaos.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">
       <p class="eyebrow">Level 40 · 1989 Arcade</p>
@@ -15,7 +17,7 @@
         Anchor the Cooler and clear the Double Deuce floor. Contain chaos, eject the rowdies, and keep the glass from taking over the dance tiles.
       </p>
     </header>
-    <main class="page-layout">
+    <main id="main-content" class="page-layout">
       <section class="briefing" aria-labelledby="briefing-title">
         <h2 id="briefing-title">Stage Notes</h2>
         <p>

--- a/madia.new/public/secret/1989/culdesac-curiosity/index.html
+++ b/madia.new/public/secret/1989/culdesac-curiosity/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cul-de-sac Curiosity</title>
+    <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="culdesac-curiosity.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">
       <p class="eyebrow">Level 35 · 1989 Arcade</p>
@@ -15,7 +17,7 @@
         Neighborly swaps fuel digging expeditions beneath the Klopek house. Gossip too hard and your paranoia boils over.
       </p>
     </header>
-    <main class="page-layout">
+    <main id="main-content" class="page-layout">
       <section class="briefing" aria-labelledby="briefing-title">
         <h2 id="briefing-title">Neighborhood Briefing</h2>
         <p>

--- a/madia.new/public/secret/1989/dream-team-breakout/index.html
+++ b/madia.new/public/secret/1989/dream-team-breakout/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dream Team Breakout</title>
+    <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="dream-team-breakout.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">
       <p class="eyebrow">Level 49 · 1989 Arcade</p>
@@ -15,7 +17,7 @@
         Shepherd four escape artists with clashing quirks through Midtown without rattling their shared sanity meter.
       </p>
     </header>
-    <main class="page-layout">
+    <main id="main-content" class="page-layout">
       <section class="briefing" aria-labelledby="briefing-title">
         <h2 id="briefing-title">City Desk Briefing</h2>
         <p>

--- a/madia.new/public/secret/1989/gates-of-eastside/index.html
+++ b/madia.new/public/secret/1989/gates-of-eastside/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Gates of Eastside</title>
+    <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="gates-of-eastside.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">
       <p class="eyebrow">Level 37 · 1989 Arcade</p>
@@ -15,7 +17,7 @@
         Joe Clark&rsquo;s bullhorn echoes down Eastside High. Clear the hallways, charge the MBST bar, and haul every study crew to their goals.
       </p>
     </header>
-    <main class="page-layout">
+    <main id="main-content" class="page-layout">
       <section class="briefing" aria-labelledby="briefing-title">
         <h2 id="briefing-title">Hallway Briefing</h2>
         <p>

--- a/madia.new/public/secret/1989/halo-hustle/index.html
+++ b/madia.new/public/secret/1989/halo-hustle/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Halo Hustle</title>
+    <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="halo-hustle.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">
       <p class="eyebrow">Level 43 · 1989 Arcade</p>
@@ -15,7 +17,7 @@
         Smuggle Life Chips back into the Clock of Life before the last grain of sand slips away.
       </p>
     </header>
-    <main class="page-layout">
+    <main id="main-content" class="page-layout">
       <section class="briefing" aria-labelledby="briefing-title">
         <h2 id="briefing-title">Parlor Briefing</h2>
         <p>

--- a/madia.new/public/secret/1989/heatwave-block-party/index.html
+++ b/madia.new/public/secret/1989/heatwave-block-party/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Heatwave Block Party</title>
+    <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="heatwave-block-party.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">
       <p class="eyebrow">Level 42 · 1989 Arcade</p>
@@ -15,7 +17,7 @@
         Ride out the heat wave by venting grievances, routing cooling fans, and timing the final trash can toss.
       </p>
     </header>
-    <main class="page-layout">
+    <main id="main-content" class="page-layout">
       <section class="briefing" aria-labelledby="briefing-title">
         <h2 id="briefing-title">Neighborhood Briefing</h2>
         <p>

--- a/madia.new/public/secret/1989/index.html
+++ b/madia.new/public/secret/1989/index.html
@@ -4,16 +4,18 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>1989 Arcade</title>
+    <link rel="stylesheet" href="common.css" />
     <link rel="stylesheet" href="1989.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to game grid</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="arcade-header">
       <p class="eyebrow">Secret Annex</p>
       <h1>1989 Arcade</h1>
       <p class="tagline">Slot in a cartridge and let the neon hum.</p>
     </header>
-    <main>
+    <main id="main-content">
       <section class="arcade-grid" id="game-grid" aria-label="Game selection"></section>
     </main>
     <template id="game-card-template">

--- a/madia.new/public/secret/1989/kodiak-covenant/index.html
+++ b/madia.new/public/secret/1989/kodiak-covenant/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kodiak Covenant</title>
+    <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="kodiak-covenant.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">
       <p class="eyebrow">Level 38 · 1989 Arcade</p>
@@ -15,7 +17,7 @@
         Thread the guardian and the orphan along the predator-prey paths before the hunter's sweep reaches their den.
       </p>
     </header>
-    <main class="page-layout">
+    <main id="main-content" class="page-layout">
       <section class="briefing" aria-labelledby="briefing-title">
         <h2 id="briefing-title">Field Briefing</h2>
         <p>

--- a/madia.new/public/secret/1989/say-anything/index.html
+++ b/madia.new/public/secret/1989/say-anything/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Say Anything...</title>
+    <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="say-anything.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">
       <p class="eyebrow">Level 44 · 1989 Arcade</p>
@@ -15,7 +17,7 @@
         Bridge Lloyd and Diane's wavelengths by locking emotional frequencies in tandem and keeping the conversation alive.
       </p>
     </header>
-    <main class="page-layout">
+    <main id="main-content" class="page-layout">
       <section class="briefing" aria-labelledby="briefing-title">
         <h2 id="briefing-title">Stage Notes</h2>
         <p>

--- a/madia.new/public/secret/1989/second-star-flight/index.html
+++ b/madia.new/public/secret/1989/second-star-flight/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Second Star Flight (Re-issue)</title>
+    <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="second-star-flight.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">
       <p class="eyebrow">Level 41 · 1989 Arcade</p>
@@ -16,7 +18,7 @@
         darkness swallows Neverland whole.
       </p>
     </header>
-    <main class="page-layout">
+    <main id="main-content" class="page-layout">
       <section class="briefing" aria-labelledby="briefing-title">
         <h2 id="briefing-title">Stage Notes</h2>
         <p>

--- a/madia.new/public/secret/1989/speed-zone/index.html
+++ b/madia.new/public/secret/1989/speed-zone/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Speed Zone</title>
+    <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="speed-zone.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">
       <p class="eyebrow">Level 46 · 1989 Arcade</p>
@@ -15,7 +17,7 @@
         Draft a coast-to-coast cannonball route, surf the High-Speed Dice, and outfox the sirens before they tighten the net.
       </p>
     </header>
-    <main class="page-layout">
+    <main id="main-content" class="page-layout">
       <section class="briefing" aria-labelledby="briefing-title">
         <h2 id="briefing-title">Stage Notes</h2>
         <p>

--- a/madia.new/public/secret/1989/velvet-syncopation/index.html
+++ b/madia.new/public/secret/1989/velvet-syncopation/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Velvet Syncopation</title>
+    <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="velvet-syncopation.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">
       <p class="eyebrow">Level 47 · 1989 Arcade</p>
@@ -15,7 +17,7 @@
         Keep the Baker brothers locked in and thread the singer's velvet slip cues without cracking the harmony.
       </p>
     </header>
-    <main class="page-layout">
+    <main id="main-content" class="page-layout">
       <section class="briefing" aria-labelledby="briefing-title">
         <h2 id="briefing-title">Stage Notes</h2>
         <p>

--- a/madia.new/public/secret/1989/vendetta-convoy/index.html
+++ b/madia.new/public/secret/1989/vendetta-convoy/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vendetta Convoy</title>
+    <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="vendetta-convoy.css" />
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">
       <p class="eyebrow">Level 36 · 1989 Arcade</p>
@@ -15,7 +17,7 @@
         Clear the cartel causeway one sabotage at a time, guiding the tanker convoy toward the cliffside rendezvous before the explosives reshuffle your odds.
       </p>
     </header>
-    <main class="page-layout">
+    <main id="main-content" class="page-layout">
       <section class="briefing" aria-labelledby="briefing-title">
         <h2 id="briefing-title">Stage Notes</h2>
         <p>


### PR DESCRIPTION
## Summary
- add a shared `common.css` for the 1989 arcade with global focus, skip link, and reduced motion styling
- update the arcade hub and every cabinet page to load the shared styles and expose skip links to the main game content
- anchor each game layout with a consistent `main-content` target so keyboard users can bypass the chrome quickly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df0dc699a08328bf6b5b94ea93b9a6