### PR TITLE
Add 1989 arcade polish design rules

### DIFF
--- a/madia.new/public/secret/1989/AGENTS.md
+++ b/madia.new/public/secret/1989/AGENTS.md
@@ -5,3 +5,29 @@ Reference this project simply as "1989" in future prompts (e.g., "here's another
 Each level should ladder upward from Level 50 to Level 1, pairing puzzle mechanics with thematic cues from 1989 cinema.
 Use oblique level titles that allude to, but do not repeat, the exact film names.
 games should be added to the 1989 arcade so that they can be played/replayed in any order
+
+## 1989 Arcade Polish Rules
+
+Study the strongest cabinet builds (e.g., "Speed Zone", "Second Star Flight", "Velvet Syncopation") and apply these shared rules to every new level so it instantly feels at home in the arcade:
+
+- **Score clarity**
+  - Surface the scoring goal immediately in the header or a persistent HUD, echoing the high-score banner pattern provided by `arcade-scores.js`.
+  - Use one primary score value that updates with each meaningful action; secondary meters are fine, but never hide the route to victory.
+  - Announce threshold moments (new personal bests, combo tiers, bonus unlocks) with copy and color pops so players understand their performance.
+- **Progress & pacing**
+  - Break the experience into clearly labeled phases (setup ➜ rounds ➜ finale) or a visible track of objectives; show what is completed and what comes next.
+  - Deliver a gentle on-ramp: the first interaction should be low stakes, with later turns layering additional systems, hazards, or multipliers.
+  - Tie difficulty ramps to player mastery cues—introduce new obstacles only after the prior mechanic has been successfully exercised.
+- **Decision pressure & risk/reward**
+  - Present at least two competing options on every turn (safer route vs. high-payoff gamble, resource spend vs. saving for later) with explicit consequences in the copy.
+  - Track persistent resources (fuel, crew morale, time, etc.) and show how each choice alters those meters so the gamble is transparent.
+  - Reward calculated risks with escalating multipliers, rare FX, or access to hidden routes that the cautious path never reveals.
+- **Feedback, animation, and FX**
+  - Use the shared particle system (`particles.js`) or bespoke CSS transitions to punctuate victories, damage, and state changes within 200 ms of the action.
+  - Reserve palette shifts, screen shakes, or audio stingers for milestone moments so the cabinet feels alive without becoming noisy.
+  - Ensure every interactive element highlights on hover/focus and provides tactile button states that mirror other top-performing cabinets.
+- **Session wrap-up**
+  - End each run with a concise recap panel summarizing score, key decisions, and unlocked bonuses before prompting a replay.
+  - Pipe the final score into the arcade leaderboard helper and offer a rematch button so the feedback loop stays tight.
+
+Treat these as non-negotiable guardrails—the arcade thrives when every cabinet broadcasts progress, stakes, and spectacle the moment the lights turn on.


### PR DESCRIPTION
## Summary
- add a polish rule set to the 1989 arcade AGENTS.md so new cabinets emphasize score clarity, pacing, and feedback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e00c41e6a48328ba7526238e1aa9b6