### PR TITLE
Rasterize 1989 cabinet logos for genuine pixelation

### DIFF
--- a/madia.new/public/secret/1989/1989.css
+++ b/madia.new/public/secret/1989/1989.css
@@ -258,7 +258,19 @@ main {
   width: 100%;
   height: 100%;
   max-width: 180px;
-  filter: saturate(1.1) drop-shadow(0 12px 18px rgba(0, 0, 0, 0.35));
+}
+
+.game-thumb canvas.pixelated-logo {
+  width: 100%;
+  height: auto;
+  max-width: 180px;
+  image-rendering: pixelated;
+  filter: saturate(1.05) drop-shadow(0 12px 18px rgba(0, 0, 0, 0.35));
+  display: block;
+}
+
+.game-thumb svg.pixelated-fallback {
+  filter: drop-shadow(0 12px 18px rgba(0, 0, 0, 0.35));
 }
 
 .game-info {


### PR DESCRIPTION
## Summary
- replace the SVG filter approach with a canvas-based rasterization that downsamples each logo before scaling it up
- simplify styling to target the generated canvas elements and keep a graceful SVG fallback when rasterization fails
- drop the unused hidden filter definition from the 1989 index markup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df290e657083288e39464c9ee4301c