### PR TITLE
Fix Augmentum cabinet name mismatch

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -177,8 +177,8 @@ const games = [
     `,
   },
   {
-    id: "argumentum",
-    name: "Argumentum",
+    id: "augmentum",
+    name: "Augmentum",
 
     description: "Synth-grid puzzle fusion hidden deep in the archives.",
     url: "../augmentum/index.html",


### PR DESCRIPTION
## Summary
- align the 1989 arcade listing to use the Augmentum name and identifier so it matches the game page

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df2b5bf0508328a003c7f7aca44339