### PR TITLE
Add shared arcade feedback enhancer

### DIFF
--- a/madia.new/public/secret/1989/amore-express/amore-express.js
+++ b/madia.new/public/secret/1989/amore-express/amore-express.js
@@ -2,6 +2,8 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 
+import { autoEnhanceFeedback } from "../feedback.js";
+
 const particleSystem = mountParticleField({
   effects: {
     palette: ["#f97316", "#38bdf8", "#facc15", "#fb7185"],
@@ -588,3 +590,4 @@ function edgeKey(a, b) {
   return `${first.row},${first.col}|${second.row},${second.col}`;
 }
 
+autoEnhanceFeedback();

--- a/madia.new/public/secret/1989/blaze/blaze.js
+++ b/madia.new/public/secret/1989/blaze/blaze.js
@@ -2,6 +2,8 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 
+import { autoEnhanceFeedback } from "../feedback.js";
+
 const particleSystem = mountParticleField({
   effects: {
     palette: ["#f97316", "#facc15", "#38bdf8", "#fda4af"],
@@ -709,3 +711,5 @@ document.addEventListener("keydown", (event) => {
 });
 
 resetState();
+
+autoEnhanceFeedback();

--- a/madia.new/public/secret/1989/cable-clash/cable-clash.js
+++ b/madia.new/public/secret/1989/cable-clash/cable-clash.js
@@ -2,6 +2,8 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 
+import { autoEnhanceFeedback } from "../feedback.js";
+
 const particleSystem = mountParticleField({
   effects: {
     palette: ["#38bdf8", "#f472b6", "#facc15", "#f97316"],
@@ -509,3 +511,5 @@ document.addEventListener("keydown", (event) => {
 });
 
 resetState();
+
+autoEnhanceFeedback();

--- a/madia.new/public/secret/1989/captains-echo/captains-echo.js
+++ b/madia.new/public/secret/1989/captains-echo/captains-echo.js
@@ -2,6 +2,8 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 
+import { autoEnhanceFeedback } from "../feedback.js";
+
 const particleSystem = mountParticleField({
   effects: {
     palette: ["#38bdf8", "#f472b6", "#facc15", "#fb7185"],
@@ -445,3 +447,5 @@ resetButton.addEventListener("click", () => {
   logEvent("Board cleared. Ready for a new attempt.");
 });
 loadButton.addEventListener("click", loadFacultyPlan);
+
+autoEnhanceFeedback();

--- a/madia.new/public/secret/1989/common.css
+++ b/madia.new/public/secret/1989/common.css
@@ -94,3 +94,198 @@ button {
     scroll-behavior: auto !important;
   }
 }
+
+.feedback-status {
+  --feedback-color: rgba(148, 163, 184, 0.65);
+  --feedback-glow: rgba(59, 130, 246, 0.2);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.94), rgba(30, 41, 59, 0.92));
+  border: 1px solid var(--feedback-color);
+  box-shadow: 0 18px 36px rgba(2, 6, 23, 0.35);
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  transition: background 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease,
+    color 0.3s ease, transform 0.3s ease;
+}
+
+.feedback-status::before {
+  content: attr(data-feedback-icon);
+  font-size: 1.35rem;
+  line-height: 1;
+  filter: drop-shadow(0 0 12px rgba(56, 189, 248, 0.4));
+  opacity: 0.9;
+}
+
+.feedback-status::after {
+  content: "";
+  position: absolute;
+  inset: -45% -40%;
+  background: radial-gradient(circle at center, var(--feedback-glow), transparent 70%);
+  opacity: 0;
+  transform: scale(0.75);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.feedback-status[data-feedback-tone="success"] {
+  --feedback-color: rgba(34, 197, 94, 0.5);
+  --feedback-glow: rgba(34, 197, 94, 0.28);
+  color: #ecfdf5;
+}
+
+.feedback-status[data-feedback-tone="warning"] {
+  --feedback-color: rgba(249, 115, 22, 0.55);
+  --feedback-glow: rgba(249, 115, 22, 0.28);
+  color: #fff7ed;
+}
+
+.feedback-status[data-feedback-tone="danger"] {
+  --feedback-color: rgba(248, 113, 113, 0.55);
+  --feedback-glow: rgba(248, 113, 113, 0.3);
+  color: #fee2e2;
+}
+
+.feedback-status[data-feedback-tone="info"] {
+  --feedback-color: rgba(56, 189, 248, 0.45);
+  --feedback-glow: rgba(56, 189, 248, 0.24);
+  color: #e0f2fe;
+}
+
+.feedback-status.feedback-status-pulse {
+  animation: feedback-status-lift 0.8s ease;
+}
+
+.feedback-status.feedback-status-pulse::after {
+  animation: feedback-status-ripple 0.8s ease;
+}
+
+@keyframes feedback-status-lift {
+  0% {
+    transform: translateY(0) scale(1);
+    box-shadow: 0 18px 36px rgba(2, 6, 23, 0.35);
+  }
+  35% {
+    transform: translateY(-2px) scale(1.01);
+    box-shadow: 0 22px 44px rgba(2, 6, 23, 0.45);
+  }
+  100% {
+    transform: translateY(0) scale(1);
+    box-shadow: 0 18px 36px rgba(2, 6, 23, 0.35);
+  }
+}
+
+@keyframes feedback-status-ripple {
+  0% {
+    opacity: 0.75;
+    transform: scale(0.6);
+  }
+  70% {
+    opacity: 0.15;
+    transform: scale(1.05);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.15);
+  }
+}
+
+.feedback-log {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.feedback-log-entry {
+  --feedback-log-glow: rgba(56, 189, 248, 0.16);
+  position: relative;
+  padding: 0.55rem 0.75rem 0.55rem 2.75rem;
+  border-radius: 12px;
+  background: linear-gradient(130deg, rgba(15, 23, 42, 0.88), rgba(30, 41, 59, 0.82));
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  box-shadow: 0 10px 26px rgba(2, 6, 23, 0.28);
+  transition: transform 0.3s ease, border-color 0.3s ease, background 0.3s ease;
+  overflow: hidden;
+}
+
+.feedback-log-entry::before {
+  content: attr(data-feedback-icon);
+  position: absolute;
+  left: 1.1rem;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 1rem;
+  line-height: 1;
+  filter: drop-shadow(0 0 10px rgba(56, 189, 248, 0.4));
+  opacity: 0.9;
+}
+
+.feedback-log-entry::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at left, var(--feedback-log-glow), transparent 65%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.feedback-log-entry[data-feedback-tone="success"] {
+  --feedback-log-glow: rgba(34, 197, 94, 0.22);
+  border-color: rgba(34, 197, 94, 0.45);
+}
+
+.feedback-log-entry[data-feedback-tone="warning"] {
+  --feedback-log-glow: rgba(249, 115, 22, 0.22);
+  border-color: rgba(249, 115, 22, 0.45);
+}
+
+.feedback-log-entry[data-feedback-tone="danger"] {
+  --feedback-log-glow: rgba(248, 113, 113, 0.24);
+  border-color: rgba(248, 113, 113, 0.45);
+}
+
+.feedback-log-entry[data-feedback-tone="info"] {
+  --feedback-log-glow: rgba(56, 189, 248, 0.2);
+  border-color: rgba(56, 189, 248, 0.38);
+}
+
+.feedback-log-entry.feedback-log-pulse {
+  animation: feedback-log-rise 0.75s ease;
+}
+
+.feedback-log-entry.feedback-log-pulse::after {
+  opacity: 0.85;
+}
+
+@keyframes feedback-log-rise {
+  0% {
+    transform: translateY(6px);
+    opacity: 0;
+  }
+  40% {
+    transform: translateY(-1px);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .feedback-status,
+  .feedback-log-entry {
+    transition: none;
+    animation-duration: 0.01ms !important;
+  }
+}

--- a/madia.new/public/secret/1989/cooler-chaos/cooler-chaos.js
+++ b/madia.new/public/secret/1989/cooler-chaos/cooler-chaos.js
@@ -2,6 +2,8 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 
+import { autoEnhanceFeedback } from "../feedback.js";
+
 const particleSystem = mountParticleField({
   effects: {
     palette: ["#38bdf8", "#f97316", "#facc15", "#fda4af"],
@@ -582,3 +584,5 @@ function shuffle(values) {
   }
   return copy;
 }
+
+autoEnhanceFeedback();

--- a/madia.new/public/secret/1989/culdesac-curiosity/culdesac-curiosity.js
+++ b/madia.new/public/secret/1989/culdesac-curiosity/culdesac-curiosity.js
@@ -2,6 +2,8 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 
+import { autoEnhanceFeedback } from "../feedback.js";
+
 const particleSystem = mountParticleField({
   effects: {
     palette: ["#38bdf8", "#c084fc", "#facc15", "#f97316"],
@@ -678,3 +680,5 @@ failureResetButton.addEventListener("click", resetGame);
 resetButton.addEventListener("click", resetGame);
 
 resetGame();
+
+autoEnhanceFeedback();

--- a/madia.new/public/secret/1989/dream-team-breakout/dream-team-breakout.js
+++ b/madia.new/public/secret/1989/dream-team-breakout/dream-team-breakout.js
@@ -2,6 +2,8 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 
+import { autoEnhanceFeedback } from "../feedback.js";
+
 const particleSystem = mountParticleField({
   effects: {
     palette: ["#38bdf8", "#34d399", "#facc15", "#f97316"],
@@ -898,3 +900,5 @@ buildPlanner();
 renderWildcardSequence();
 resetPlanner();
 showInitialState();
+
+autoEnhanceFeedback();

--- a/madia.new/public/secret/1989/feedback.js
+++ b/madia.new/public/secret/1989/feedback.js
@@ -1,0 +1,232 @@
+const toneAliases = {
+  neutral: "neutral",
+  info: "info",
+  success: "success",
+  positive: "success",
+  victory: "success",
+  warning: "warning",
+  caution: "warning",
+  alert: "warning",
+  danger: "danger",
+  negative: "danger",
+  failure: "danger",
+};
+
+const toneIcons = {
+  neutral: "✶",
+  info: "✷",
+  success: "✦",
+  warning: "⚠",
+  danger: "✖",
+};
+
+function normalizeTone(tone = "neutral") {
+  const key = String(tone).toLowerCase();
+  return toneAliases[key] ?? (toneIcons[key] ? key : "neutral");
+}
+
+function setToneData(element, tone) {
+  element.dataset.feedbackTone = tone;
+  element.dataset.feedbackIcon = toneIcons[tone] ?? toneIcons.neutral;
+}
+
+function pulse(element, className) {
+  element.classList.remove(className);
+  // eslint-disable-next-line no-unused-expressions
+  element.offsetWidth;
+  element.classList.add(className);
+}
+
+function detectToneFromElement(element) {
+  if (!element) {
+    return "neutral";
+  }
+  const dataTone = element.dataset.tone || element.dataset.statusTone || element.dataset.feedbackTone;
+  if (dataTone) {
+    return normalizeTone(dataTone);
+  }
+  const classes = Array.from(element.classList);
+  if (classes.some((cls) => ["success", "is-success", "positive", "is-positive"].includes(cls))) {
+    return "success";
+  }
+  if (classes.some((cls) => ["warning", "is-warning", "caution"].includes(cls))) {
+    return "warning";
+  }
+  if (classes.some((cls) => ["danger", "is-danger", "failure", "error", "negative", "is-negative"].includes(cls))) {
+    return "danger";
+  }
+  return "neutral";
+}
+
+function ensureStatusRole(element) {
+  if (!element.hasAttribute("role")) {
+    element.setAttribute("role", "status");
+  }
+  element.setAttribute("aria-live", "polite");
+}
+
+function decorateStatusElement(element) {
+  if (!element || element.dataset.feedbackDecorated === "status") {
+    return;
+  }
+  element.dataset.feedbackDecorated = "status";
+  element.classList.add("feedback-status");
+  ensureStatusRole(element);
+  const tone = detectToneFromElement(element);
+  setToneData(element, tone);
+  const observer = new MutationObserver(() => {
+    const updatedTone = detectToneFromElement(element);
+    setToneData(element, updatedTone);
+    pulse(element, "feedback-status-pulse");
+  });
+  observer.observe(element, {
+    childList: true,
+    characterData: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["class", "data-tone", "data-status-tone"],
+  });
+}
+
+function decorateLogEntry(entry) {
+  if (!(entry instanceof HTMLElement) || entry.dataset.feedbackDecorated === "log-entry") {
+    return;
+  }
+  entry.dataset.feedbackDecorated = "log-entry";
+  const tone = detectToneFromElement(entry);
+  entry.classList.add("feedback-log-entry");
+  setToneData(entry, tone);
+  pulse(entry, "feedback-log-pulse");
+}
+
+function decorateLogList(list) {
+  if (!list || list.dataset.feedbackDecorated === "log") {
+    return;
+  }
+  list.dataset.feedbackDecorated = "log";
+  list.classList.add("feedback-log");
+  Array.from(list.children).forEach((child) => {
+    if (child instanceof HTMLElement) {
+      decorateLogEntry(child);
+    }
+  });
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      mutation.addedNodes.forEach((node) => {
+        if (node instanceof HTMLElement) {
+          decorateLogEntry(node);
+        }
+      });
+    });
+  });
+  observer.observe(list, { childList: true });
+}
+
+export function createStatusChannel(statusElement, { onTone } = {}) {
+  if (!statusElement) {
+    return () => {};
+  }
+  statusElement.classList.add("feedback-status");
+  if (!statusElement.hasAttribute("role")) {
+    statusElement.setAttribute("role", "status");
+  }
+  statusElement.setAttribute("aria-live", "polite");
+  setToneData(statusElement, "neutral");
+  return (message, tone = "neutral") => {
+    const normalized = normalizeTone(tone);
+    statusElement.textContent = message;
+    setToneData(statusElement, normalized);
+    pulse(statusElement, "feedback-status-pulse");
+    if (typeof onTone === "function") {
+      onTone(normalized, { message, element: statusElement });
+    }
+  };
+}
+
+export function createLogChannel(
+  listElement,
+  { limit = 12, mode = "append", onTone } = {}
+) {
+  if (!listElement) {
+    return {
+      push() {
+        return null;
+      },
+      decorate() {},
+    };
+  }
+  listElement.classList.add("feedback-log");
+
+  function trim() {
+    while (listElement.children.length > limit) {
+      if (mode === "prepend") {
+        listElement.removeChild(listElement.lastElementChild);
+      } else {
+        listElement.removeChild(listElement.firstElementChild);
+      }
+    }
+  }
+
+  function insert(entry) {
+    if (mode === "prepend") {
+      listElement.prepend(entry);
+    } else {
+      listElement.append(entry);
+      listElement.scrollTop = listElement.scrollHeight;
+    }
+    trim();
+  }
+
+  function decorate(entry, tone = "info") {
+    if (!entry) {
+      return null;
+    }
+    const normalized = normalizeTone(tone);
+    entry.classList.add("feedback-log-entry");
+    setToneData(entry, normalized);
+    pulse(entry, "feedback-log-pulse");
+    if (typeof onTone === "function") {
+      onTone(normalized, { entry });
+    }
+    return entry;
+  }
+
+  function push(message, tone = "info") {
+    const entry = document.createElement("li");
+    entry.textContent = message;
+    decorate(entry, tone);
+    insert(entry);
+    return entry;
+  }
+
+  return { push, decorate };
+}
+
+const DEFAULT_STATUS_SELECTORS = [
+  "#status-bar",
+  "#status-readout",
+  ".status-readout",
+  "#status-message",
+  "#status-banner",
+  "#operation-status",
+  "#chain-status",
+  "#target-callout",
+];
+
+const DEFAULT_LOG_SELECTORS = ["#event-log", "#event-list", "#log-entries"];
+
+export function autoEnhanceFeedback({
+  statusSelectors = DEFAULT_STATUS_SELECTORS,
+  logSelectors = DEFAULT_LOG_SELECTORS,
+} = {}) {
+  statusSelectors.forEach((selector) => {
+    document.querySelectorAll(selector).forEach((element) => {
+      decorateStatusElement(element);
+    });
+  });
+  logSelectors.forEach((selector) => {
+    document.querySelectorAll(selector).forEach((list) => {
+      decorateLogList(list);
+    });
+  });
+}

--- a/madia.new/public/secret/1989/gates-of-eastside/gates-of-eastside.js
+++ b/madia.new/public/secret/1989/gates-of-eastside/gates-of-eastside.js
@@ -2,6 +2,8 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 
+import { autoEnhanceFeedback } from "../feedback.js";
+
 const particleSystem = mountParticleField({
   effects: {
     palette: ["#38bdf8", "#facc15", "#fb7185", "#34d399"],
@@ -450,3 +452,5 @@ function activateChain() {
   updateStatus("Gates chained. New trouble frozen for a moment.", "success");
   logEvent("Chained the gates. Troublemaker spawns paused.");
 }
+
+autoEnhanceFeedback();

--- a/madia.new/public/secret/1989/halo-hustle/halo-hustle.js
+++ b/madia.new/public/secret/1989/halo-hustle/halo-hustle.js
@@ -2,6 +2,8 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 
+import { autoEnhanceFeedback } from "../feedback.js";
+
 const particleSystem = mountParticleField({
   effects: {
     palette: ["#38bdf8", "#facc15", "#a855f7", "#34d399"],
@@ -495,3 +497,5 @@ function logEvent(message) {
     eventList.removeChild(eventList.lastElementChild);
   }
 }
+
+autoEnhanceFeedback();

--- a/madia.new/public/secret/1989/heatwave-block-party/heatwave-block-party.js
+++ b/madia.new/public/secret/1989/heatwave-block-party/heatwave-block-party.js
@@ -2,6 +2,8 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 
+import { autoEnhanceFeedback } from "../feedback.js";
+
 const particleSystem = mountParticleField({
   effects: {
     palette: ["#f97316", "#38bdf8", "#facc15", "#fb7185"],
@@ -515,3 +517,5 @@ function endDay(success, message) {
   updateButtons();
   updateLockBanner();
 }
+
+autoEnhanceFeedback();

--- a/madia.new/public/secret/1989/kodiak-covenant/kodiak-covenant.js
+++ b/madia.new/public/secret/1989/kodiak-covenant/kodiak-covenant.js
@@ -2,6 +2,8 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 
+import { autoEnhanceFeedback } from "../feedback.js";
+
 const particleSystem = mountParticleField({
   effects: {
     palette: ["#38bdf8", "#facc15", "#fb7185", "#34d399"],
@@ -600,3 +602,5 @@ exampleButton.addEventListener("click", () => {
 createPlanner();
 initBoard();
 resetPlanner();
+
+autoEnhanceFeedback();

--- a/madia.new/public/secret/1989/say-anything/say-anything.js
+++ b/madia.new/public/secret/1989/say-anything/say-anything.js
@@ -2,6 +2,8 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 
+import { autoEnhanceFeedback } from "../feedback.js";
+
 const particleSystem = mountParticleField({
   effects: {
     palette: ["#38bdf8", "#f472b6", "#facc15", "#fb7185"],
@@ -649,3 +651,5 @@ function clearEventTimeout() {
 function createBlock(label, key, tone, signature) {
   return { label, key, tone, signature };
 }
+
+autoEnhanceFeedback();

--- a/madia.new/public/secret/1989/second-star-flight/second-star-flight.js
+++ b/madia.new/public/secret/1989/second-star-flight/second-star-flight.js
@@ -2,6 +2,8 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 
+import { autoEnhanceFeedback } from "../feedback.js";
+
 const particleSystem = mountParticleField({
   effects: {
     palette: ["#38bdf8", "#facc15", "#f472b6", "#a855f7"],
@@ -575,3 +577,5 @@ window.addEventListener("beforeunload", () => {
     window.clearTimeout(state.freezeTimeout);
   }
 });
+
+autoEnhanceFeedback();

--- a/madia.new/public/secret/1989/speed-zone/speed-zone.js
+++ b/madia.new/public/secret/1989/speed-zone/speed-zone.js
@@ -2,6 +2,8 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 
+import { autoEnhanceFeedback } from "../feedback.js";
+
 const particleSystem = mountParticleField({
   effects: {
     palette: ["#38bdf8", "#facc15", "#fb7185", "#34d399"],
@@ -579,3 +581,5 @@ drawMap();
 updateDiceReadout(null);
 updateHeatDisplay();
 updateCheckpointReadout();
+
+autoEnhanceFeedback();

--- a/madia.new/public/secret/1989/velvet-syncopation/velvet-syncopation.js
+++ b/madia.new/public/secret/1989/velvet-syncopation/velvet-syncopation.js
@@ -2,6 +2,8 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 
+import { autoEnhanceFeedback } from "../feedback.js";
+
 const particleSystem = mountParticleField({
   effects: {
     palette: ["#38bdf8", "#f472b6", "#facc15", "#a855f7"],
@@ -555,3 +557,5 @@ function clearHighlights() {
     badges.forEach((badge) => badge.classList.remove("is-hit", "is-miss", "is-complete"));
   });
 }
+
+autoEnhanceFeedback();

--- a/madia.new/public/secret/1989/vendetta-convoy/vendetta-convoy.js
+++ b/madia.new/public/secret/1989/vendetta-convoy/vendetta-convoy.js
@@ -2,6 +2,8 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 
+import { autoEnhanceFeedback } from "../feedback.js";
+
 const particleSystem = mountParticleField({
   effects: {
     palette: ["#38bdf8", "#facc15", "#fb7185", "#34d399"],
@@ -829,3 +831,5 @@ function laneAlignedColumns(width) {
   }
   return columns;
 }
+
+autoEnhanceFeedback();


### PR DESCRIPTION
## Summary
- add a shared `autoEnhanceFeedback` helper that decorates status readouts and event logs across the 1989 arcade
- layer in glowing status and log styles so updates pulse with tone-specific color cues
- import and invoke the enhancer in every 1989 game script so existing gameplay messages gain the new feedback treatment

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68df2b14337083289ddc10987d494d35