### PR TITLE
Add 1989 film coverage README

### DIFF
--- a/docs/1989/movie-coverage.md
+++ b/docs/1989/movie-coverage.md
@@ -1,0 +1,39 @@
+# 1989 Arcade Film Coverage
+
+This reference tracks how the 1989 arcade cabinets map to their source films and how far the ladder has progressed up the 1989 domestic box office chart.
+
+## Covered Films
+
+| Level | Game | Film Inspiration | 1989 Domestic Gross Rank |
+| --- | --- | --- | --- |
+| 50 | The Cable Clash | *No Holds Barred* | #68 |
+| 49 | Dream Team Breakout | *The Dream Team* | #38 |
+| 48 | Amore Express | *Loverboy* | #83 |
+| 47 | Velvet Syncopation | *The Fabulous Baker Boys* | #57 |
+| 46 | Speed Zone | *Speed Zone!* | #122 |
+| 45 | Paper Trail Blaze | *Blaze* | #52 |
+| 44 | Say Anything Sync | *Say Anything...* | #43 |
+| 43 | Halo Hustle | *All Dogs Go to Heaven* | #40 |
+| 42 | Heatwave Block Party | *Do the Right Thing* | #39 |
+| 41 | Second Star Flight | *Peter Pan* (1989 re-issue) | #61 |
+| 40 | Cooler Chaos | *Road House* | #33 |
+| 39 | Captain's Echo | *Dead Poets Society* | #10 |
+| 38 | Kodiak Covenant | *The Bear* | #30 |
+| 37 | Gates of Eastside | *Lean on Me* | #36 |
+| 36 | Vendetta Convoy | *Licence to Kill* | #24 |
+| 35 | Cul-de-sac Curiosity | *The 'Burbs* | #23 |
+
+## Remaining Targets to Reach #1
+
+Dead Poets Society currently marks our highest climb at #10 on the 1989 chart, so the next cabinets should honor the movies ranked 9 through 1:
+
+1. *Parenthood* (#9)
+2. *Driving Miss Daisy* (#8)
+3. *Ghostbusters II* (#7)
+4. *Back to the Future Part II* (#6)
+5. *Honey, I Shrunk the Kids* (#5)
+6. *Look Who's Talking* (#4)
+7. *Lethal Weapon 2* (#3)
+8. *Indiana Jones and the Last Crusade* (#2)
+9. *Batman* (#1)
+


### PR DESCRIPTION
## Summary
- add a 1989 arcade coverage README that maps each existing cabinet to its film inspiration and domestic 1989 box office rank
- note the highest remaining box-office targets so the ladder can climb from #10 to #1

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e00ec489b08328bed4e5b7c2fffc69