### PR TITLE
feat: add Secret Annex SNES theming

### DIFF
--- a/madia.new/public/secret/1989/amore-express/index.html
+++ b/madia.new/public/secret/1989/amore-express/index.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Amore Express</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
     <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="amore-express.css" />
   </head>
-  <body>
+  <body class="secret-annex-snes">
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">

--- a/madia.new/public/secret/1989/blaze/index.html
+++ b/madia.new/public/secret/1989/blaze/index.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Paper Trail Blaze</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
     <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="blaze.css" />
   </head>
-  <body>
+  <body class="secret-annex-snes">
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">

--- a/madia.new/public/secret/1989/cable-clash/index.html
+++ b/madia.new/public/secret/1989/cable-clash/index.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>The Cable Clash</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
     <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="cable-clash.css" />
   </head>
-  <body>
+  <body class="secret-annex-snes">
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">

--- a/madia.new/public/secret/1989/captains-echo/index.html
+++ b/madia.new/public/secret/1989/captains-echo/index.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Captain's Echo</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
     <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="captains-echo.css" />
   </head>
-  <body>
+  <body class="secret-annex-snes">
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">

--- a/madia.new/public/secret/1989/cooler-chaos/index.html
+++ b/madia.new/public/secret/1989/cooler-chaos/index.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cooler Chaos</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
     <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="cooler-chaos.css" />
   </head>
-  <body>
+  <body class="secret-annex-snes">
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">

--- a/madia.new/public/secret/1989/culdesac-curiosity/index.html
+++ b/madia.new/public/secret/1989/culdesac-curiosity/index.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cul-de-sac Curiosity</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
     <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="culdesac-curiosity.css" />
   </head>
-  <body>
+  <body class="secret-annex-snes">
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">

--- a/madia.new/public/secret/1989/dream-team-breakout/index.html
+++ b/madia.new/public/secret/1989/dream-team-breakout/index.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dream Team Breakout</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
     <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="dream-team-breakout.css" />
   </head>
-  <body>
+  <body class="secret-annex-snes">
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">

--- a/madia.new/public/secret/1989/gates-of-eastside/index.html
+++ b/madia.new/public/secret/1989/gates-of-eastside/index.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Gates of Eastside</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
     <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="gates-of-eastside.css" />
   </head>
-  <body>
+  <body class="secret-annex-snes">
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">

--- a/madia.new/public/secret/1989/halo-hustle/index.html
+++ b/madia.new/public/secret/1989/halo-hustle/index.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Halo Hustle</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
     <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="halo-hustle.css" />
   </head>
-  <body>
+  <body class="secret-annex-snes">
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">

--- a/madia.new/public/secret/1989/heatwave-block-party/index.html
+++ b/madia.new/public/secret/1989/heatwave-block-party/index.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Heatwave Block Party</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
     <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="heatwave-block-party.css" />
   </head>
-  <body>
+  <body class="secret-annex-snes">
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">

--- a/madia.new/public/secret/1989/kodiak-covenant/index.html
+++ b/madia.new/public/secret/1989/kodiak-covenant/index.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kodiak Covenant</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
     <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="kodiak-covenant.css" />
   </head>
-  <body>
+  <body class="secret-annex-snes">
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">

--- a/madia.new/public/secret/1989/say-anything/index.html
+++ b/madia.new/public/secret/1989/say-anything/index.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Say Anything...</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
     <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="say-anything.css" />
   </head>
-  <body>
+  <body class="secret-annex-snes">
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">

--- a/madia.new/public/secret/1989/second-star-flight/index.html
+++ b/madia.new/public/secret/1989/second-star-flight/index.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Second Star Flight (Re-issue)</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
     <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="second-star-flight.css" />
   </head>
-  <body>
+  <body class="secret-annex-snes">
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">

--- a/madia.new/public/secret/1989/speed-zone/index.html
+++ b/madia.new/public/secret/1989/speed-zone/index.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Speed Zone</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
     <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="speed-zone.css" />
   </head>
-  <body>
+  <body class="secret-annex-snes">
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">

--- a/madia.new/public/secret/1989/velvet-syncopation/index.html
+++ b/madia.new/public/secret/1989/velvet-syncopation/index.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Velvet Syncopation</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
     <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="velvet-syncopation.css" />
   </head>
-  <body>
+  <body class="secret-annex-snes">
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">

--- a/madia.new/public/secret/1989/vendetta-convoy/index.html
+++ b/madia.new/public/secret/1989/vendetta-convoy/index.html
@@ -4,10 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vendetta Convoy</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
     <link rel="stylesheet" href="../common.css" />
     <link rel="stylesheet" href="vendetta-convoy.css" />
   </head>
-  <body>
+  <body class="secret-annex-snes">
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">

--- a/madia.new/public/secret/augmentum/index.html
+++ b/madia.new/public/secret/augmentum/index.html
@@ -4,9 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Augmentum</title>
+    <link rel="stylesheet" href="../secret-annex-snes.css" />
     <link rel="stylesheet" href="augmentum.css" />
   </head>
-  <body>
+  <body class="secret-annex-snes">
     <header class="page-header">
       <a class="back-link" href="../1989/index.html">◀ Back to 1989 Arcade</a>
       <h1>Augmentum</h1>

--- a/madia.new/public/secret/secret-annex-snes.css
+++ b/madia.new/public/secret/secret-annex-snes.css
@@ -1,0 +1,456 @@
+@import url("https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Space+Grotesk:wght@400;600;700&display=swap");
+
+body.secret-annex-snes {
+  --snes-body-font: "Space Grotesk", "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --snes-heading-font: "Press Start 2P", "Space Grotesk", system-ui, sans-serif;
+  --snes-bg: #1b1e3a;
+  --snes-radial-1: rgba(122, 112, 210, 0.45);
+  --snes-radial-2: rgba(58, 215, 255, 0.28);
+  --snes-radial-3: rgba(255, 111, 145, 0.22);
+  --snes-text: #f8f7ff;
+  --snes-muted: rgba(228, 224, 255, 0.78);
+  --snes-panel-bg: rgba(21, 25, 50, 0.9);
+  --snes-panel-border: rgba(214, 205, 255, 0.38);
+  --snes-panel-shadow: 0 32px 68px -28px rgba(6, 8, 20, 0.82);
+  --snes-divider: rgba(214, 205, 255, 0.16);
+  --snes-highlight: #ff6f91;
+  --snes-highlight-alt: #3ad7ff;
+  --snes-button-top: #cbc1ff;
+  --snes-button-mid: #7f6dd8;
+  --snes-button-bottom: #4237a3;
+  --snes-button-border: rgba(214, 205, 255, 0.6);
+  --snes-button-shadow: 0 18px 38px rgba(6, 8, 20, 0.45);
+  --snes-focus-ring: rgba(58, 215, 255, 0.8);
+  --snes-scanline: rgba(255, 255, 255, 0.04);
+  --snes-scanline-horizontal: rgba(255, 255, 255, 0.02);
+  color-scheme: dark;
+  font-family: var(--snes-body-font);
+  margin: 0;
+  min-height: 100vh;
+  line-height: 1.6;
+  color: var(--snes-text);
+  background:
+    radial-gradient(circle at 16% 18%, var(--snes-radial-1), transparent 55%),
+    radial-gradient(circle at 82% 12%, var(--snes-radial-2), transparent 45%),
+    radial-gradient(circle at 48% 84%, var(--snes-radial-3), transparent 45%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.06) 0 25%, transparent 25% 50%) 0 0 / 32px 32px,
+    linear-gradient(-135deg, rgba(0, 0, 0, 0.18) 0 25%, transparent 25% 50%) 0 0 / 32px 32px,
+    var(--snes-bg);
+  padding-bottom: clamp(3rem, 9vw, 5.5rem);
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+body.secret-annex-snes *,
+body.secret-annex-snes *::before,
+body.secret-annex-snes *::after {
+  box-sizing: border-box;
+}
+
+body.secret-annex-snes ::selection {
+  background: rgba(255, 111, 145, 0.4);
+  color: var(--snes-text);
+}
+
+.secret-annex-snes a {
+  color: var(--snes-highlight-alt);
+  text-decoration: none;
+}
+
+.secret-annex-snes a:hover,
+.secret-annex-snes a:focus-visible {
+  color: #7be3ff;
+}
+
+.secret-annex-snes :focus-visible {
+  outline: 3px solid var(--snes-focus-ring);
+  outline-offset: 3px;
+}
+
+.secret-annex-snes .skip-link {
+  position: absolute;
+  left: 50%;
+  top: 0.75rem;
+  transform: translate(-50%, -150%);
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  background: rgba(12, 14, 30, 0.96);
+  color: var(--snes-text);
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  box-shadow: 0 20px 40px rgba(6, 8, 20, 0.45);
+  transition: transform 0.2s ease, opacity 0.2s ease;
+  opacity: 0;
+  z-index: 200;
+}
+
+.secret-annex-snes .skip-link:focus,
+.secret-annex-snes .skip-link:focus-visible {
+  transform: translate(-50%, 0);
+  opacity: 1;
+}
+
+.secret-annex-snes .scanlines {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    repeating-linear-gradient(
+      to bottom,
+      var(--snes-scanline),
+      var(--snes-scanline) 1px,
+      transparent 1px,
+      transparent 3px
+    ),
+    repeating-linear-gradient(
+      to right,
+      var(--snes-scanline-horizontal),
+      var(--snes-scanline-horizontal) 1px,
+      transparent 1px,
+      transparent 4px
+    );
+  mix-blend-mode: screen;
+  opacity: 0.45;
+  z-index: 0;
+}
+
+.secret-annex-snes .page-header {
+  position: relative;
+  padding: clamp(3rem, 7vw, 5rem) clamp(1.5rem, 5vw, 5rem) clamp(2.5rem, 5vw, 3.5rem);
+  text-align: center;
+  z-index: 1;
+  display: grid;
+  justify-items: center;
+  gap: 0.9rem;
+}
+
+.secret-annex-snes .eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.42em;
+  font-size: 0.78rem;
+  color: var(--snes-muted);
+  font-family: var(--snes-heading-font);
+}
+
+.secret-annex-snes .page-header h1 {
+  margin: 0;
+  font-size: clamp(2.6rem, 7vw, 4.6rem);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-family: var(--snes-heading-font);
+  color: #fff8ff;
+  text-shadow:
+    0 4px 0 rgba(0, 0, 0, 0.35),
+    0 18px 45px rgba(9, 13, 32, 0.65);
+}
+
+.secret-annex-snes .subtitle {
+  margin: 0;
+  max-width: min(720px, 90vw);
+  color: var(--snes-muted);
+  font-size: clamp(0.95rem, 2.2vw, 1.1rem);
+  letter-spacing: 0.05em;
+}
+
+.secret-annex-snes .page-layout,
+.secret-annex-snes .game-layout {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: clamp(1.5rem, 4.5vw, 3.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  padding: 0 clamp(1.5rem, 5vw, 4.5rem) clamp(3rem, 6vw, 4rem);
+  align-items: start;
+}
+
+.secret-annex-snes .page-layout > *,
+.secret-annex-snes .game-layout > * {
+  background: var(--snes-panel-bg);
+  border-radius: 28px;
+  border: 1px solid var(--snes-panel-border);
+  padding: clamp(1.5rem, 4vw, 2.75rem);
+  box-shadow: var(--snes-panel-shadow);
+  backdrop-filter: blur(6px);
+}
+
+.secret-annex-snes .page-layout > *:not(:last-child),
+.secret-annex-snes .game-layout > *:not(:last-child) {
+  position: relative;
+}
+
+.secret-annex-snes .page-layout > *:not(:last-child)::after,
+.secret-annex-snes .game-layout > *:not(:last-child)::after {
+  content: "";
+  position: absolute;
+  inset: auto clamp(-1.5rem, -3vw, -2.5rem) -1.5rem clamp(-1.5rem, -3vw, -2.5rem);
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  opacity: 0.22;
+  pointer-events: none;
+}
+
+.secret-annex-snes h2,
+.secret-annex-snes h3 {
+  font-family: var(--snes-heading-font);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #fdfbff;
+}
+
+.secret-annex-snes h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: clamp(1.15rem, 2.4vw, 1.35rem);
+}
+
+.secret-annex-snes h3 {
+  margin-bottom: 0.85rem;
+  font-size: clamp(0.95rem, 2vw, 1.1rem);
+}
+
+.secret-annex-snes p {
+  color: var(--snes-muted);
+}
+
+.secret-annex-snes strong {
+  color: #ffffff;
+}
+
+.secret-annex-snes .callouts {
+  margin: 1.5rem 0;
+  padding-left: 1.35rem;
+  display: grid;
+  gap: 0.9rem;
+  color: var(--snes-muted);
+}
+
+.secret-annex-snes .controls dl,
+.secret-annex-snes dl.horizontal {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.secret-annex-snes .controls dt,
+.secret-annex-snes dl.horizontal dt {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.88rem;
+  color: #ffffff;
+}
+
+.secret-annex-snes .controls dd,
+.secret-annex-snes dl.horizontal dd {
+  margin: 0;
+  color: var(--snes-muted);
+  font-size: 0.95rem;
+}
+
+.secret-annex-snes .key-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.15rem 0.45rem;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(214, 205, 255, 0.32);
+  background: rgba(12, 14, 30, 0.75);
+  font-family: "JetBrains Mono", "SFMono-Regular", ui-monospace, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.8rem;
+  color: #fff;
+  box-shadow: inset 0 -2px 0 rgba(255, 255, 255, 0.12);
+}
+
+.secret-annex-snes .status-bar,
+.secret-annex-snes .meter,
+.secret-annex-snes .harmony-panel,
+.secret-annex-snes .reactor-hud,
+.secret-annex-snes .simulator-header,
+.secret-annex-snes .arena-header {
+  background: rgba(12, 14, 30, 0.65);
+  border: 1px solid rgba(214, 205, 255, 0.2);
+  border-radius: 18px;
+  padding: 0.85rem 1.1rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.secret-annex-snes .status-bar {
+  margin: 1rem 0 1.5rem;
+  color: var(--snes-text);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.secret-annex-snes .meter {
+  background: rgba(12, 14, 30, 0.55);
+  position: relative;
+  overflow: hidden;
+}
+
+.secret-annex-snes .meter::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.06), transparent 65%);
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.secret-annex-snes .action-button,
+.secret-annex-snes .mode-button,
+.secret-annex-snes .palette-button,
+.secret-annex-snes .control-button,
+.secret-annex-snes .virtual-key,
+.secret-annex-snes .back-link,
+.secret-annex-snes .play-button,
+.secret-annex-snes .fullscreen-button,
+.secret-annex-snes .back-button,
+.secret-annex-snes button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1.35rem;
+  border-radius: 14px;
+  border: 1px solid var(--snes-button-border);
+  background: linear-gradient(180deg, var(--snes-button-top), var(--snes-button-mid) 60%, var(--snes-button-bottom));
+  color: #ffffff;
+  font-family: var(--snes-body-font);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: var(--snes-button-shadow);
+  transition: transform 0.15s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.secret-annex-snes .action-button:disabled,
+.secret-annex-snes .mode-button:disabled,
+.secret-annex-snes .palette-button:disabled,
+.secret-annex-snes .control-button:disabled,
+.secret-annex-snes .virtual-key:disabled,
+.secret-annex-snes button:disabled {
+  cursor: not-allowed;
+  filter: grayscale(0.4);
+  opacity: 0.7;
+}
+
+.secret-annex-snes .action-button:hover:not(:disabled),
+.secret-annex-snes .mode-button:hover:not(:disabled),
+.secret-annex-snes .palette-button:hover:not(:disabled),
+.secret-annex-snes .control-button:hover:not(:disabled),
+.secret-annex-snes .virtual-key:hover:not(:disabled),
+.secret-annex-snes button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 44px rgba(6, 8, 20, 0.55);
+}
+
+.secret-annex-snes .action-button:active:not(:disabled),
+.secret-annex-snes .mode-button:active:not(:disabled),
+.secret-annex-snes .palette-button:active:not(:disabled),
+.secret-annex-snes .control-button:active:not(:disabled),
+.secret-annex-snes .virtual-key:active:not(:disabled),
+.secret-annex-snes button:active:not(:disabled) {
+  transform: translateY(1px);
+  box-shadow: 0 12px 24px rgba(6, 8, 20, 0.45);
+}
+
+.secret-annex-snes .mode-button[aria-pressed="true"],
+.secret-annex-snes .palette-button[aria-pressed="true"],
+.secret-annex-snes .control-button[aria-pressed="true"] {
+  filter: saturate(1.25);
+  box-shadow: 0 18px 36px rgba(255, 111, 145, 0.4);
+}
+
+.secret-annex-snes .back-link {
+  align-self: flex-start;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  background: rgba(12, 14, 30, 0.75);
+}
+
+.secret-annex-snes .page-footer {
+  position: relative;
+  z-index: 1;
+  margin: clamp(3rem, 7vw, 5rem) auto 0;
+  max-width: min(680px, 90vw);
+  text-align: center;
+  color: var(--snes-muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  padding: 0 clamp(1.5rem, 5vw, 3.5rem);
+}
+
+.secret-annex-snes .page-footer::before {
+  content: "";
+  position: absolute;
+  inset: -2rem clamp(-2rem, -4vw, -3rem) -2.5rem clamp(-2rem, -4vw, -3rem);
+  background: linear-gradient(180deg, rgba(12, 14, 30, 0.7), transparent 75%);
+  z-index: -1;
+  border-radius: 32px;
+  border: 1px solid rgba(214, 205, 255, 0.1);
+}
+
+.secret-annex-snes footer p {
+  margin: 0;
+}
+
+.secret-annex-snes hr {
+  border: none;
+  height: 1px;
+  background: var(--snes-divider);
+  margin: 2rem 0;
+}
+
+.secret-annex-snes table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(12, 14, 30, 0.55);
+  border: 1px solid rgba(214, 205, 255, 0.22);
+  border-radius: 18px;
+  overflow: hidden;
+}
+
+.secret-annex-snes th,
+.secret-annex-snes td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(214, 205, 255, 0.12);
+}
+
+.secret-annex-snes th {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.85rem;
+  color: #ffffff;
+  background: rgba(21, 25, 50, 0.95);
+}
+
+.secret-annex-snes tbody tr:last-child td {
+  border-bottom: none;
+}
+
+@media (max-width: 960px) {
+  .secret-annex-snes .page-layout,
+  .secret-annex-snes .game-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .secret-annex-snes .page-layout > *:not(:last-child)::after,
+  .secret-annex-snes .game-layout > *:not(:last-child)::after {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .secret-annex-snes *,
+  .secret-annex-snes *::before,
+  .secret-annex-snes *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared `secret-annex-snes.css` skin that applies the Secret Annex SNES look-and-feel
- attach the skin to every secret arcade game so the cabinet styling is consistent across the collection, including Augmentum

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df27902cf48328a9551f29e87b21a5