### PR TITLE
feat: add shared high scores across 1989 arcade

### DIFF
--- a/madia.new/public/secret/1989/1989.css
+++ b/madia.new/public/secret/1989/1989.css
@@ -156,6 +156,23 @@ main {
   line-height: 1.4;
 }
 
+.game-score {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.85);
+  transition: color 180ms ease, transform 180ms ease;
+}
+
+.game-score[data-empty="true"] {
+  color: rgba(148, 163, 184, 0.75);
+  font-style: italic;
+}
+
+.game-score.is-score-updated {
+  color: #facc15;
+  transform: translateY(-1px);
+}
+
 .card-actions {
   display: flex;
   align-items: center;

--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -1,3 +1,6 @@
+import { getHighScore, onHighScoreChange } from "./arcade-scores.js";
+import { getScoreConfig } from "./score-config.js";
+
 /**
  * Register launchable cabinets here. You can also import { registerGame }
  * elsewhere and call it at runtime for dynamic catalogs.
@@ -741,6 +744,37 @@ const fullscreenButton = document.getElementById("fullscreen-toggle");
 
 const gameLookup = new Map(games.map((game) => [game.id, game]));
 let lastFocusElement = null;
+const scoreSlots = new Map();
+const scorePulseTimers = new Map();
+
+function renderScore(gameId, entry = getHighScore(gameId)) {
+  const slot = scoreSlots.get(gameId);
+  if (!slot) {
+    return;
+  }
+  const { element, config } = slot;
+  if (entry) {
+    element.textContent = config.format(entry);
+    element.dataset.empty = "false";
+  } else {
+    element.textContent = config.empty;
+    element.dataset.empty = "true";
+  }
+}
+
+function pulseScore(gameId) {
+  const slot = scoreSlots.get(gameId);
+  if (!slot) {
+    return;
+  }
+  const { element } = slot;
+  window.clearTimeout(scorePulseTimers.get(gameId));
+  element.classList.add("is-score-updated");
+  const timer = window.setTimeout(() => {
+    element.classList.remove("is-score-updated");
+  }, 900);
+  scorePulseTimers.set(gameId, timer);
+}
 
 function isOverlayFullscreen() {
   return document.fullscreenElement === overlayFrame;
@@ -786,6 +820,12 @@ function renderGames() {
     thumb.innerHTML = game.thumbnail;
     card.querySelector(".game-title").textContent = game.name;
     card.querySelector(".game-meta").textContent = game.description;
+    const scoreElement = card.querySelector("[data-high-score]");
+    if (scoreElement) {
+      const config = getScoreConfig(game.id);
+      scoreSlots.set(game.id, { element: scoreElement, config });
+      renderScore(game.id);
+    }
     card.querySelector(".play-button").dataset.gameId = game.id;
     fragment.appendChild(card);
   });
@@ -823,6 +863,14 @@ function closeGame() {
 }
 
 renderGames();
+
+onHighScoreChange(({ gameId, entry }) => {
+  if (!gameId) {
+    return;
+  }
+  renderScore(gameId, entry);
+  pulseScore(gameId);
+});
 
 grid.addEventListener("click", (event) => {
   const button = event.target.closest(".play-button");

--- a/madia.new/public/secret/1989/amore-express/amore-express.js
+++ b/madia.new/public/secret/1989/amore-express/amore-express.js
@@ -1,3 +1,14 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+
+const scoreConfig = getScoreConfig("amore-express");
+const highScore = initHighScoreBanner({
+  gameId: "amore-express",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
 const boardSize = 6;
 const shop = { row: 2, col: 0, label: "Hub", name: "Amore Slices dispatch" };
 const houses = [
@@ -401,6 +412,7 @@ function finalizeRoute() {
   });
 
   deliveredCount += 1;
+  highScore.submit(deliveredCount);
   updateDeliveredCount();
   logEvent(`Delivered ${order.pizza} to ${housesById.get(order.houseId)?.name ?? "a client"}.`);
   updateStatus("Delivery locked in. Queue up the next order.");

--- a/madia.new/public/secret/1989/arcade-scores.js
+++ b/madia.new/public/secret/1989/arcade-scores.js
@@ -1,0 +1,316 @@
+const STORAGE_KEY = "1989-shared-high-scores";
+const CELEBRATE_TIMEOUT = 1200;
+const widgetState = {
+  element: null,
+  label: null,
+  value: null,
+  note: null,
+  celebrateTimer: null,
+};
+
+const eventTarget = new EventTarget();
+let memoryStore = {};
+let storageAvailable = true;
+
+try {
+  const testKey = `${STORAGE_KEY}-check`;
+  window.localStorage.setItem(testKey, "ok");
+  window.localStorage.removeItem(testKey);
+} catch (error) {
+  storageAvailable = false;
+}
+
+function readStore() {
+  if (storageAvailable) {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return {};
+      }
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") {
+        return parsed;
+      }
+    } catch (error) {
+      console.warn("Failed to parse shared high scores", error);
+    }
+    return {};
+  }
+  return { ...memoryStore };
+}
+
+function writeStore(store) {
+  const payload = JSON.stringify(store);
+  if (storageAvailable) {
+    window.localStorage.setItem(STORAGE_KEY, payload);
+  } else {
+    memoryStore = { ...store };
+  }
+}
+
+function sanitizeEntry(entry) {
+  if (!entry || typeof entry !== "object") {
+    return null;
+  }
+  const value = Number(entry.value);
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+  const meta = sanitizeMeta(entry.meta);
+  return {
+    value,
+    meta,
+    updatedAt: typeof entry.updatedAt === "string" ? entry.updatedAt : new Date().toISOString(),
+  };
+}
+
+function sanitizeMeta(meta) {
+  if (!meta || typeof meta !== "object") {
+    return {};
+  }
+  const clean = {};
+  Object.entries(meta).forEach(([key, value]) => {
+    if (value === null) {
+      clean[key] = null;
+    } else if (typeof value === "number" || typeof value === "string" || typeof value === "boolean") {
+      clean[key] = value;
+    } else if (typeof value === "object") {
+      clean[key] = sanitizeMeta(value);
+    }
+  });
+  return clean;
+}
+
+function notifyChange(gameId, entry) {
+  const detail = { gameId, entry: sanitizeEntry(entry) };
+  eventTarget.dispatchEvent(new CustomEvent("score", { detail }));
+}
+
+export function getHighScore(gameId) {
+  if (!gameId) {
+    return null;
+  }
+  const store = readStore();
+  const entry = sanitizeEntry(store[gameId]);
+  return entry;
+}
+
+export function getAllHighScores() {
+  const store = readStore();
+  return new Map(
+    Object.entries(store)
+      .map(([gameId, entry]) => [gameId, sanitizeEntry(entry)])
+      .filter(([, entry]) => entry !== null),
+  );
+}
+
+export function recordHighScore(gameId, score, meta = {}) {
+  if (!gameId || !Number.isFinite(score)) {
+    return { updated: false, entry: getHighScore(gameId) };
+  }
+  const store = readStore();
+  const current = sanitizeEntry(store[gameId]);
+  if (current && current.value >= score) {
+    return { updated: false, entry: current };
+  }
+  const entry = {
+    value: score,
+    meta: sanitizeMeta(meta),
+    updatedAt: new Date().toISOString(),
+  };
+  store[gameId] = entry;
+  writeStore(store);
+  notifyChange(gameId, entry);
+  return { updated: true, entry: sanitizeEntry(entry) };
+}
+
+export function onHighScoreChange(handler) {
+  if (typeof handler !== "function") {
+    return () => {};
+  }
+  const listener = (event) => {
+    handler(event.detail);
+  };
+  eventTarget.addEventListener("score", listener);
+  return () => {
+    eventTarget.removeEventListener("score", listener);
+  };
+}
+
+export function onGameHighScore(gameId, handler) {
+  if (!gameId || typeof handler !== "function") {
+    return () => {};
+  }
+  return onHighScoreChange((detail) => {
+    if (detail?.gameId === gameId) {
+      handler(detail.entry);
+    }
+  });
+}
+
+export function initHighScoreBanner({ gameId, label = "High Score", format, emptyText = "No score yet." }) {
+  if (!gameId) {
+    throw new Error("gameId is required for initHighScoreBanner");
+  }
+  ensureWidget();
+  widgetState.label.textContent = label;
+  const render = (entry) => {
+    if (entry) {
+      widgetState.value.textContent = typeof format === "function" ? format(entry) : String(entry.value);
+      widgetState.value.dataset.empty = "false";
+      widgetState.note.textContent = "Personal best";
+    } else {
+      widgetState.value.textContent = emptyText;
+      widgetState.value.dataset.empty = "true";
+      widgetState.note.textContent = "Set a record to lock it in.";
+    }
+  };
+  render(getHighScore(gameId));
+
+  const celebrate = () => {
+    widgetState.element.classList.add("is-celebrate");
+    window.clearTimeout(widgetState.celebrateTimer);
+    widgetState.celebrateTimer = window.setTimeout(() => {
+      widgetState.element.classList.remove("is-celebrate");
+    }, CELEBRATE_TIMEOUT);
+  };
+
+  const unsubscribe = onGameHighScore(gameId, (entry) => {
+    render(entry);
+    if (entry) {
+      celebrate();
+    }
+  });
+
+  return {
+    submit(score, meta = {}) {
+      const result = recordHighScore(gameId, score, meta);
+      if (result.updated) {
+        render(result.entry);
+        celebrate();
+      }
+      return result;
+    },
+    render,
+    destroy() {
+      unsubscribe();
+    },
+  };
+}
+
+function ensureWidget() {
+  if (widgetState.element) {
+    return widgetState.element;
+  }
+  injectStyles();
+  const wrapper = document.createElement("aside");
+  wrapper.id = "shared-high-score";
+  wrapper.className = "shared-high-score";
+  wrapper.setAttribute("role", "status");
+  wrapper.setAttribute("aria-live", "polite");
+
+  const heading = document.createElement("p");
+  heading.className = "shared-high-score__heading";
+  heading.textContent = "High Score";
+
+  const label = document.createElement("p");
+  label.className = "shared-high-score__label";
+
+  const value = document.createElement("p");
+  value.className = "shared-high-score__value";
+  value.dataset.empty = "true";
+
+  const note = document.createElement("p");
+  note.className = "shared-high-score__note";
+
+  wrapper.append(heading, label, value, note);
+  document.body.appendChild(wrapper);
+
+  widgetState.element = wrapper;
+  widgetState.label = label;
+  widgetState.value = value;
+  widgetState.note = note;
+  return wrapper;
+}
+
+function injectStyles() {
+  if (document.getElementById("shared-high-score-style")) {
+    return;
+  }
+  const style = document.createElement("style");
+  style.id = "shared-high-score-style";
+  style.textContent = `
+    #shared-high-score {
+      position: fixed;
+      top: 1.25rem;
+      right: 1.25rem;
+      z-index: 40;
+      min-width: 12rem;
+      max-width: 18rem;
+      padding: 0.75rem 1rem;
+      border-radius: 0.85rem;
+      background: rgba(15, 23, 42, 0.88);
+      border: 1px solid rgba(148, 163, 184, 0.45);
+      box-shadow: 0 0.75rem 2.5rem rgba(15, 23, 42, 0.35);
+      color: #f8fafc;
+      font-family: "Spline Sans", "Segoe UI", sans-serif;
+      backdrop-filter: blur(6px);
+      transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
+    }
+    #shared-high-score.is-celebrate {
+      transform: translateY(-4px);
+      border-color: rgba(96, 165, 250, 0.9);
+      box-shadow: 0 1.1rem 3.2rem rgba(59, 130, 246, 0.35);
+    }
+    .shared-high-score__heading {
+      margin: 0;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: rgba(148, 163, 184, 0.85);
+    }
+    .shared-high-score__label {
+      margin: 0.25rem 0 0;
+      font-size: 0.85rem;
+      color: rgba(203, 213, 225, 0.85);
+    }
+    .shared-high-score__value {
+      margin: 0.4rem 0 0;
+      font-size: 1.45rem;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      color: #f8fafc;
+    }
+    .shared-high-score__value[data-empty="true"] {
+      font-size: 1rem;
+      font-weight: 400;
+      color: rgba(226, 232, 240, 0.8);
+    }
+    .shared-high-score__note {
+      margin: 0.3rem 0 0;
+      font-size: 0.7rem;
+      color: rgba(148, 163, 184, 0.85);
+    }
+    @media (max-width: 720px) {
+      #shared-high-score {
+        left: 1rem;
+        right: 1rem;
+        top: auto;
+        bottom: 1rem;
+      }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key !== STORAGE_KEY) {
+      return;
+    }
+    const store = readStore();
+    Object.entries(store).forEach(([gameId, entry]) => {
+      notifyChange(gameId, entry);
+    });
+  });
+}

--- a/madia.new/public/secret/1989/blaze/blaze.js
+++ b/madia.new/public/secret/1989/blaze/blaze.js
@@ -1,3 +1,14 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+
+const scoreConfig = getScoreConfig("blaze");
+const highScore = initHighScoreBanner({
+  gameId: "blaze",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
 const boardElement = document.getElementById("board");
 const statusBar = document.getElementById("status-bar");
 const capitalMeter = document.getElementById("capital-meter");
@@ -443,6 +454,7 @@ function advanceFlow() {
     billPosition = { ...nextStep };
     if (billPosition.row === GOAL.row && billPosition.col === GOAL.col) {
       signedBills += 1;
+      highScore.submit(signedBills);
       politicalCapital += BILL_REWARD;
       logEvent(`Bill signed cleanly. Political Capital +${BILL_REWARD} (now ${politicalCapital}).`);
       updateCapitalMeter();

--- a/madia.new/public/secret/1989/cable-clash/cable-clash.js
+++ b/madia.new/public/secret/1989/cable-clash/cable-clash.js
@@ -1,3 +1,14 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+
+const scoreConfig = getScoreConfig("cable-clash");
+const highScore = initHighScoreBanner({
+  gameId: "cable-clash",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
 const boardElement = document.getElementById("board");
 const statusBar = document.getElementById("status-bar");
 const logList = document.getElementById("log-entries");
@@ -445,6 +456,7 @@ function onCircuitClosed() {
   circuitClosed = true;
   setStatus("Circuit complete! The main-event slam erupts and stuns nearby rivals.");
   logEvent("The main-event slam fires—broadcast restored!");
+  highScore.submit(turnCounter);
   rivals.forEach((rival) => {
     if (isAdjacent(rival.position, GOAL)) {
       rival.stunned = true;

--- a/madia.new/public/secret/1989/captains-echo/captains-echo.js
+++ b/madia.new/public/secret/1989/captains-echo/captains-echo.js
@@ -1,3 +1,14 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+
+const scoreConfig = getScoreConfig("captains-echo");
+const highScore = initHighScoreBanner({
+  gameId: "captains-echo",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
 const students = [
   {
     id: "neil",
@@ -373,6 +384,7 @@ function evaluatePlan() {
 
   renderContributions(contributions);
   setMeter(score);
+  highScore.submit(score);
 
   targetCallout.classList.remove("warning", "success");
   if (score >= TARGET_SCORE) {

--- a/madia.new/public/secret/1989/cooler-chaos/cooler-chaos.js
+++ b/madia.new/public/secret/1989/cooler-chaos/cooler-chaos.js
@@ -1,3 +1,14 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+
+const scoreConfig = getScoreConfig("cooler-chaos");
+const highScore = initHighScoreBanner({
+  gameId: "cooler-chaos",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
 const GRID_ROWS = 8;
 const GRID_COLS = 8;
 const TICK_MS = 1200;
@@ -299,6 +310,7 @@ function tryPushChain(startRow, startCol, delta) {
 
 function handleEjection(exitCell) {
   state.ejected += 1;
+  highScore.submit(state.ejected);
   const now = performance.now();
   if (now - state.lastEjectTime <= COMBO_WINDOW) {
     state.comboCount += 1;

--- a/madia.new/public/secret/1989/culdesac-curiosity/culdesac-curiosity.js
+++ b/madia.new/public/secret/1989/culdesac-curiosity/culdesac-curiosity.js
@@ -1,3 +1,14 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+
+const scoreConfig = getScoreConfig("culdesac-curiosity");
+const highScore = initHighScoreBanner({
+  gameId: "culdesac-curiosity",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
 const boardElement = document.getElementById("gossip-grid");
 const statusBar = document.getElementById("status-bar");
 const logList = document.getElementById("log-entries");
@@ -87,6 +98,7 @@ let selectedTile = null;
 let resolvingBoard = false;
 let paranoia = 0;
 let tokens = 0;
+let peakTokens = 0;
 let curiosity = 0;
 let paranoiaTimer = null;
 let gameActive = true;
@@ -352,6 +364,10 @@ function updateTokensUI() {
   tokenReading.textContent = String(tokens);
   const ratio = Math.min(tokens / MAX_TOKENS_DISPLAY, 1);
   tokenFill.style.width = `${ratio * 100}%`;
+  if (tokens > peakTokens) {
+    peakTokens = tokens;
+    highScore.submit(peakTokens);
+  }
 }
 
 function updateCuriosityUI() {
@@ -626,6 +642,7 @@ function resetGame() {
   resolvingBoard = false;
   paranoia = 0;
   tokens = 0;
+  peakTokens = 0;
   curiosity = 0;
   selectedTile = null;
   updateParanoiaUI();

--- a/madia.new/public/secret/1989/dream-team-breakout/dream-team-breakout.js
+++ b/madia.new/public/secret/1989/dream-team-breakout/dream-team-breakout.js
@@ -1,3 +1,14 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+
+const scoreConfig = getScoreConfig("dream-team-breakout");
+const highScore = initHighScoreBanner({
+  gameId: "dream-team-breakout",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
 const TURN_COUNT = 6;
 const SANITY_MAX = 3;
 const wildcardDeck = ["S", "E", "S", "E", "S", "E"];
@@ -823,6 +834,7 @@ runButton.addEventListener("click", () => {
   statusReadout.textContent = "Simulating the breakout...";
   const result = runSimulation(plan);
   setSanity(result.sanity);
+  highScore.submit(result.sanity);
   applySnapshot(result.timeline);
   result.events.forEach(({ message, type }) => {
     pushEvent(message, type);

--- a/madia.new/public/secret/1989/gates-of-eastside/gates-of-eastside.js
+++ b/madia.new/public/secret/1989/gates-of-eastside/gates-of-eastside.js
@@ -17,6 +17,17 @@ const statusBanner = document.getElementById("status-banner");
 const mbstMeter = document.getElementById("mbst-meter");
 const mbstFill = document.getElementById("mbst-fill");
 const mbstLabel = document.getElementById("mbst-label");
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+
+const scoreConfig = getScoreConfig("gates-of-eastside");
+const highScore = initHighScoreBanner({
+  gameId: "gates-of-eastside",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
 const testScoreMeter = document.getElementById("test-score-meter");
 const testScoreFill = document.getElementById("test-score-fill");
 const testScoreLabel = document.getElementById("test-score-label");
@@ -281,6 +292,7 @@ function deliverStudyFlow(row) {
   const spend = Math.min(mbstProgress, DELIVERY_COST);
   mbstProgress = Math.max(0, mbstProgress - spend);
   testScore = Math.min(TEST_SCORE_TARGET, testScore + spend);
+  highScore.submit(Math.round(testScore));
   updateMeters();
   updateStatus(`Lane ${row + 1} cashed in ${spend} MBST for scores.`, "success");
   logEvent(`Lane ${row + 1} converted ${spend} MBST into test score progress.`);

--- a/madia.new/public/secret/1989/halo-hustle/halo-hustle.js
+++ b/madia.new/public/secret/1989/halo-hustle/halo-hustle.js
@@ -1,3 +1,14 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+
+const scoreConfig = getScoreConfig("halo-hustle");
+const highScore = initHighScoreBanner({
+  gameId: "halo-hustle",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
 const MAX_TIME = 80;
 const STARTING_TIME = 60;
 const CHIP_TIME_VALUE = 4;
@@ -145,6 +156,7 @@ function depositChips() {
   const restored = pendingChips * CHIP_TIME_VALUE;
   timeSand = Math.min(MAX_TIME, timeSand + restored);
   lifeChips += pendingChips;
+  highScore.submit(lifeChips);
   logEvent(`Deposited ${pendingChips} Life Chip${pendingChips === 1 ? "" : "s"}. Restored ${restored} seconds.`);
   pendingChips = 0;
   updateTime();

--- a/madia.new/public/secret/1989/heatwave-block-party/heatwave-block-party.js
+++ b/madia.new/public/secret/1989/heatwave-block-party/heatwave-block-party.js
@@ -15,6 +15,17 @@ const ROUTE_COOL_PER_EXTRA = 2;
 const TRASH_CAN_LOCK_MS = 6_000;
 const STARTING_TEMPERATURE = 46;
 
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+
+const scoreConfig = getScoreConfig("heatwave-block-party");
+const highScore = initHighScoreBanner({
+  gameId: "heatwave-block-party",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
 const boardTemplate = [
   { id: "dj-rooftop", label: "DJ Booth Roof", type: "vent", passable: true, initialGrievance: 0 },
   { id: "stoop-a", label: "Brownstone Stoop", type: "stoop", passable: true, initialGrievance: 1 },
@@ -77,6 +88,8 @@ const state = {
   cells: [],
 };
 
+let totalCooling = 0;
+
 initializeBoard();
 resetState();
 
@@ -138,6 +151,7 @@ function resetState() {
     ...cell,
     grievance: cell.initialGrievance,
   }));
+  totalCooling = 0;
   logEntries.innerHTML = "";
   updateBoard();
   updateGauges();
@@ -211,6 +225,8 @@ function commitRoute() {
     adjustOutburst(OUTBURST_COOL_BONUS);
     updateStatus(`Cooling fan clears ${cleared} grievance block${cleared > 1 ? "s" : ""}.`);
     logEvent(`Cooling fan clears ${cleared} grievance block${cleared > 1 ? "s" : ""}.`, "success");
+    totalCooling += cleared;
+    highScore.submit(totalCooling);
   } else if (!blocked) {
     adjustOutburst(OUTBURST_WAIT_PENALTY);
     updateStatus("The route swept clean stoops. No relief, pressure grows.");

--- a/madia.new/public/secret/1989/index.html
+++ b/madia.new/public/secret/1989/index.html
@@ -22,6 +22,7 @@
         <div class="game-info">
           <h2 class="game-title"></h2>
           <p class="game-meta"></p>
+          <p class="game-score" data-high-score></p>
         </div>
         <div class="card-actions">
           <button class="play-button" type="button">Play</button>

--- a/madia.new/public/secret/1989/kodiak-covenant/kodiak-covenant.js
+++ b/madia.new/public/secret/1989/kodiak-covenant/kodiak-covenant.js
@@ -1,3 +1,14 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+
+const scoreConfig = getScoreConfig("kodiak-covenant");
+const highScore = initHighScoreBanner({
+  gameId: "kodiak-covenant",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
 const TURN_COUNT = 9;
 const PROTECTION_WINDOW = 2;
 const GRID_WIDTH = 6;
@@ -492,6 +503,7 @@ function simulatePlan(plan) {
     states,
     events,
     success,
+    trapCount: clearedTraps.size,
   };
 }
 
@@ -540,6 +552,7 @@ function loadExamplePlan() {
 function runSimulation() {
   const plan = readPlan();
   const result = simulatePlan(plan);
+  highScore.submit(result.trapCount ?? 0);
   history = result.states;
   executedTurns = history[history.length - 1]?.turn ?? 0;
   currentStateIndex = 0;

--- a/madia.new/public/secret/1989/say-anything/say-anything.js
+++ b/madia.new/public/secret/1989/say-anything/say-anything.js
@@ -1,3 +1,14 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+
+const scoreConfig = getScoreConfig("say-anything");
+const highScore = initHighScoreBanner({
+  gameId: "say-anything",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
 const STARTING_FLOW = 72;
 const MAX_FLOW = 100;
 const SYNC_WINDOW_MS = 520;
@@ -48,6 +59,7 @@ const state = {
   playing: false,
   index: -1,
   flow: STARTING_FLOW,
+  highestFlow: STARTING_FLOW,
   miscommunication: [],
   positiveStreak: 0,
   activeEvent: null,
@@ -106,6 +118,7 @@ function beginSession() {
   state.miscommunication = [];
   state.positiveStreak = 0;
   state.flow = STARTING_FLOW;
+  state.highestFlow = STARTING_FLOW;
   state.activeEvent = null;
   state.activePair = null;
   state.boomboxWindow = false;
@@ -524,6 +537,10 @@ function setFlow(value) {
   flowFill.style.width = `${clamped}%`;
   flowValue.textContent = String(clamped);
   flowMeter.setAttribute("aria-valuenow", String(clamped));
+  if (clamped > state.highestFlow) {
+    state.highestFlow = clamped;
+    highScore.submit(state.highestFlow);
+  }
   if (clamped === 0 && state.playing) {
     logEvent("Communication flow collapsed. The moment slips away.", "danger");
     stopSession({ status: "Communication flow collapsed. The moment slips away." });

--- a/madia.new/public/secret/1989/score-config.js
+++ b/madia.new/public/secret/1989/score-config.js
@@ -1,0 +1,103 @@
+export const scoreConfigs = {
+  "amore-express": {
+    label: "Deliveries",
+    empty: "No deliveries logged yet.",
+    format: ({ value }) =>
+      value === 1 ? "1 delivery" : `${value ?? 0} deliveries`,
+  },
+  blaze: {
+    label: "Bills Signed",
+    empty: "No bills signed yet.",
+    format: ({ value }) =>
+      value === 1 ? "1 bill signed" : `${value ?? 0} bills signed`,
+  },
+  "cable-clash": {
+    label: "Turns to Lock Circuit",
+    empty: "No circuits closed yet.",
+    format: ({ value }) =>
+      value === 1 ? "1 turn" : `${value ?? 0} turns`,
+  },
+  "captains-echo": {
+    label: "Salute Score",
+    empty: "No salute scored yet.",
+    format: ({ value }) => `Score ${value ?? 0}`,
+  },
+  "cooler-chaos": {
+    label: "Rowdies Ejected",
+    empty: "No ejections logged yet.",
+    format: ({ value }) =>
+      value === 1 ? "1 ejection" : `${value ?? 0} ejections`,
+  },
+  "culdesac-curiosity": {
+    label: "Peak Dig Tokens",
+    empty: "No tokens earned yet.",
+    format: ({ value }) =>
+      value === 1 ? "1 token" : `${value ?? 0} tokens`,
+  },
+  "dream-team-breakout": {
+    label: "Final Sanity",
+    empty: "No breakout simulated yet.",
+    format: ({ value }) => `Sanity ${value ?? 0} / 3`,
+  },
+  "gates-of-eastside": {
+    label: "Test Score",
+    empty: "No study sessions yet.",
+    format: ({ value }) => `${value ?? 0} / 120`,
+  },
+  "halo-hustle": {
+    label: "Life Chips Banked",
+    empty: "No life chips deposited yet.",
+    format: ({ value }) =>
+      value === 1 ? "1 chip" : `${value ?? 0} chips`,
+  },
+  "heatwave-block-party": {
+    label: "Grievances Cooled",
+    empty: "No grievances cooled yet.",
+    format: ({ value }) =>
+      value === 1 ? "1 cooled" : `${value ?? 0} cooled`,
+  },
+  "kodiak-covenant": {
+    label: "Traps Cleared",
+    empty: "No traps cleared yet.",
+    format: ({ value }) =>
+      value === 1 ? "1 trap" : `${value ?? 0} traps`,
+  },
+  "say-anything": {
+    label: "Peak Flow",
+    empty: "No sync sessions yet.",
+    format: ({ value }) => `${value ?? 0}% flow`,
+  },
+  "second-star-flight": {
+    label: "Flight Meter",
+    empty: "No flight logged yet.",
+    format: ({ value }) => `${value ?? 0} / 100`,
+  },
+  "speed-zone": {
+    label: "Checkpoints Cleared",
+    empty: "No checkpoints cleared yet.",
+    format: ({ value }) => `${value ?? 0} / 4`,
+  },
+  "velvet-syncopation": {
+    label: "Harmony Peak",
+    empty: "No harmony recorded yet.",
+    format: ({ value }) => `${value ?? 0}% harmony`,
+  },
+  "vendetta-convoy": {
+    label: "Evidence Secured",
+    empty: "No evidence recovered yet.",
+    format: ({ value, meta }) => {
+      const total = Number(meta?.total) || 8;
+      return `${value ?? 0} / ${total}`;
+    },
+  },
+};
+
+export function getScoreConfig(gameId) {
+  return (
+    scoreConfigs[gameId] ?? {
+      label: "High Score",
+      empty: "No score recorded yet.",
+      format: ({ value }) => String(value ?? 0),
+    }
+  );
+}

--- a/madia.new/public/secret/1989/second-star-flight/second-star-flight.js
+++ b/madia.new/public/secret/1989/second-star-flight/second-star-flight.js
@@ -1,3 +1,14 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+
+const scoreConfig = getScoreConfig("second-star-flight");
+const highScore = initHighScoreBanner({
+  gameId: "second-star-flight",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
 const GRID_SIZE = 6;
 const SHADOW_COUNT = 7;
 const LIGHT_DURATION_MS = 8000;
@@ -43,6 +54,7 @@ const state = {
   flowMode: false,
   dust: 0,
   flight: STARTING_FLIGHT,
+  peakFlight: STARTING_FLIGHT,
   captured: 0,
   path: [],
   pathCells: new Set(),
@@ -414,6 +426,10 @@ function updateDust(value) {
 function updateFlight(value, announce = true) {
   const clamped = Math.max(0, Math.min(FLIGHT_GOAL, value));
   state.flight = clamped;
+  if (clamped > state.peakFlight) {
+    state.peakFlight = clamped;
+    highScore.submit(state.peakFlight);
+  }
   flightFill.style.width = `${clamped}%`;
   flightValue.textContent = String(clamped);
   flightMeter.setAttribute("aria-valuenow", String(clamped));

--- a/madia.new/public/secret/1989/speed-zone/speed-zone.js
+++ b/madia.new/public/secret/1989/speed-zone/speed-zone.js
@@ -1,3 +1,14 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+
+const scoreConfig = getScoreConfig("speed-zone");
+const highScore = initHighScoreBanner({
+  gameId: "speed-zone",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
 const svgNS = "http://www.w3.org/2000/svg";
 
 const nodes = [
@@ -440,6 +451,7 @@ function resolveRoute() {
     const clearedId = checkpoints[checkpointIndex];
     const clearedName = nodesById.get(clearedId).name;
     checkpointIndex += 1;
+    highScore.submit(checkpointIndex);
     adjustHeat(-4);
     logEvent(`🏁 Cleared ${clearedName}. Heat -4.`);
   }
@@ -477,6 +489,7 @@ function triggerBypass() {
   if (checkpointIndex < checkpoints.length) {
     const skipped = nodesById.get(checkpoints[checkpointIndex]).name;
     checkpointIndex += 1;
+    highScore.submit(checkpointIndex);
     logEvent(`🪄 Bypass actuation burns ${skipped}. Next checkpoint auto-cleared.`);
     updateCheckpointReadout();
   }

--- a/madia.new/public/secret/1989/velvet-syncopation/velvet-syncopation.js
+++ b/madia.new/public/secret/1989/velvet-syncopation/velvet-syncopation.js
@@ -1,3 +1,14 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+
+const scoreConfig = getScoreConfig("velvet-syncopation");
+const highScore = initHighScoreBanner({
+  gameId: "velvet-syncopation",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
 const chart = [
   { left: "KeyA", right: "KeyL" },
   { left: "KeyS", right: "KeyK" },
@@ -47,6 +58,7 @@ const syncCells = [];
 const syncStepBadges = new Map();
 
 let harmony = STARTING_HARMONY;
+let highestHarmony = STARTING_HARMONY;
 let playing = false;
 let currentTick = 0;
 let intervalId = null;
@@ -165,6 +177,7 @@ function beginSequence() {
   clearHighlights();
   eventList.innerHTML = "";
   setHarmony(STARTING_HARMONY);
+  highestHarmony = STARTING_HARMONY;
   updateStatus("Rehearsal in motion.");
   logEvent("Rehearsal started. Keep the brothers in phase.");
   startButton.disabled = true;
@@ -450,6 +463,10 @@ function handleInput(code) {
 function setHarmony(value) {
   const clamped = Math.max(0, Math.min(HARMONY_MAX, Math.round(value)));
   harmony = clamped;
+  if (clamped > highestHarmony) {
+    highestHarmony = clamped;
+    highScore.submit(highestHarmony);
+  }
   harmonyFill.style.width = `${clamped}%`;
   harmonyMeter.setAttribute("aria-valuenow", String(clamped));
   harmonyValue.textContent = String(clamped);

--- a/madia.new/public/secret/1989/vendetta-convoy/vendetta-convoy.js
+++ b/madia.new/public/secret/1989/vendetta-convoy/vendetta-convoy.js
@@ -1,3 +1,14 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+
+const scoreConfig = getScoreConfig("vendetta-convoy");
+const highScore = initHighScoreBanner({
+  gameId: "vendetta-convoy",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
 const BOARD_WIDTH = 8;
 const BOARD_HEIGHT = 14;
 const LANE_COLUMNS = [2, 3, 4, 5];
@@ -392,6 +403,7 @@ function sabotageEvidence(row, col) {
     cell.type = "cleared";
     cell.revealed = true;
     state.evidenceCleared += 1;
+    highScore.submit(state.evidenceCleared, { total: TOTAL_EVIDENCE });
   }
 
   state.actuation = Math.max(0, state.actuation - SABOTAGE_COST);
@@ -521,6 +533,7 @@ function triggerPhoenix(row) {
       const cell = state.board[r][c];
       if (cell.type === "evidence" || cell.type === "explosive") {
         state.evidenceCleared += 1;
+        highScore.submit(state.evidenceCleared, { total: TOTAL_EVIDENCE });
         cell.type = "cleared";
         cell.revealed = true;
       }


### PR DESCRIPTION
## Summary
- add a localStorage-backed high score module and per-game formatting metadata
- surface each cabinet's best run on the 1989 arcade menu with live updates
- wire every 1989 game to publish its score through the shared tracker

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68df0de1be6c8328807ed458407b6fae