### PR TITLE
feat: add particle overlays to 1989 games

### DIFF
--- a/madia.new/public/secret/1989/amore-express/amore-express.js
+++ b/madia.new/public/secret/1989/amore-express/amore-express.js
@@ -1,3 +1,10 @@
+import { initParticleSystem } from "../particle-effects.js";
+
+const particleSystem = initParticleSystem({
+  palette: ["#f97316", "#38bdf8", "#facc15", "#fb7185"],
+  ambientDensity: 0.6,
+});
+
 const boardSize = 6;
 const shop = { row: 2, col: 0, label: "Hub", name: "Amore Slices dispatch" };
 const houses = [
@@ -403,6 +410,7 @@ function finalizeRoute() {
   deliveredCount += 1;
   updateDeliveredCount();
   logEvent(`Delivered ${order.pizza} to ${housesById.get(order.houseId)?.name ?? "a client"}.`);
+  particleSystem.emitBurst(1.2);
   updateStatus("Delivery locked in. Queue up the next order.");
 
   activeOrders = activeOrders.filter((item) => item.id !== order.id);
@@ -448,6 +456,7 @@ function endShift(success, message) {
     logEvent(message);
   } else {
     logEvent("Shift cleared with every order delivered.");
+    particleSystem.emitBurst(1.6);
   }
 }
 

--- a/madia.new/public/secret/1989/blaze/blaze.js
+++ b/madia.new/public/secret/1989/blaze/blaze.js
@@ -1,3 +1,10 @@
+import { initParticleSystem } from "../particle-effects.js";
+
+const particleSystem = initParticleSystem({
+  palette: ["#f97316", "#facc15", "#38bdf8", "#fda4af"],
+  ambientDensity: 0.55,
+});
+
 const boardElement = document.getElementById("board");
 const statusBar = document.getElementById("status-bar");
 const capitalMeter = document.getElementById("capital-meter");
@@ -441,14 +448,15 @@ function advanceFlow() {
   } else {
     const nextStep = route[currentIndex + 1];
     billPosition = { ...nextStep };
-    if (billPosition.row === GOAL.row && billPosition.col === GOAL.col) {
-      signedBills += 1;
-      politicalCapital += BILL_REWARD;
-      logEvent(`Bill signed cleanly. Political Capital +${BILL_REWARD} (now ${politicalCapital}).`);
-      updateCapitalMeter();
-      if (gameOver) {
-        return;
-      }
+      if (billPosition.row === GOAL.row && billPosition.col === GOAL.col) {
+        signedBills += 1;
+        politicalCapital += BILL_REWARD;
+        logEvent(`Bill signed cleanly. Political Capital +${BILL_REWARD} (now ${politicalCapital}).`);
+        particleSystem.emitSparkle(1.1);
+        updateCapitalMeter();
+        if (gameOver) {
+          return;
+        }
       if (signedBills >= BILLS_REQUIRED) {
         renderBillToken();
         triggerWin();
@@ -598,6 +606,7 @@ function triggerWin() {
   gameOver = true;
   setStatus("Two clean bills signed. The chamber erupts in relief.");
   logEvent("Victory! The paper trail held under pressure.");
+  particleSystem.emitBurst(1.5);
 }
 
 function setActiveMode(mode) {

--- a/madia.new/public/secret/1989/cable-clash/cable-clash.js
+++ b/madia.new/public/secret/1989/cable-clash/cable-clash.js
@@ -1,3 +1,10 @@
+import { initParticleSystem } from "../particle-effects.js";
+
+const particleSystem = initParticleSystem({
+  palette: ["#38bdf8", "#f472b6", "#facc15", "#f97316"],
+  ambientDensity: 0.55,
+});
+
 const boardElement = document.getElementById("board");
 const statusBar = document.getElementById("status-bar");
 const logList = document.getElementById("log-entries");
@@ -445,10 +452,12 @@ function onCircuitClosed() {
   circuitClosed = true;
   setStatus("Circuit complete! The main-event slam erupts and stuns nearby rivals.");
   logEvent("The main-event slam fires—broadcast restored!");
+  particleSystem.emitBurst(1.4);
   rivals.forEach((rival) => {
     if (isAdjacent(rival.position, GOAL)) {
       rival.stunned = true;
       logEvent(`${rival.name} is stunned by the surge!`);
+      particleSystem.emitSparkle(0.9);
     }
   });
   cableNetwork.forEach((segment, tileKey) => {

--- a/madia.new/public/secret/1989/captains-echo/captains-echo.js
+++ b/madia.new/public/secret/1989/captains-echo/captains-echo.js
@@ -1,3 +1,10 @@
+import { initParticleSystem } from "../particle-effects.js";
+
+const particleSystem = initParticleSystem({
+  palette: ["#38bdf8", "#f472b6", "#facc15", "#fb7185"],
+  ambientDensity: 0.5,
+});
+
 const students = [
   {
     id: "neil",
@@ -379,6 +386,7 @@ function evaluatePlan() {
     targetCallout.textContent = `Success! Score ${score}—the hall erupts in applause.`;
     targetCallout.classList.add("success");
     logEvent(`Score ${score}. The salute holds.`);
+    particleSystem.emitBurst(1.3);
   } else {
     const delta = TARGET_SCORE - score;
     targetCallout.textContent = `Score ${score}. Need ${delta} more to lock the salute.`;

--- a/madia.new/public/secret/1989/cooler-chaos/cooler-chaos.js
+++ b/madia.new/public/secret/1989/cooler-chaos/cooler-chaos.js
@@ -1,3 +1,10 @@
+import { initParticleSystem } from "../particle-effects.js";
+
+const particleSystem = initParticleSystem({
+  palette: ["#38bdf8", "#f97316", "#facc15", "#fda4af"],
+  ambientDensity: 0.6,
+});
+
 const GRID_ROWS = 8;
 const GRID_COLS = 8;
 const TICK_MS = 1200;
@@ -307,6 +314,7 @@ function handleEjection(exitCell) {
   }
   state.lastEjectTime = now;
   addLog(`Troublemaker launched through ${formatTile(exitCell.row, exitCell.col)}.`);
+  particleSystem.emitSparkle(0.9 + state.comboCount * 0.1);
   if (state.comboCount >= 3) {
     triggerBeNice(exitCell);
     state.comboCount = 0;
@@ -344,6 +352,7 @@ function triggerBeNice(anchorCell) {
       anchorElement.removeAttribute("data-highlight");
     }, 600);
   }
+  particleSystem.emitBurst(1.4);
 
   if (cleared > 0) {
     addLog(`Be Nice bonus clears ${cleared} shard${cleared === 1 ? "" : "s"} near ${formatTile(anchorCell.row, anchorCell.col)}.`);

--- a/madia.new/public/secret/1989/culdesac-curiosity/culdesac-curiosity.js
+++ b/madia.new/public/secret/1989/culdesac-curiosity/culdesac-curiosity.js
@@ -1,3 +1,10 @@
+import { initParticleSystem } from "../particle-effects.js";
+
+const particleSystem = initParticleSystem({
+  palette: ["#38bdf8", "#c084fc", "#facc15", "#f97316"],
+  ambientDensity: 0.55,
+});
+
 const boardElement = document.getElementById("gossip-grid");
 const statusBar = document.getElementById("status-bar");
 const logList = document.getElementById("log-entries");
@@ -376,6 +383,7 @@ function checkVictory() {
     paranoiaTimer = null;
     setStatus("Mystery solved. Deliver the evidence before the Klopeks notice.");
     logEvent("Curiosity meter filled—victory!");
+    particleSystem.emitBurst(1.6);
   }
 }
 
@@ -399,6 +407,7 @@ function resolveMatchesLoop(initialMatches) {
       totalCleared += clearedPositions.length;
       setStatus(`Rumor cascade x${chain}! ${clearedPositions.length} neighbors convinced.`);
       logEvent(`Cleared ${clearedPositions.length} tiles in chain ${chain}.`);
+      particleSystem.emitSparkle(0.8 + chain * 0.25);
       collapseBoard();
       renderBoard();
       setTimeout(() => {

--- a/madia.new/public/secret/1989/dream-team-breakout/dream-team-breakout.js
+++ b/madia.new/public/secret/1989/dream-team-breakout/dream-team-breakout.js
@@ -1,3 +1,10 @@
+import { initParticleSystem } from "../particle-effects.js";
+
+const particleSystem = initParticleSystem({
+  palette: ["#38bdf8", "#34d399", "#facc15", "#f97316"],
+  ambientDensity: 0.5,
+});
+
 const TURN_COUNT = 6;
 const SANITY_MAX = 3;
 const wildcardDeck = ["S", "E", "S", "E", "S", "E"];
@@ -354,6 +361,9 @@ function pushEvent(message, type = "info") {
   }
   if (type === "success") {
     item.style.color = "#34d399";
+    particleSystem.emitBurst(1.2);
+  } else if (type === "info") {
+    particleSystem.emitSparkle(0.4);
   }
   eventList.appendChild(item);
 }

--- a/madia.new/public/secret/1989/gates-of-eastside/gates-of-eastside.js
+++ b/madia.new/public/secret/1989/gates-of-eastside/gates-of-eastside.js
@@ -1,3 +1,10 @@
+import { initParticleSystem } from "../particle-effects.js";
+
+const particleSystem = initParticleSystem({
+  palette: ["#38bdf8", "#facc15", "#fb7185", "#34d399"],
+  ambientDensity: 0.55,
+});
+
 const ROWS = 5;
 const COLS = 6;
 const CHAOS_LIMIT = 18;
@@ -401,10 +408,13 @@ function updateStatus(message, tone = "neutral") {
   statusBanner.classList.remove("is-success", "is-warning", "is-danger");
   if (tone === "success") {
     statusBanner.classList.add("is-success");
+    particleSystem.emitBurst(1.2);
   } else if (tone === "warning") {
     statusBanner.classList.add("is-warning");
+    particleSystem.emitSparkle(0.7);
   } else if (tone === "danger") {
     statusBanner.classList.add("is-danger");
+    particleSystem.emitSparkle(0.9);
   }
 }
 

--- a/madia.new/public/secret/1989/halo-hustle/halo-hustle.js
+++ b/madia.new/public/secret/1989/halo-hustle/halo-hustle.js
@@ -1,3 +1,10 @@
+import { initParticleSystem } from "../particle-effects.js";
+
+const particleSystem = initParticleSystem({
+  palette: ["#38bdf8", "#facc15", "#a855f7", "#34d399"],
+  ambientDensity: 0.55,
+});
+
 const MAX_TIME = 80;
 const STARTING_TIME = 60;
 const CHIP_TIME_VALUE = 4;
@@ -131,10 +138,13 @@ function updateStatus(message, tone = "neutral") {
   statusBanner.classList.remove("is-success", "is-warning", "is-danger");
   if (tone === "success") {
     statusBanner.classList.add("is-success");
+    particleSystem.emitBurst(1.1);
   } else if (tone === "warning") {
     statusBanner.classList.add("is-warning");
+    particleSystem.emitSparkle(0.7);
   } else if (tone === "danger") {
     statusBanner.classList.add("is-danger");
+    particleSystem.emitSparkle(0.95);
   }
 }
 

--- a/madia.new/public/secret/1989/heatwave-block-party/heatwave-block-party.js
+++ b/madia.new/public/secret/1989/heatwave-block-party/heatwave-block-party.js
@@ -1,3 +1,10 @@
+import { initParticleSystem } from "../particle-effects.js";
+
+const particleSystem = initParticleSystem({
+  palette: ["#f97316", "#38bdf8", "#facc15", "#fb7185"],
+  ambientDensity: 0.6,
+});
+
 const GRID_SIZE = 5;
 const LEVEL_DURATION_MS = 90_000;
 const TEMPERATURE_MAX = 100;
@@ -447,6 +454,13 @@ function logEvent(message, variant = "info") {
   entry.className = `log-entry ${variant}`;
   entry.textContent = message;
   logEntries.prepend(entry);
+  if (variant === "success") {
+    particleSystem.emitBurst(1.3);
+  } else if (variant === "warning") {
+    particleSystem.emitSparkle(0.8);
+  } else if (variant === "danger") {
+    particleSystem.emitSparkle(1.0);
+  }
   while (logEntries.children.length > 12) {
     logEntries.removeChild(logEntries.lastElementChild);
   }

--- a/madia.new/public/secret/1989/kodiak-covenant/kodiak-covenant.js
+++ b/madia.new/public/secret/1989/kodiak-covenant/kodiak-covenant.js
@@ -1,3 +1,10 @@
+import { initParticleSystem } from "../particle-effects.js";
+
+const particleSystem = initParticleSystem({
+  palette: ["#38bdf8", "#facc15", "#fb7185", "#34d399"],
+  ambientDensity: 0.5,
+});
+
 const TURN_COUNT = 9;
 const PROTECTION_WINDOW = 2;
 const GRID_WIDTH = 6;
@@ -264,7 +271,7 @@ function renderState() {
 
 function renderEvents(events) {
   eventList.innerHTML = "";
-  events.forEach((event) => {
+  events.forEach((event, index) => {
     const item = document.createElement("li");
     item.className = "event-entry";
     item.textContent = event.text;
@@ -272,6 +279,15 @@ function renderEvents(events) {
       item.dataset.tone = event.tone;
     }
     eventList.appendChild(item);
+    if (index === events.length - 1) {
+      if (event.tone === "success") {
+        particleSystem.emitBurst(1.4);
+      } else if (event.tone === "danger") {
+        particleSystem.emitSparkle(0.9);
+      } else if (event.tone) {
+        particleSystem.emitSparkle(0.6);
+      }
+    }
   });
 }
 

--- a/madia.new/public/secret/1989/particle-effects.js
+++ b/madia.new/public/secret/1989/particle-effects.js
@@ -1,0 +1,227 @@
+const DEFAULT_PALETTE = ["#38bdf8", "#f472b6", "#facc15", "#f97316", "#a855f7"];
+const STYLE_ID = "particle-effects-style";
+
+function ensureStyles() {
+  if (document.getElementById(STYLE_ID)) {
+    return;
+  }
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+    .particle-layer {
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      overflow: hidden;
+      z-index: 24;
+    }
+
+    .particle-layer .particle {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: var(--particle-size, 8px);
+      height: var(--particle-size, 8px);
+      background: var(--particle-color, rgba(248, 250, 252, 0.9));
+      border-radius: 999px;
+      opacity: 0;
+      transform: translate(-50%, -50%) scale(0.6);
+      filter: drop-shadow(0 0 6px rgba(148, 163, 184, 0.45));
+      animation: particle-float var(--particle-duration, 3200ms) ease-out forwards;
+    }
+
+    .particle-layer .particle.is-shard {
+      border-radius: 3px;
+      transform: translate(-50%, -50%) rotate(var(--particle-rotation, 0deg)) scale(0.7);
+      animation: particle-shard var(--particle-duration, 2800ms) ease-out forwards;
+    }
+
+    @keyframes particle-float {
+      0% {
+        opacity: 0;
+        transform: translate(-50%, -50%) scale(var(--particle-scale-start, 0.6));
+      }
+      12% {
+        opacity: var(--particle-opacity, 0.9);
+      }
+      70% {
+        opacity: calc(var(--particle-opacity, 0.9) * 0.7);
+      }
+      100% {
+        opacity: 0;
+        transform: translate(
+          calc(-50% + var(--particle-drift-x, 0px)),
+          calc(-50% - var(--particle-lift, 140px))
+        )
+        scale(var(--particle-scale-end, 0.35));
+      }
+    }
+
+    @keyframes particle-shard {
+      0% {
+        opacity: 0;
+        transform: translate(-50%, -50%) rotate(var(--particle-rotation, 0deg)) scale(0.7);
+      }
+      18% {
+        opacity: var(--particle-opacity, 0.85);
+      }
+      60% {
+        opacity: calc(var(--particle-opacity, 0.85) * 0.75);
+      }
+      100% {
+        opacity: 0;
+        transform: translate(
+          calc(-50% + var(--particle-drift-x, 0px)),
+          calc(-50% - var(--particle-lift, 160px))
+        )
+        rotate(calc(var(--particle-rotation, 0deg) + var(--particle-spin, 180deg)))
+        scale(var(--particle-scale-end, 0.45));
+      }
+    }
+  `;
+  document.head.append(style);
+}
+
+function randomBetween(min, max) {
+  return Math.random() * (max - min) + min;
+}
+
+function randomChoice(list) {
+  return list[Math.floor(Math.random() * list.length)];
+}
+
+function createParticle(layer, palette, overrides = {}) {
+  const particle = document.createElement("span");
+  particle.classList.add("particle");
+
+  const isShard = Math.random() < (overrides.shardChance ?? 0.35);
+  if (isShard) {
+    particle.classList.add("is-shard");
+  }
+
+  const color = overrides.color ?? randomChoice(palette);
+  const size = overrides.size ?? randomBetween(4, 10);
+  const duration = overrides.duration ?? randomBetween(2400, 4200);
+  const opacity = overrides.opacity ?? randomBetween(0.55, 0.95);
+  const lift = overrides.lift ?? randomBetween(120, 220);
+  const driftX = overrides.driftX ?? randomBetween(-60, 60);
+  const scaleEnd = overrides.scaleEnd ?? randomBetween(0.25, 0.45);
+  const rotation = overrides.rotation ?? randomBetween(-40, 40);
+  const spin = overrides.spin ?? randomBetween(120, 320);
+  const x = overrides.x ?? Math.random();
+  const y = overrides.y ?? randomBetween(0.2, 0.9);
+
+  particle.style.setProperty("--particle-color", color);
+  particle.style.setProperty("--particle-size", `${size}px`);
+  particle.style.setProperty("--particle-duration", `${duration}ms`);
+  particle.style.setProperty("--particle-opacity", String(opacity));
+  particle.style.setProperty("--particle-lift", `${lift}px`);
+  particle.style.setProperty("--particle-drift-x", `${driftX}px`);
+  particle.style.setProperty("--particle-scale-end", String(scaleEnd));
+  particle.style.setProperty("--particle-rotation", `${rotation}deg`);
+  particle.style.setProperty("--particle-spin", `${spin}deg`);
+
+  const scaleStart = overrides.scaleStart ?? randomBetween(0.55, 0.85);
+  particle.style.setProperty("--particle-scale-start", String(scaleStart));
+
+  particle.style.left = `${x * 100}%`;
+  particle.style.top = `${y * 100}%`;
+
+  layer.append(particle);
+
+  window.setTimeout(() => {
+    particle.remove();
+  }, duration + 60);
+}
+
+export function initParticleSystem(options = {}) {
+  const {
+    container = document.body,
+    palette = DEFAULT_PALETTE,
+    ambientDensity = 0.5,
+    zIndex = 24,
+  } = options;
+
+  ensureStyles();
+
+  const layer = document.createElement("div");
+  layer.classList.add("particle-layer");
+  layer.style.zIndex = String(zIndex);
+  layer.setAttribute("aria-hidden", "true");
+  container.append(layer);
+
+  let disposed = false;
+  let ambientTimer = null;
+
+  const normalizedDensity = Math.max(0, Math.min(1, ambientDensity));
+
+  function scheduleAmbient() {
+    if (disposed || normalizedDensity === 0) {
+      return;
+    }
+    const minDelay = 450 - normalizedDensity * 180;
+    const maxDelay = 1200 - normalizedDensity * 280;
+    const delay = randomBetween(Math.max(160, minDelay), Math.max(400, maxDelay));
+    ambientTimer = window.setTimeout(() => {
+      if (disposed) {
+        return;
+      }
+      const count = Math.round(randomBetween(1, 2 + normalizedDensity * 2));
+      for (let index = 0; index < count; index += 1) {
+        createParticle(layer, palette);
+      }
+      scheduleAmbient();
+    }, delay);
+  }
+
+  scheduleAmbient();
+
+  function emitBurst(strength = 1) {
+    if (disposed) {
+      return;
+    }
+    const burstStrength = Math.max(0.2, strength);
+    const count = Math.round(randomBetween(10, 16) * burstStrength);
+    for (let index = 0; index < count; index += 1) {
+      createParticle(layer, palette, {
+        y: randomBetween(0.4, 0.85),
+        lift: randomBetween(160, 280),
+        driftX: randomBetween(-80, 80),
+        size: randomBetween(5, 12),
+        duration: randomBetween(2600, 4600),
+        opacity: randomBetween(0.65, 0.95),
+        shardChance: 0.45,
+      });
+    }
+  }
+
+  function emitSparkle(strength = 1) {
+    if (disposed) {
+      return;
+    }
+    const sparkleStrength = Math.max(0.2, strength);
+    const count = Math.round(randomBetween(4, 8) * sparkleStrength);
+    for (let index = 0; index < count; index += 1) {
+      createParticle(layer, palette, {
+        y: randomBetween(0.15, 0.65),
+        lift: randomBetween(120, 180),
+        driftX: randomBetween(-40, 40),
+        size: randomBetween(4, 8),
+        duration: randomBetween(2200, 3600),
+        shardChance: 0.25,
+      });
+    }
+  }
+
+  function destroy() {
+    disposed = true;
+    if (ambientTimer) {
+      window.clearTimeout(ambientTimer);
+      ambientTimer = null;
+    }
+    layer.remove();
+  }
+
+  return { emitBurst, emitSparkle, destroy };
+}
+

--- a/madia.new/public/secret/1989/say-anything/say-anything.js
+++ b/madia.new/public/secret/1989/say-anything/say-anything.js
@@ -1,3 +1,10 @@
+import { initParticleSystem } from "../particle-effects.js";
+
+const particleSystem = initParticleSystem({
+  palette: ["#38bdf8", "#f472b6", "#facc15", "#fb7185"],
+  ambientDensity: 0.6,
+});
+
 const STARTING_FLOW = 72;
 const MAX_FLOW = 100;
 const SYNC_WINDOW_MS = 520;
@@ -588,10 +595,13 @@ function logEvent(message, variant = "info") {
   item.className = "log-entry";
   if (variant === "success") {
     item.classList.add("success");
+    particleSystem.emitBurst(1.2);
   } else if (variant === "warning") {
     item.classList.add("warning");
+    particleSystem.emitSparkle(0.7);
   } else if (variant === "danger") {
     item.classList.add("danger");
+    particleSystem.emitSparkle(1.0);
   }
   item.textContent = message;
   eventLog.prepend(item);

--- a/madia.new/public/secret/1989/second-star-flight/second-star-flight.js
+++ b/madia.new/public/secret/1989/second-star-flight/second-star-flight.js
@@ -1,3 +1,10 @@
+import { initParticleSystem } from "../particle-effects.js";
+
+const particleSystem = initParticleSystem({
+  palette: ["#38bdf8", "#facc15", "#f472b6", "#a855f7"],
+  ambientDensity: 0.55,
+});
+
 const GRID_SIZE = 6;
 const SHADOW_COUNT = 7;
 const LIGHT_DURATION_MS = 8000;
@@ -438,6 +445,13 @@ function logEvent(message, variant = "info") {
     entry.classList.add(variant);
   }
   eventLog.prepend(entry);
+  if (variant === "success") {
+    particleSystem.emitBurst(1.3);
+  } else if (variant === "warning") {
+    particleSystem.emitSparkle(0.8);
+  } else if (variant === "danger") {
+    particleSystem.emitSparkle(1.0);
+  }
   while (eventLog.children.length > 12) {
     eventLog.removeChild(eventLog.lastElementChild);
   }

--- a/madia.new/public/secret/1989/speed-zone/speed-zone.js
+++ b/madia.new/public/secret/1989/speed-zone/speed-zone.js
@@ -1,3 +1,10 @@
+import { initParticleSystem } from "../particle-effects.js";
+
+const particleSystem = initParticleSystem({
+  palette: ["#38bdf8", "#facc15", "#fb7185", "#34d399"],
+  ambientDensity: 0.55,
+});
+
 const svgNS = "http://www.w3.org/2000/svg";
 
 const nodes = [
@@ -421,18 +428,21 @@ function resolveRoute() {
   if (hazardTriggered) {
     const penalty = face.penalty || 6;
     const ended = adjustHeat(penalty);
+    particleSystem.emitSparkle(0.9);
     logEvent(`⚠️ ${face.hazardLabel} clamps down at ${finalName}. Heat +${penalty}.`);
     if (ended) {
       return;
     }
   } else {
     adjustHeat(-1);
+    particleSystem.emitBurst(1.0);
     logEvent(`✅ Clean run into ${finalName}. Heat -1.`);
   }
 
   const finalNodeData = nodesById.get(finalNode);
   if (finalNodeData?.type === "rest") {
     adjustHeat(-5);
+    particleSystem.emitBurst(1.1);
     logEvent(`🛠️ Crew cools off at ${finalNodeData.name}. Heat -5.`);
   }
 
@@ -441,12 +451,14 @@ function resolveRoute() {
     const clearedName = nodesById.get(clearedId).name;
     checkpointIndex += 1;
     adjustHeat(-4);
+    particleSystem.emitBurst(1.3);
     logEvent(`🏁 Cleared ${clearedName}. Heat -4.`);
   }
 
   updateCheckpointReadout();
 
   if (checkpointIndex >= checkpoints.length) {
+    particleSystem.emitBurst(1.6);
     logEvent("🎉 All checkpoints cleared. Neon Pier throws a midnight fireworks show!");
     endRun(true);
     return;
@@ -463,6 +475,7 @@ function endRun(success) {
     diceReadout.textContent = "Run complete. The crew celebrates at Neon Pier.";
   } else {
     diceReadout.textContent = "Heat maxed out. Federal sting ends the run.";
+    particleSystem.emitSparkle(1.0);
     logEvent("🚨 The Heat maxed out. Cross-country sting shuts down the convoy.");
   }
 }
@@ -477,6 +490,7 @@ function triggerBypass() {
   if (checkpointIndex < checkpoints.length) {
     const skipped = nodesById.get(checkpoints[checkpointIndex]).name;
     checkpointIndex += 1;
+    particleSystem.emitBurst(1.25);
     logEvent(`🪄 Bypass actuation burns ${skipped}. Next checkpoint auto-cleared.`);
     updateCheckpointReadout();
   }
@@ -484,6 +498,7 @@ function triggerBypass() {
     clearPlanning();
     highlightHazards(null);
     currentRoll = null;
+    particleSystem.emitBurst(1.5);
     logEvent("🎉 Bypass rockets the crew straight into Neon Pier. Run complete.");
     endRun(true);
     return;

--- a/madia.new/public/secret/1989/velvet-syncopation/velvet-syncopation.js
+++ b/madia.new/public/secret/1989/velvet-syncopation/velvet-syncopation.js
@@ -1,3 +1,10 @@
+import { initParticleSystem } from "../particle-effects.js";
+
+const particleSystem = initParticleSystem({
+  palette: ["#38bdf8", "#f472b6", "#facc15", "#a855f7"],
+  ambientDensity: 0.6,
+});
+
 const chart = [
   { left: "KeyA", right: "KeyL" },
   { left: "KeyS", right: "KeyK" },
@@ -507,8 +514,10 @@ function logEvent(message, type = "neutral") {
   item.textContent = message;
   if (type === "positive") {
     item.classList.add("is-positive");
+    particleSystem.emitBurst(1.2);
   } else if (type === "warning") {
     item.classList.add("is-warning");
+    particleSystem.emitSparkle(0.8);
   }
   eventList.prepend(item);
   while (eventList.children.length > 8) {

--- a/madia.new/public/secret/1989/vendetta-convoy/vendetta-convoy.js
+++ b/madia.new/public/secret/1989/vendetta-convoy/vendetta-convoy.js
@@ -1,3 +1,10 @@
+import { initParticleSystem } from "../particle-effects.js";
+
+const particleSystem = initParticleSystem({
+  palette: ["#38bdf8", "#facc15", "#fb7185", "#34d399"],
+  ambientDensity: 0.55,
+});
+
 const BOARD_WIDTH = 8;
 const BOARD_HEIGHT = 14;
 const LANE_COLUMNS = [2, 3, 4, 5];
@@ -694,6 +701,13 @@ function logEvent(message, tone = "info") {
   state.logs.unshift({ message, tone });
   if (state.logs.length > MAX_LOG_ENTRIES) {
     state.logs.length = MAX_LOG_ENTRIES;
+  }
+  if (tone === "success") {
+    particleSystem.emitBurst(1.4);
+  } else if (tone === "danger") {
+    particleSystem.emitSparkle(1.0);
+  } else if (tone === "warning") {
+    particleSystem.emitSparkle(0.8);
   }
   renderLog();
 }


### PR DESCRIPTION
## Summary
- add a shared particle-effects module for the 1989 arcade that renders ambient sparkles and burst animations
- hook each 1989 game into the new system so victories, status updates, and combos trigger celebratory particles

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68df0fd03eb4832893cd993f5ccfa3fa