### PR TITLE
feat: add nose-for-trouble level to 1989 arcade

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -581,6 +581,53 @@ const games = [
     `,
   },
   {
+    id: "nose-for-trouble",
+    name: "Nose for Trouble",
+    description: "Route Jerry’s scent trail past explosive tunnels before the frustration spike drags him off course.",
+    url: "./nose-for-trouble/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Nose for Trouble preview">
+        <defs>
+          <linearGradient id="k9Backdrop" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="rgba(15,23,42,0.92)" />
+            <stop offset="100%" stop-color="rgba(15,23,42,0.76)" />
+          </linearGradient>
+          <linearGradient id="trailStroke" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#38bdf8" />
+            <stop offset="100%" stop-color="#34d399" />
+          </linearGradient>
+        </defs>
+        <rect x="8" y="10" width="144" height="100" rx="18" fill="url(#k9Backdrop)" stroke="rgba(56,189,248,0.35)" />
+        <rect x="26" y="24" width="108" height="72" rx="16" fill="rgba(9,14,32,0.9)" stroke="rgba(148,163,184,0.3)" />
+        <g stroke="rgba(71,85,105,0.4)" stroke-width="1">
+          ${Array.from({ length: 6 }, (_, i) => `<line x1="${40 + i * 16}" y1="28" x2="${40 + i * 16}" y2="92" />`).join("")}
+          ${Array.from({ length: 4 }, (_, i) => `<line x1="30" y1="${40 + i * 14}" x2="130" y2="${40 + i * 14}" />`).join("")}
+        </g>
+        <path d="M38 88 L58 72 Q74 60 94 68 T122 56" fill="none" stroke="url(#trailStroke)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+        <g>
+          <circle cx="42" cy="84" r="10" fill="rgba(59,130,246,0.85)" stroke="rgba(148,163,184,0.5)" stroke-width="2" />
+          <path d="M38 82 Q42 78 46 82" fill="none" stroke="rgba(241,245,249,0.85)" stroke-width="2" stroke-linecap="round" />
+          <circle cx="120" cy="56" r="7" fill="rgba(34,197,94,0.85)" stroke="rgba(148,163,184,0.45)" stroke-width="1.5" />
+          <rect x="116" y="52" width="8" height="8" rx="2" fill="rgba(14,165,233,0.4)" stroke="rgba(148,163,184,0.3)" />
+        </g>
+        <g>
+          <rect x="54" y="48" width="12" height="12" rx="3" fill="rgba(15,23,42,0.8)" stroke="rgba(94,234,212,0.55)" />
+          <rect x="70" y="38" width="12" height="12" rx="3" fill="rgba(15,23,42,0.8)" stroke="rgba(94,234,212,0.55)" />
+          <rect x="88" y="62" width="12" height="12" rx="3" fill="rgba(15,23,42,0.8)" stroke="rgba(94,234,212,0.55)" />
+        </g>
+        <g transform="translate(30 26)">
+          <rect x="0" y="0" width="32" height="10" rx="5" fill="rgba(14,165,233,0.2)" stroke="rgba(56,189,248,0.45)" />
+          <rect x="0" y="0" width="22" height="10" rx="5" fill="rgba(56,189,248,0.75)" />
+        </g>
+        <g transform="translate(108 80)">
+          <rect x="0" y="0" width="32" height="18" rx="6" fill="rgba(30,41,59,0.85)" stroke="rgba(148,163,184,0.35)" />
+          <path d="M6 9 L26 9" stroke="rgba(250,204,21,0.65)" stroke-width="3" stroke-linecap="round" />
+          <circle cx="16" cy="9" r="4" fill="rgba(250,204,21,0.85)" stroke="rgba(248,250,252,0.6)" stroke-width="1" />
+        </g>
+      </svg>
+    `,
+  },
+  {
     id: "captains-echo",
     name: "Captain's Echo",
     description: "Stage the four-beat desk salute before the dean snuffs the Carpe Diem spark.",

--- a/madia.new/public/secret/1989/nose-for-trouble/index.html
+++ b/madia.new/public/secret/1989/nose-for-trouble/index.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nose for Trouble</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="nose-for-trouble.css" />
+  </head>
+  <body class="secret-annex-snes">
+    <a class="skip-link" href="#main-content">Skip to game</a>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 31 · 1989 Arcade</p>
+      <h1>Nose for Trouble</h1>
+      <p class="subtitle">
+        Sweep the waterfront warehouse with Jerry Lee’s scent trail, tagging every illicit drop before the tunnels go
+        boom.
+      </p>
+    </header>
+    <main id="main-content" class="page-layout">
+      <section class="briefing" aria-labelledby="briefing-title">
+        <h2 id="briefing-title">Stage Notes</h2>
+        <p>
+          Captain Dooley cracked the courier ring, but the smugglers laced their maze with explosive tunnels. Jerry Lee can
+          smell the next drug baggie a mile away—your job is to steer the scent trail through the grid without brushing a
+          single detonator.
+        </p>
+        <ul class="callouts">
+          <li>
+            <strong>Drug baggies:</strong> Pop up anywhere the tunnels leave space. Reach one with the scent trail to secure
+            the evidence and reveal the next drop.
+          </li>
+          <li>
+            <strong>Explosive tunnels:</strong> Permanent hazards. Cross a tunnel with the trail and the whole pier block
+            detonates.
+          </li>
+          <li>
+            <strong>Frustration meter:</strong> Fills while a baggie is active. When maxed, Jerry surges forward on his own,
+            tugging the trail into risky territory.
+          </li>
+          <li>
+            <strong>Flow reroutes:</strong> Backtrack a single step with <span class="key-label">Backspace</span> or restart
+            from the nose with the <span class="key-label">Reset Trail</span> button.
+          </li>
+        </ul>
+        <section class="key-guide" aria-labelledby="key-guide-title">
+          <h3 id="key-guide-title">Trail Commands</h3>
+          <dl>
+            <div>
+              <dt>Draw Trail</dt>
+              <dd>Click or drag from Jerry’s nose to adjacent tiles. Keep moving until you tag the baggie.</dd>
+            </div>
+            <div>
+              <dt>Undo Step</dt>
+              <dd><span class="key-label">Backspace</span> removes the latest tile while the patrol is active.</dd>
+            </div>
+            <div>
+              <dt>Reset Trail</dt>
+              <dd>Use the <span class="key-label">Reset Trail</span> button to jump back to the starting tile.</dd>
+            </div>
+            <div>
+              <dt>Abort Patrol</dt>
+              <dd><span class="key-label">Esc</span> or the <span class="key-label">Abort Mission</span> button.</dd>
+            </div>
+          </dl>
+        </section>
+      </section>
+      <section class="simulator" aria-labelledby="simulator-title">
+        <div class="simulator-header">
+          <h2 id="simulator-title">Canine Control Console</h2>
+          <div class="simulator-controls">
+            <button type="button" class="action-button" id="start-patrol">Start Patrol</button>
+            <button type="button" class="action-button" id="reset-trail">Reset Trail</button>
+            <button type="button" class="action-button" id="abort-mission">Abort Mission</button>
+          </div>
+        </div>
+        <p class="simulator-help">
+          Keep the scent trail tight. Each baggie secured slows Jerry’s pulse, but hesitation fills the frustration meter and
+          makes him lunge on instinct. One detonated tunnel ends the night.
+        </p>
+        <div class="status-board" role="group" aria-label="Patrol status">
+          <div class="status-tile">
+            <span class="status-label">Intercept Streak</span>
+            <span class="status-value" id="streak-count">0</span>
+          </div>
+          <div class="status-tile">
+            <span class="status-label">Explosions</span>
+            <span class="status-value" id="explosion-count">0 / 1</span>
+          </div>
+          <div class="status-tile">
+            <span class="status-label">Frustration</span>
+            <div class="status-meter" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" id="frustration-bar">
+              <div class="status-meter-fill" id="frustration-fill"></div>
+            </div>
+            <span class="status-value" id="frustration-value">0%</span>
+          </div>
+          <div class="status-tile">
+            <span class="status-label">Response Time</span>
+            <span class="status-value" id="response-time">0.0s</span>
+          </div>
+        </div>
+        <div class="trail-wrapper">
+          <div class="legend" aria-hidden="true">
+            <span class="legend-item start">Jerry’s Nose</span>
+            <span class="legend-item baggie">Drug Baggie</span>
+            <span class="legend-item tunnel">Explosive Tunnel</span>
+            <span class="legend-item trail">Scent Trail</span>
+          </div>
+          <div class="trail-grid" id="trail-grid" role="grid" aria-label="Warehouse grid"></div>
+          <aside class="intel-panel" aria-label="Intel feed">
+            <h3>Field Log</h3>
+            <ul id="event-log"></ul>
+          </aside>
+        </div>
+        <p class="mission-status" id="mission-status">Press Start Patrol to begin tracing the scent.</p>
+      </section>
+    </main>
+    <footer class="page-footer">
+      <p>
+        Tip: Drop the trail in short bursts while Jerry calms down after a capture. If the frustration meter starts to glow,
+        snag the next baggie fast before his instincts yank you toward the tunnels.
+      </p>
+    </footer>
+    <script type="module" src="nose-for-trouble.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/1989/nose-for-trouble/nose-for-trouble.css
+++ b/madia.new/public/secret/1989/nose-for-trouble/nose-for-trouble.css
@@ -1,0 +1,277 @@
+.trail-wrapper {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) min(16rem, 32vw);
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+  align-items: start;
+}
+
+.trail-grid {
+  --tile-size: clamp(2.35rem, 3.2vw + 1.2rem, 3.8rem);
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(9, var(--tile-size));
+  grid-template-rows: repeat(9, var(--tile-size));
+  gap: 0.4rem;
+  padding: 1.2rem;
+  border-radius: 1.25rem;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.94), rgba(15, 23, 42, 0.78));
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: inset 0 0.75rem 2.5rem rgba(8, 12, 28, 0.4);
+}
+
+.trail-grid.is-erratic {
+  animation: erraticPulse 0.65s ease-in-out infinite;
+}
+
+@keyframes erraticPulse {
+  0% {
+    box-shadow: inset 0 0.75rem 2.5rem rgba(8, 12, 28, 0.4);
+    border-color: rgba(148, 163, 184, 0.35);
+  }
+  50% {
+    box-shadow: inset 0 0.9rem 3.1rem rgba(248, 113, 113, 0.35);
+    border-color: rgba(248, 113, 113, 0.6);
+  }
+  100% {
+    box-shadow: inset 0 0.75rem 2.5rem rgba(8, 12, 28, 0.4);
+    border-color: rgba(148, 163, 184, 0.35);
+  }
+}
+
+.trail-cell {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.9rem;
+  background: rgba(30, 41, 59, 0.86);
+  border: 1px solid rgba(100, 116, 139, 0.35);
+  color: transparent;
+  transition: transform 80ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.trail-cell:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.9);
+  outline-offset: 3px;
+}
+
+.trail-cell[data-available="true"] {
+  border-color: rgba(56, 189, 248, 0.65);
+  box-shadow: 0 0 0.35rem rgba(56, 189, 248, 0.35);
+}
+
+.trail-cell[data-path="true"] {
+  background: linear-gradient(160deg, rgba(56, 189, 248, 0.85), rgba(129, 140, 248, 0.65));
+  border-color: rgba(56, 189, 248, 0.85);
+}
+
+.trail-cell[data-head="true"] {
+  background: linear-gradient(150deg, rgba(59, 130, 246, 0.92), rgba(14, 116, 144, 0.88));
+  transform: scale(1.04);
+  box-shadow: 0 0.55rem 1.35rem rgba(59, 130, 246, 0.35);
+}
+
+.trail-cell[data-start="true"]::after {
+  content: "\1F415";
+  font-size: 1.4rem;
+}
+
+.trail-cell[data-baggie="true"]::after {
+  content: "\1F9C2";
+  font-size: 1.35rem;
+  filter: drop-shadow(0 0.2rem 0.4rem rgba(14, 165, 233, 0.35));
+}
+
+.trail-cell[data-tunnel="true"] {
+  background: repeating-linear-gradient(
+      135deg,
+      rgba(15, 23, 42, 0.15),
+      rgba(15, 23, 42, 0.15) 6px,
+      rgba(94, 234, 212, 0.12) 6px,
+      rgba(94, 234, 212, 0.12) 12px
+    ),
+    rgba(3, 7, 18, 0.8);
+  border-color: rgba(45, 212, 191, 0.55);
+}
+
+.trail-cell[data-tunnel="true"][data-path="true"] {
+  animation: detonate 0.55s ease forwards;
+}
+
+@keyframes detonate {
+  0% {
+    transform: scale(1);
+    background: rgba(248, 113, 113, 0.35);
+  }
+  50% {
+    transform: scale(1.22);
+    background: rgba(248, 113, 113, 0.85);
+    box-shadow: 0 0.65rem 1.4rem rgba(248, 113, 113, 0.65);
+  }
+  100% {
+    transform: scale(1);
+    background: rgba(15, 23, 42, 0.5);
+    border-color: rgba(248, 113, 113, 0.6);
+  }
+}
+
+.trail-cell[data-breach="true"]::after {
+  content: "\1F4A3";
+  font-size: 1.25rem;
+  filter: drop-shadow(0 0.25rem 0.45rem rgba(248, 113, 113, 0.45));
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.8rem;
+  color: rgba(203, 213, 225, 0.78);
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.legend-item::before {
+  content: "";
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background: rgba(148, 163, 184, 0.6);
+  box-shadow: 0 0 0.45rem rgba(148, 163, 184, 0.45);
+}
+
+.legend-item.start::before {
+  background: rgba(59, 130, 246, 0.9);
+}
+
+.legend-item.baggie::before {
+  background: rgba(34, 197, 94, 0.85);
+}
+
+.legend-item.tunnel::before {
+  background: rgba(45, 212, 191, 0.7);
+}
+
+.legend-item.trail::before {
+  background: rgba(244, 114, 182, 0.75);
+}
+
+.intel-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 0.6rem 1.6rem rgba(8, 11, 25, 0.4);
+}
+
+.intel-panel h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: rgba(248, 250, 252, 0.88);
+}
+
+#event-log {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.55rem;
+  font-size: 0.82rem;
+  color: rgba(226, 232, 240, 0.82);
+  max-height: 16rem;
+  overflow-y: auto;
+}
+
+#event-log li {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.4rem 0.55rem;
+  border-radius: 0.6rem;
+  background: rgba(30, 41, 59, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+#event-log li[data-tone="success"] {
+  border-color: rgba(34, 197, 94, 0.45);
+  box-shadow: 0 0.25rem 0.85rem rgba(34, 197, 94, 0.15);
+}
+
+#event-log li[data-tone="warning"] {
+  border-color: rgba(251, 191, 36, 0.45);
+  box-shadow: 0 0.25rem 0.85rem rgba(251, 191, 36, 0.15);
+}
+
+#event-log li[data-tone="danger"] {
+  border-color: rgba(248, 113, 113, 0.55);
+  box-shadow: 0 0.25rem 0.85rem rgba(248, 113, 113, 0.2);
+}
+
+#event-log time {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(148, 163, 184, 0.72);
+}
+
+#event-log span {
+  flex: 1;
+}
+
+.mission-status {
+  margin-top: 1.5rem;
+  padding: 0.85rem 1rem;
+  border-radius: 0.85rem;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: rgba(226, 232, 240, 0.85);
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.mission-status[data-tone="success"] {
+  border-color: rgba(34, 197, 94, 0.55);
+  box-shadow: 0 0.65rem 1.35rem rgba(34, 197, 94, 0.18);
+  color: rgba(190, 242, 100, 0.92);
+}
+
+.mission-status[data-tone="warning"] {
+  border-color: rgba(251, 191, 36, 0.55);
+  box-shadow: 0 0.65rem 1.35rem rgba(251, 191, 36, 0.18);
+  color: rgba(253, 230, 138, 0.95);
+}
+
+.mission-status[data-tone="danger"] {
+  border-color: rgba(248, 113, 113, 0.65);
+  box-shadow: 0 0.65rem 1.35rem rgba(248, 113, 113, 0.2);
+  color: rgba(254, 202, 202, 0.95);
+}
+
+@media (max-width: 960px) {
+  .trail-wrapper {
+    grid-template-columns: 1fr;
+  }
+
+  .intel-panel {
+    order: -1;
+  }
+}
+
+@media (max-width: 640px) {
+  .trail-grid {
+    --tile-size: clamp(2.2rem, 5vw + 0.6rem, 3.2rem);
+    gap: 0.3rem;
+  }
+}

--- a/madia.new/public/secret/1989/nose-for-trouble/nose-for-trouble.js
+++ b/madia.new/public/secret/1989/nose-for-trouble/nose-for-trouble.js
@@ -1,0 +1,568 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+import { mountParticleField } from "../particles.js";
+
+const particleSystem = mountParticleField({
+  effects: {
+    palette: ["#38bdf8", "#f472b6", "#facc15", "#34d399"],
+    ambientDensity: 0.6,
+  },
+});
+
+const scoreConfig = getScoreConfig("nose-for-trouble");
+const highScore = initHighScoreBanner({
+  gameId: "nose-for-trouble",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
+const GRID_SIZE = 9;
+const START_CELL = { row: 8, col: 1 };
+const MAX_EXPLOSIONS = 1;
+const PATH_COOLDOWN = 45;
+const ERRATIC_THRESHOLD = 100;
+const CALM_THRESHOLD = 45;
+const METER_TICK = 280;
+const ERRATIC_LURCH_DELAY = 140;
+
+const TUNNEL_POSITIONS = [
+  [0, 2],
+  [0, 3],
+  [0, 5],
+  [0, 6],
+  [1, 1],
+  [1, 4],
+  [1, 7],
+  [2, 3],
+  [2, 5],
+  [3, 1],
+  [3, 2],
+  [3, 6],
+  [3, 7],
+  [4, 4],
+  [4, 6],
+  [5, 1],
+  [5, 3],
+  [5, 5],
+  [6, 2],
+  [6, 6],
+  [7, 4],
+  [7, 7],
+  [8, 4],
+  [8, 6],
+];
+
+const TUNNEL_CELLS = new Set(TUNNEL_POSITIONS.map(([row, col]) => `${row},${col}`));
+
+const boardElement = document.getElementById("trail-grid");
+const missionStatusElement = document.getElementById("mission-status");
+const streakElement = document.getElementById("streak-count");
+const explosionElement = document.getElementById("explosion-count");
+const frustrationFill = document.getElementById("frustration-fill");
+const frustrationBar = document.getElementById("frustration-bar");
+const frustrationValue = document.getElementById("frustration-value");
+const responseTimeElement = document.getElementById("response-time");
+const eventLogElement = document.getElementById("event-log");
+
+const startButton = document.getElementById("start-patrol");
+const resetTrailButton = document.getElementById("reset-trail");
+const abortButton = document.getElementById("abort-mission");
+
+const cellElements = [];
+
+const state = {
+  patrolActive: false,
+  boardLocked: false,
+  path: [],
+  baggie: null,
+  lastBaggieKey: null,
+  frustration: 0,
+  erratic: false,
+  streak: 0,
+  explosions: 0,
+  breachKey: null,
+  meterTimer: null,
+  responseTimer: null,
+  responseStartedAt: 0,
+  log: [],
+};
+
+initializeBoard();
+renderBoard();
+updateFrustration();
+updateStats();
+renderLog();
+setMissionStatus("Press Start Patrol to begin tracing the scent.");
+
+startButton.addEventListener("click", () => {
+  startPatrol();
+});
+
+resetTrailButton.addEventListener("click", () => {
+  if (!state.patrolActive) {
+    return;
+  }
+  resetTrail();
+  addLog("Trail reset to the nose. Recenter your sweep.", "warning");
+  setMissionStatus("Trail reset. Plot a clean route to the active baggie.", "warning");
+});
+
+abortButton.addEventListener("click", () => {
+  if (!state.patrolActive) {
+    return;
+  }
+  abortMission("Patrol aborted. Jerry Lee is standing down.");
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.defaultPrevented) {
+    return;
+  }
+  if (!state.patrolActive) {
+    if (event.key === "Enter" && startButton === document.activeElement) {
+      startPatrol();
+      event.preventDefault();
+    }
+    return;
+  }
+  if (event.key === "Backspace") {
+    event.preventDefault();
+    backtrackStep();
+  } else if (event.key === "Escape") {
+    event.preventDefault();
+    abortMission("Patrol aborted. Jerry Lee is standing down.");
+  }
+});
+
+function initializeBoard() {
+  boardElement.innerHTML = "";
+  cellElements.length = 0;
+  for (let row = 0; row < GRID_SIZE; row += 1) {
+    const rowElements = [];
+    for (let col = 0; col < GRID_SIZE; col += 1) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "trail-cell";
+      button.dataset.row = String(row);
+      button.dataset.col = String(col);
+      button.setAttribute("role", "gridcell");
+      button.setAttribute("aria-label", `Row ${row + 1}, column ${col + 1}`);
+      button.addEventListener("pointerenter", handleCellPointerEnter);
+      button.addEventListener("click", handleCellClick);
+      boardElement.append(button);
+      rowElements.push(button);
+    }
+    cellElements.push(rowElements);
+  }
+}
+
+function startPatrol() {
+  state.patrolActive = true;
+  state.boardLocked = false;
+  state.path = [{ ...START_CELL }];
+  state.baggie = null;
+  state.lastBaggieKey = null;
+  state.frustration = 0;
+  state.erratic = false;
+  state.streak = 0;
+  state.explosions = 0;
+  state.breachKey = null;
+  state.log = [];
+  boardElement.classList.remove("is-erratic");
+  addLog("Patrol engaged. Jerry Lee is on the scent.", "success");
+  setMissionStatus("Scent trail live. Track the first baggie.", "success");
+  spawnBaggie();
+  updateFrustration();
+  updateStats();
+  renderBoard();
+  renderLog();
+  startFrustrationLoop();
+  restartResponseTimer();
+}
+
+function abortMission(message) {
+  state.patrolActive = false;
+  state.boardLocked = true;
+  stopFrustrationLoop();
+  stopResponseTimer();
+  boardElement.classList.remove("is-erratic");
+  setMissionStatus(message, "warning");
+  addLog(message, "warning");
+}
+
+function resetTrail() {
+  state.path = [{ ...START_CELL }];
+  state.breachKey = null;
+  renderBoard();
+}
+
+function backtrackStep() {
+  if (!state.patrolActive || state.path.length <= 1) {
+    return;
+  }
+  state.path.pop();
+  renderBoard();
+  setMissionStatus("Trail shortened. Plot the next move.");
+}
+
+function handleCellClick(event) {
+  if (!state.patrolActive || state.boardLocked) {
+    return;
+  }
+  const cell = event.currentTarget;
+  const row = Number.parseInt(cell.dataset.row ?? "-1", 10);
+  const col = Number.parseInt(cell.dataset.col ?? "-1", 10);
+  attemptStep(row, col);
+}
+
+function handleCellPointerEnter(event) {
+  if (!state.patrolActive || state.boardLocked) {
+    return;
+  }
+  if (!(event.buttons & 1)) {
+    return;
+  }
+  const cell = event.currentTarget;
+  const row = Number.parseInt(cell.dataset.row ?? "-1", 10);
+  const col = Number.parseInt(cell.dataset.col ?? "-1", 10);
+  attemptStep(row, col);
+}
+
+function attemptStep(row, col, options = {}) {
+  if (!state.patrolActive || state.boardLocked) {
+    return false;
+  }
+  if (!Number.isInteger(row) || !Number.isInteger(col)) {
+    return false;
+  }
+  if (row < 0 || row >= GRID_SIZE || col < 0 || col >= GRID_SIZE) {
+    return false;
+  }
+  const head = state.path[state.path.length - 1];
+  if (!head) {
+    return false;
+  }
+  if (head.row === row && head.col === col) {
+    return false;
+  }
+  const isAdjacent = Math.abs(head.row - row) + Math.abs(head.col - col) === 1;
+  if (!isAdjacent) {
+    return false;
+  }
+  const key = `${row},${col}`;
+  const isBaggieCell = state.baggie && state.baggie.row === row && state.baggie.col === col;
+  const alreadyVisited = state.path.some((cell) => cell.row === row && cell.col === col);
+  if (alreadyVisited && !isBaggieCell) {
+    return false;
+  }
+  state.path.push({ row, col });
+  renderBoard();
+
+  if (TUNNEL_CELLS.has(key)) {
+    triggerExplosion(key);
+    return true;
+  }
+
+  if (isBaggieCell) {
+    interceptBaggie();
+    return true;
+  }
+
+  if (state.erratic && !options.suppressErratic) {
+    scheduleErraticLurch();
+  }
+
+  return true;
+}
+
+function triggerExplosion(key) {
+  state.explosions += 1;
+  state.breachKey = key;
+  renderBoard();
+  stopFrustrationLoop();
+  stopResponseTimer();
+  setMissionStatus("Tunnel breach! Mission compromised.", "danger");
+  addLog("Explosive tunnel detonated. Evidence lost in the blast.", "danger");
+  explosionElement.textContent = `${state.explosions} / ${MAX_EXPLOSIONS}`;
+  state.boardLocked = true;
+  state.patrolActive = false;
+  boardElement.classList.remove("is-erratic");
+}
+
+function interceptBaggie() {
+  state.streak += 1;
+  highScore.submit(state.streak, {
+    response: Number.isFinite(state.responseStartedAt)
+      ? Math.max(0, Math.round((performance.now() - state.responseStartedAt) / 100) / 10)
+      : 0,
+  });
+  addLog(`Baggie secured. Streak now ${state.streak}.`, "success");
+  setMissionStatus(`Intercept locked. ${state.streak} baggies in a row.`, "success");
+  state.frustration = Math.max(0, state.frustration - PATH_COOLDOWN);
+  updateFrustration();
+  if (state.erratic && state.frustration <= CALM_THRESHOLD) {
+    state.erratic = false;
+    boardElement.classList.remove("is-erratic");
+    addLog("Jerry calms down. Trail steady again.", "success");
+  }
+  state.path = [{ ...START_CELL }];
+  state.lastBaggieKey = state.baggie ? `${state.baggie.row},${state.baggie.col}` : null;
+  state.baggie = null;
+  state.breachKey = null;
+  spawnBaggie();
+  renderBoard();
+  updateStats();
+  restartResponseTimer();
+}
+
+function spawnBaggie() {
+  const available = [];
+  for (let row = 0; row < GRID_SIZE; row += 1) {
+    for (let col = 0; col < GRID_SIZE; col += 1) {
+      const key = `${row},${col}`;
+      if (TUNNEL_CELLS.has(key)) {
+        continue;
+      }
+      if (row === START_CELL.row && col === START_CELL.col) {
+        continue;
+      }
+      if (state.path.some((segment) => segment.row === row && segment.col === col)) {
+        continue;
+      }
+      if (state.lastBaggieKey && state.lastBaggieKey === key) {
+        continue;
+      }
+      available.push({ row, col });
+    }
+  }
+  if (available.length === 0) {
+    state.baggie = null;
+    return;
+  }
+  const choice = available[Math.floor(Math.random() * available.length)];
+  state.baggie = choice;
+  state.responseStartedAt = performance.now();
+  updateStats();
+  renderBoard();
+  responseTimeElement.textContent = "0.0s";
+}
+
+function startFrustrationLoop() {
+  stopFrustrationLoop();
+  state.meterTimer = window.setInterval(() => {
+    if (!state.patrolActive || state.boardLocked) {
+      return;
+    }
+    const delta = state.erratic ? 2.5 : 1.6;
+    state.frustration = Math.min(ERRATIC_THRESHOLD, state.frustration + delta);
+    updateFrustration();
+    if (state.frustration >= ERRATIC_THRESHOLD && !state.erratic) {
+      enterErraticMode();
+    }
+  }, METER_TICK);
+}
+
+function stopFrustrationLoop() {
+  if (state.meterTimer) {
+    window.clearInterval(state.meterTimer);
+    state.meterTimer = null;
+  }
+}
+
+function restartResponseTimer() {
+  stopResponseTimer();
+  state.responseStartedAt = performance.now();
+  state.responseTimer = window.setInterval(() => {
+    if (!state.patrolActive || state.boardLocked || !state.responseStartedAt) {
+      responseTimeElement.textContent = "0.0s";
+      return;
+    }
+    const elapsed = Math.max(0, performance.now() - state.responseStartedAt);
+    responseTimeElement.textContent = `${(Math.round(elapsed / 100) / 10).toFixed(1)}s`;
+  }, 120);
+}
+
+function stopResponseTimer() {
+  if (state.responseTimer) {
+    window.clearInterval(state.responseTimer);
+    state.responseTimer = null;
+  }
+  responseTimeElement.textContent = "0.0s";
+}
+
+function enterErraticMode() {
+  state.erratic = true;
+  boardElement.classList.add("is-erratic");
+  addLog("Frustration maxed. Jerry is lunging on instinct!", "warning");
+  setMissionStatus("Frustration spike! Guide Jerry before he bolts into a tunnel.", "warning");
+  scheduleErraticLurch();
+}
+
+function scheduleErraticLurch() {
+  window.setTimeout(() => {
+    if (!state.erratic || !state.patrolActive || state.boardLocked) {
+      return;
+    }
+    const head = state.path[state.path.length - 1];
+    if (!head) {
+      return;
+    }
+    const neighbors = getNeighbors(head).filter((cell) => {
+      if (!cell) {
+        return false;
+      }
+      const key = `${cell.row},${cell.col}`;
+      if (TUNNEL_CELLS.has(key)) {
+        return true;
+      }
+      if (state.path.some((segment) => segment.row === cell.row && segment.col === cell.col)) {
+        return false;
+      }
+      return true;
+    });
+    if (neighbors.length === 0) {
+      return;
+    }
+    const choice = neighbors[Math.floor(Math.random() * neighbors.length)];
+    attemptStep(choice.row, choice.col, { suppressErratic: true });
+  }, ERRATIC_LURCH_DELAY);
+}
+
+function getNeighbors(cell) {
+  if (!cell) {
+    return [];
+  }
+  return [
+    { row: cell.row - 1, col: cell.col },
+    { row: cell.row + 1, col: cell.col },
+    { row: cell.row, col: cell.col - 1 },
+    { row: cell.row, col: cell.col + 1 },
+  ].filter((candidate) => candidate.row >= 0 && candidate.row < GRID_SIZE && candidate.col >= 0 && candidate.col < GRID_SIZE);
+}
+
+function updateFrustration() {
+  frustrationFill.style.width = `${state.frustration}%`;
+  frustrationValue.textContent = `${Math.round(state.frustration)}%`;
+  frustrationBar.setAttribute("aria-valuenow", String(Math.round(state.frustration)));
+}
+
+function updateStats() {
+  streakElement.textContent = String(state.streak);
+  explosionElement.textContent = `${state.explosions} / ${MAX_EXPLOSIONS}`;
+  if (!state.patrolActive || !state.responseStartedAt) {
+    responseTimeElement.textContent = "0.0s";
+  }
+}
+
+function renderBoard() {
+  for (let row = 0; row < GRID_SIZE; row += 1) {
+    for (let col = 0; col < GRID_SIZE; col += 1) {
+      const cell = cellElements[row][col];
+      const key = `${row},${col}`;
+      if (row === START_CELL.row && col === START_CELL.col) {
+        cell.dataset.start = "true";
+      } else {
+        delete cell.dataset.start;
+      }
+      if (state.baggie && state.baggie.row === row && state.baggie.col === col) {
+        cell.dataset.baggie = "true";
+      } else {
+        delete cell.dataset.baggie;
+      }
+      if (TUNNEL_CELLS.has(key)) {
+        cell.dataset.tunnel = "true";
+      } else {
+        delete cell.dataset.tunnel;
+      }
+      if (state.breachKey === key) {
+        cell.dataset.breach = "true";
+      } else {
+        delete cell.dataset.breach;
+      }
+      delete cell.dataset.path;
+      delete cell.dataset.head;
+      delete cell.dataset.available;
+    }
+  }
+  state.path.forEach((segment, index) => {
+    const cell = cellElements[segment.row]?.[segment.col];
+    if (!cell) {
+      return;
+    }
+    cell.dataset.path = "true";
+    if (index === state.path.length - 1) {
+      cell.dataset.head = "true";
+    } else {
+      delete cell.dataset.head;
+    }
+  });
+  const head = state.path[state.path.length - 1];
+  if (head) {
+    const neighbors = getNeighbors(head);
+    neighbors.forEach((neighbor) => {
+      const cell = cellElements[neighbor.row]?.[neighbor.col];
+      if (!cell) {
+        return;
+      }
+      const key = `${neighbor.row},${neighbor.col}`;
+      if (state.path.some((segment) => segment.row === neighbor.row && segment.col === neighbor.col)) {
+        return;
+      }
+      if (state.baggie && state.baggie.row === neighbor.row && state.baggie.col === neighbor.col) {
+        cell.dataset.available = "true";
+        return;
+      }
+      if (TUNNEL_CELLS.has(key)) {
+        cell.dataset.available = "true";
+        return;
+      }
+      cell.dataset.available = "true";
+    });
+  }
+}
+
+function renderLog() {
+  eventLogElement.innerHTML = "";
+  state.log.forEach((entry) => {
+    const item = document.createElement("li");
+    if (entry.tone) {
+      item.dataset.tone = entry.tone;
+    }
+    const time = document.createElement("time");
+    time.dateTime = entry.timestamp.toISOString();
+    time.textContent = entry.timestamp.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+    const message = document.createElement("span");
+    message.textContent = entry.message;
+    item.append(time, message);
+    eventLogElement.prepend(item);
+  });
+}
+
+function addLog(message, tone = "info") {
+  const entry = {
+    message,
+    tone,
+    timestamp: new Date(),
+  };
+  state.log.push(entry);
+  if (state.log.length > 12) {
+    state.log.shift();
+  }
+  renderLog();
+}
+
+function setMissionStatus(message, tone = "info") {
+  missionStatusElement.textContent = message;
+  if (tone && tone !== "info") {
+    missionStatusElement.dataset.tone = tone;
+  } else {
+    delete missionStatusElement.dataset.tone;
+  }
+}
+
+window.addEventListener("beforeunload", () => {
+  particleSystem?.destroy?.();
+  stopFrustrationLoop();
+  stopResponseTimer();
+});

--- a/madia.new/public/secret/1989/score-config.js
+++ b/madia.new/public/secret/1989/score-config.js
@@ -62,6 +62,12 @@ export const scoreConfigs = {
     format: ({ value }) =>
       value === 1 ? "1 trap" : `${value ?? 0} traps`,
   },
+  "nose-for-trouble": {
+    label: "Intercept Streak",
+    empty: "No intercepts logged yet.",
+    format: ({ value }) =>
+      value === 1 ? "1 intercept" : `${value ?? 0} intercepts`,
+  },
   "say-anything": {
     label: "Peak Flow",
     empty: "No sync sessions yet.",


### PR DESCRIPTION
## Summary
- add the Nose for Trouble level with a scent-trail flow puzzle, frustration meter, and explosive tunnel hazards
- style the warehouse grid, legend, and mission status treatments for the new stage
- register the cabinet and score config so the level appears in the 1989 arcade

## Testing
- node --check madia.new/public/secret/1989/nose-for-trouble/nose-for-trouble.js

------
https://chatgpt.com/codex/tasks/task_e_68e00c64438883289b83ba966fe67810