### PR TITLE
Add Level 30 Gilded Partition estate puzzle

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -491,6 +491,53 @@ const games = [
     `,
   },
   {
+    id: "gilded-partition",
+    name: "Gilded Partition",
+    description: "Broker rival deeds while avoiding the ruinous sparks of a split estate.",
+    url: "./gilded-partition/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Gilded Partition preview">
+        <defs>
+          <linearGradient id="partitionGlow" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#f87171" />
+            <stop offset="100%" stop-color="#38bdf8" />
+          </linearGradient>
+          <linearGradient id="estateFloor" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(248,113,113,0.32)" />
+            <stop offset="50%" stop-color="rgba(15,23,42,0.88)" />
+            <stop offset="100%" stop-color="rgba(56,189,248,0.32)" />
+          </linearGradient>
+        </defs>
+        <rect x="8" y="10" width="144" height="100" rx="18" fill="rgba(7,11,24,0.92)" stroke="rgba(148,163,184,0.35)" />
+        <rect x="18" y="22" width="124" height="76" rx="16" fill="url(#estateFloor)" stroke="rgba(148,163,184,0.35)" />
+        <g stroke="rgba(148,163,184,0.2)" stroke-width="1">
+          ${Array.from({ length: 5 }, (_, i) => `<line x1="${32 + i * 18}" y1="28" x2="${32 + i * 18}" y2="92" />`).join("")}
+          ${Array.from({ length: 3 }, (_, i) => `<line x1="26" y1="${44 + i * 16}" x2="134" y2="${44 + i * 16}" />`).join("")}
+        </g>
+        <g>
+          <rect x="28" y="30" width="40" height="26" rx="8" fill="rgba(248,113,113,0.65)" stroke="rgba(248,250,252,0.45)" />
+          <rect x="92" y="54" width="40" height="26" rx="8" fill="rgba(56,189,248,0.65)" stroke="rgba(248,250,252,0.45)" />
+        </g>
+        <g>
+          <rect x="52" y="58" width="24" height="24" rx="6" fill="rgba(15,23,42,0.88)" stroke="url(#partitionGlow)" />
+          <path d="M52 70h24" stroke="rgba(248,250,252,0.4)" stroke-width="2" stroke-dasharray="4 6" />
+          <path d="M64 58v24" stroke="rgba(248,250,252,0.25)" stroke-width="2" stroke-dasharray="4 6" />
+        </g>
+        <g>
+          <rect x="36" y="82" width="32" height="14" rx="6" fill="rgba(248,113,113,0.8)" stroke="rgba(248,113,113,0.5)" />
+          <rect x="92" y="34" width="32" height="14" rx="6" fill="rgba(56,189,248,0.8)" stroke="rgba(56,189,248,0.5)" />
+        </g>
+        <g>
+          <rect x="76" y="42" width="12" height="12" rx="4" fill="rgba(148,163,184,0.45)" />
+          <rect x="108" y="74" width="12" height="12" rx="4" fill="rgba(148,163,184,0.45)" />
+        </g>
+        <rect x="60" y="18" width="40" height="12" rx="6" fill="rgba(15,23,42,0.95)" stroke="url(#partitionGlow)" />
+        <rect x="60" y="18" width="20" height="12" rx="6" fill="rgba(248,113,113,0.7)" />
+        <rect x="80" y="18" width="20" height="12" rx="6" fill="rgba(56,189,248,0.7)" />
+      </svg>
+    `,
+  },
+  {
     id: "vendetta-convoy",
     name: "Vendetta Convoy",
     description: "Chain sabotage charges to shepherd the rogue tanker convoy past concealed explosives.",

--- a/madia.new/public/secret/1989/gilded-partition/gilded-partition.css
+++ b/madia.new/public/secret/1989/gilded-partition/gilded-partition.css
@@ -1,0 +1,261 @@
+:root {
+  --barbara-color: #f87171;
+  --barbara-accent: #fbbf24;
+  --oliver-color: #38bdf8;
+  --oliver-accent: #60a5fa;
+  --destruction-color: #1f2937;
+  --neutral-color: #94a3b8;
+  --room-border: rgba(148, 163, 184, 0.35);
+}
+
+.page-layout {
+  align-items: flex-start;
+}
+
+.simulator {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.simulator-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.simulator-help {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.estate-status {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+}
+
+.status-card {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.4);
+}
+
+.status-card h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.status-value {
+  margin: 0.5rem 0 0;
+  font-family: 'Press Start 2P', system-ui;
+  font-size: 0.75rem;
+  color: rgba(241, 245, 249, 0.95);
+}
+
+.status-note {
+  margin: 0.25rem 0 0;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.meter {
+  position: relative;
+  height: 0.65rem;
+  border-radius: 0.5rem;
+  background: rgba(51, 65, 85, 0.8);
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.meter-fill {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  border-radius: inherit;
+  transition: width 0.3s ease;
+}
+
+#barbara-meter-fill {
+  background: linear-gradient(90deg, var(--barbara-color), var(--barbara-accent));
+}
+
+#oliver-meter-fill {
+  background: linear-gradient(90deg, var(--oliver-color), var(--oliver-accent));
+}
+
+.estate-board {
+  --rows: 8;
+  --cols: 8;
+  display: grid;
+  gap: 0.4rem;
+  grid-template-columns: repeat(var(--cols), minmax(2.75rem, 1fr));
+  align-items: stretch;
+  justify-items: stretch;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.75);
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: inset 0 0 18px rgba(8, 12, 24, 0.9);
+}
+
+.estate-cell {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 0.35rem;
+  background: rgba(15, 23, 42, 0.6);
+  color: rgba(241, 245, 249, 0.9);
+  font-family: 'Press Start 2P', system-ui;
+  font-size: 0.65rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.estate-cell:focus-visible {
+  outline: 2px solid rgba(248, 250, 252, 0.8);
+  outline-offset: 2px;
+}
+
+.estate-cell.is-selected {
+  box-shadow: 0 0 0.65rem rgba(248, 250, 252, 0.45);
+  transform: translateY(-2px);
+}
+
+.estate-cell[data-risk='high']::after {
+  content: '⚠';
+  position: absolute;
+  top: 0.15rem;
+  right: 0.25rem;
+  font-size: 0.75rem;
+  filter: drop-shadow(0 0 4px rgba(248, 113, 113, 0.7));
+}
+
+.ownership-chip {
+  position: absolute;
+  inset: 0.15rem;
+  border-radius: 0.65rem;
+  opacity: 0.75;
+  transition: background 0.2s ease, opacity 0.2s ease;
+}
+
+.estate-cell[data-owner='barbara'] .ownership-chip {
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.85), rgba(250, 204, 21, 0.6));
+}
+
+.estate-cell[data-owner='oliver'] .ownership-chip {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.85), rgba(96, 165, 250, 0.6));
+}
+
+.estate-cell[data-owner='neutral'] .ownership-chip {
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.6), rgba(226, 232, 240, 0.35));
+}
+
+.estate-cell[data-owner='destruction'] .ownership-chip {
+  background: repeating-linear-gradient(135deg, rgba(15, 23, 42, 0.95) 0, rgba(15, 23, 42, 0.95) 6px, rgba(100, 116, 139, 0.45) 6px, rgba(100, 116, 139, 0.45) 9px);
+  opacity: 1;
+}
+
+.piece-label {
+  position: relative;
+  z-index: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.piece-label[data-piece='granite'],
+.piece-label[data-piece='slate'] {
+  color: #fee2e2;
+}
+
+.piece-label[data-piece='marble'],
+.piece-label[data-piece='quartz'] {
+  color: #cffafe;
+}
+
+.piece-label[data-piece='barbara'] {
+  color: #fecaca;
+}
+
+.piece-label[data-piece='oliver'] {
+  color: #bae6fd;
+}
+
+.estate-rooms {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.estate-rooms h3 {
+  margin: 0 0 0.75rem;
+}
+
+.estate-rooms dl {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 0.75rem 1.5rem;
+  margin: 0;
+}
+
+.estate-rooms dt {
+  font-weight: 600;
+  color: rgba(248, 250, 252, 0.9);
+}
+
+.estate-rooms dd {
+  margin: 0.1rem 0 0;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.event-log {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.event-log h3 {
+  margin: 0 0 0.75rem;
+}
+
+#event-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+  max-height: 14rem;
+  overflow-y: auto;
+}
+
+#event-list li {
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.9);
+  line-height: 1.4;
+}
+
+@media (max-width: 960px) {
+  .estate-board {
+    grid-template-columns: repeat(var(--cols), minmax(2.25rem, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .page-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .estate-board {
+    gap: 0.3rem;
+    padding: 0.75rem;
+  }
+}

--- a/madia.new/public/secret/1989/gilded-partition/gilded-partition.js
+++ b/madia.new/public/secret/1989/gilded-partition/gilded-partition.js
@@ -1,0 +1,783 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+import { mountParticleField } from "../particles.js";
+
+const particleSystem = mountParticleField({
+  effects: {
+    palette: ["#f87171", "#38bdf8", "#facc15", "#fbbf24"],
+    ambientDensity: 0.45,
+    sparkleProbability: 0.12,
+  },
+});
+
+const scoreConfig = getScoreConfig("gilded-partition");
+const highScore = initHighScoreBanner({
+  gameId: "gilded-partition",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
+const ROWS = 8;
+const COLS = 8;
+const TARGET_PERCENT = 65;
+const MAX_DESTRUCTION = 7;
+const LEGAL_VICTORY_THRESHOLD = 6;
+const MAX_LOG_ENTRIES = 12;
+const DIRECTIONS = [
+  { row: 1, col: 0 },
+  { row: -1, col: 0 },
+  { row: 0, col: 1 },
+  { row: 0, col: -1 },
+];
+
+const FLOOR_PLAN = [
+  "AABBBCCD",
+  "AABBBCCD",
+  "EEJFGGCD",
+  "EEJGGHDD",
+  "IIJKKHHD",
+  "IIJLLHHD",
+  "MMJNNPPP",
+  "MMJOOOPP",
+];
+
+const ROOMS = {
+  A: { name: "Grand Stair", detail: "Double-height entryway" },
+  B: { name: "Gallery Walk", detail: "Barbara's lithograph hall" },
+  C: { name: "Winter Garden", detail: "Glasswork courtyard" },
+  D: { name: "Litigation Landing", detail: "Neutral corridor" },
+  E: { name: "Atrium Mezzanine", detail: "Floating bridge" },
+  F: { name: "Scarlet Kitchen", detail: "Barbara's culinary flank" },
+  G: { name: "Cobalt Study", detail: "Oliver's war room" },
+  H: { name: "Verdant Spa", detail: "Sunken bath suite" },
+  I: { name: "Carriage Hall", detail: "Garage vestibule" },
+  J: { name: "Chandelier Room", detail: "Two-story showpiece" },
+  K: { name: "Velvet Library", detail: "Mahogany stacks" },
+  L: { name: "Negotiation Den", detail: "Whiskey bar" },
+  M: { name: "Garage Loft", detail: "Vintage auto gallery" },
+  N: { name: "Roof Terrace", detail: "Slate patio" },
+  O: { name: "Solarium Nook", detail: "Walled greenhouse" },
+  P: { name: "Cellar Vault", detail: "Reserve vintages" },
+};
+
+const PIECES = [
+  { id: "granite", label: "GR", longName: "granite writ", side: "barbara", weight: 3 },
+  { id: "slate", label: "SL", longName: "slate filing", side: "barbara", weight: 2 },
+  { id: "marble", label: "MA", longName: "marble retainer", side: "oliver", weight: 3 },
+  { id: "quartz", label: "QZ", longName: "quartz clause", side: "oliver", weight: 2 },
+  { id: "barbara", label: "BA", longName: "Barbara's gambit", side: "barbara", weight: 1 },
+  { id: "oliver", label: "OL", longName: "Oliver's riposte", side: "oliver", weight: 1 },
+];
+
+const PIECE_INFO = new Map(PIECES.map((piece) => [piece.id, piece]));
+const WEIGHT_TOTAL = PIECES.reduce((sum, piece) => sum + piece.weight, 0);
+
+const boardElement = document.getElementById("estate-board");
+const eventList = document.getElementById("event-list");
+const resetButton = document.getElementById("reset-estate");
+const hintButton = document.getElementById("hint-toggle");
+const barbaraMeterFill = document.getElementById("barbara-meter-fill");
+const barbaraMeter = document.getElementById("barbara-meter");
+const barbaraShareText = document.getElementById("barbara-share");
+const barbaraTilesText = document.getElementById("barbara-tiles");
+const oliverMeterFill = document.getElementById("oliver-meter-fill");
+const oliverMeter = document.getElementById("oliver-meter");
+const oliverShareText = document.getElementById("oliver-share");
+const oliverTilesText = document.getElementById("oliver-tiles");
+const destructionCountText = document.getElementById("destruction-count");
+const roomList = document.getElementById("room-list");
+
+const cellsByKey = new Map();
+const labelsByKey = new Map();
+const ownershipChips = new Map();
+
+const state = {
+  board: [],
+  pieces: [],
+  selectedKey: null,
+  cursor: { row: 0, col: 0 },
+  hints: false,
+  destruction: new Set(),
+};
+
+populateRooms();
+setupBoard();
+resetEstate(true);
+wireControls();
+
+function populateRooms() {
+  roomList.innerHTML = "";
+  Object.entries(ROOMS).forEach(([id, info]) => {
+    if (!isRoomUsed(id)) {
+      return;
+    }
+    const dt = document.createElement("dt");
+    dt.textContent = info.name;
+    const dd = document.createElement("dd");
+    dd.textContent = info.detail;
+    roomList.append(dt, dd);
+  });
+}
+
+function setupBoard() {
+  boardElement.style.setProperty("--rows", ROWS);
+  boardElement.style.setProperty("--cols", COLS);
+  boardElement.innerHTML = "";
+  cellsByKey.clear();
+  labelsByKey.clear();
+  ownershipChips.clear();
+
+  for (let row = 0; row < ROWS; row += 1) {
+    for (let col = 0; col < COLS; col += 1) {
+      const cellKey = keyFrom(row, col);
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "estate-cell";
+      button.dataset.row = String(row);
+      button.dataset.col = String(col);
+      button.setAttribute("role", "gridcell");
+      button.addEventListener("click", () => {
+        focusCell(row, col);
+        handleCellActivation(row, col);
+      });
+
+      const chip = document.createElement("span");
+      chip.className = "ownership-chip";
+
+      const label = document.createElement("span");
+      label.className = "piece-label";
+
+      button.append(chip, label);
+      boardElement.appendChild(button);
+
+      cellsByKey.set(cellKey, button);
+      labelsByKey.set(cellKey, label);
+      ownershipChips.set(cellKey, chip);
+    }
+  }
+}
+
+function wireControls() {
+  resetButton.addEventListener("click", () => {
+    addLog("Estate reseeded. Fresh claims filed.");
+    resetEstate(false);
+  });
+
+  hintButton.addEventListener("click", () => {
+    state.hints = !state.hints;
+    hintButton.textContent = state.hints ? "Disable Risk Hints" : "Toggle Risk Hints";
+    addLog(state.hints ? "Risk hints enabled." : "Risk hints disabled.");
+    refreshHints();
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+      return;
+    }
+    const { key } = event;
+    if (key === "ArrowUp") {
+      event.preventDefault();
+      moveCursor(-1, 0);
+    } else if (key === "ArrowDown") {
+      event.preventDefault();
+      moveCursor(1, 0);
+    } else if (key === "ArrowLeft") {
+      event.preventDefault();
+      moveCursor(0, -1);
+    } else if (key === "ArrowRight") {
+      event.preventDefault();
+      moveCursor(0, 1);
+    } else if (key === "Enter" || key === " ") {
+      event.preventDefault();
+      handleCellActivation(state.cursor.row, state.cursor.col);
+    } else if (key === "Escape") {
+      clearSelection();
+    } else if (key === "r" || key === "R") {
+      event.preventDefault();
+      addLog("Manual reseed requested.");
+      resetEstate(false);
+    }
+  });
+}
+
+function resetEstate(isInitial) {
+  state.destruction.clear();
+  state.board = buildOwnershipGrid();
+  state.pieces = buildPieceGrid();
+  state.selectedKey = null;
+  state.cursor = { row: 0, col: 0 };
+  if (!isInitial) {
+    particleSystem?.burst?.({ palette: ["#fbbf24", "#38bdf8", "#f87171"] });
+  }
+  renderBoard();
+  focusCell(0, 0);
+  updateStatus();
+  addLog("Deed ledger reset.");
+}
+
+function buildOwnershipGrid() {
+  const grid = [];
+  const assignments = [];
+  for (let row = 0; row < ROWS; row += 1) {
+    const rowAssignments = [];
+    for (let col = 0; col < COLS; col += 1) {
+      const roomId = FLOOR_PLAN[row][col];
+      rowAssignments.push({ owner: "neutral", room: roomId });
+      assignments.push({ row, col });
+    }
+    grid.push(rowAssignments);
+  }
+  const shuffled = shuffle(assignments);
+  const half = Math.floor(shuffled.length / 2);
+  shuffled.forEach((entry, index) => {
+    const owner = index < half ? "barbara" : "oliver";
+    grid[entry.row][entry.col].owner = owner;
+  });
+  if (shuffled.length % 2 === 1) {
+    const middle = shuffled[half];
+    grid[middle.row][middle.col].owner = "neutral";
+  }
+  return grid;
+}
+
+function buildPieceGrid() {
+  const grid = Array.from({ length: ROWS }, () => Array(COLS).fill(null));
+  for (let row = 0; row < ROWS; row += 1) {
+    for (let col = 0; col < COLS; col += 1) {
+      grid[row][col] = generatePiece(row, col, grid);
+    }
+  }
+  return grid;
+}
+
+function generatePiece(row, col, grid) {
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    const candidate = drawPiece();
+    if (!createsImmediateMatch(row, col, candidate, grid)) {
+      return candidate;
+    }
+  }
+  return drawPiece();
+}
+
+function drawPiece() {
+  let ticket = Math.random() * WEIGHT_TOTAL;
+  for (const piece of PIECES) {
+    ticket -= piece.weight;
+    if (ticket <= 0) {
+      return piece.id;
+    }
+  }
+  return PIECES[0].id;
+}
+
+function createsImmediateMatch(row, col, candidate, grid) {
+  const leftOne = col - 1 >= 0 ? grid[row][col - 1] : null;
+  const leftTwo = col - 2 >= 0 ? grid[row][col - 2] : null;
+  if (leftOne && leftTwo && leftOne === candidate && leftTwo === candidate) {
+    return true;
+  }
+  const upOne = row - 1 >= 0 ? grid[row - 1][col] : null;
+  const upTwo = row - 2 >= 0 ? grid[row - 2][col] : null;
+  if (upOne && upTwo && upOne === candidate && upTwo === candidate) {
+    return true;
+  }
+  return false;
+}
+
+function renderBoard() {
+  for (let row = 0; row < ROWS; row += 1) {
+    for (let col = 0; col < COLS; col += 1) {
+      updateCell(row, col);
+    }
+  }
+  refreshHints();
+  updateSelectionHighlight();
+}
+
+function updateCell(row, col) {
+  const key = keyFrom(row, col);
+  const cell = cellsByKey.get(key);
+  const label = labelsByKey.get(key);
+  const ownership = state.board[row][col];
+  const pieceType = state.pieces[row][col];
+  cell.dataset.owner = ownership.owner;
+  cell.dataset.room = ownership.room;
+  cell.dataset.piece = pieceType;
+  if (ownership.owner === "destruction") {
+    cell.setAttribute("aria-label", formatAriaLabel(row, col, "Destruction locked", pieceType));
+  } else {
+    const ownerLabel = ownership.owner === "neutral" ? "Unclaimed" : `${capitalize(ownership.owner)} control`;
+    cell.setAttribute("aria-label", formatAriaLabel(row, col, ownerLabel, pieceType));
+  }
+  const info = PIECE_INFO.get(pieceType);
+  if (label) {
+    label.dataset.piece = pieceType;
+    label.textContent = info ? info.label : "";
+  }
+}
+
+function refreshHints() {
+  for (let row = 0; row < ROWS; row += 1) {
+    for (let col = 0; col < COLS; col += 1) {
+      applyRisk(row, col);
+    }
+  }
+}
+
+function applyRisk(row, col) {
+  const key = keyFrom(row, col);
+  const cell = cellsByKey.get(key);
+  if (!cell) {
+    return;
+  }
+  if (!state.hints) {
+    cell.removeAttribute("data-risk");
+    return;
+  }
+  const ownership = state.board[row][col];
+  const pieceType = state.pieces[row][col];
+  const info = PIECE_INFO.get(pieceType);
+  if (!info || ownership.owner === "destruction" || ownership.owner === "neutral") {
+    cell.removeAttribute("data-risk");
+    return;
+  }
+  if (info.side && info.side !== ownership.owner) {
+    cell.dataset.risk = "high";
+  } else {
+    cell.removeAttribute("data-risk");
+  }
+}
+
+function updateSelectionHighlight() {
+  cellsByKey.forEach((cell, key) => {
+    if (key === state.selectedKey) {
+      cell.classList.add("is-selected");
+    } else {
+      cell.classList.remove("is-selected");
+    }
+  });
+}
+
+function handleCellActivation(row, col) {
+  const key = keyFrom(row, col);
+  if (state.selectedKey === key) {
+    clearSelection();
+    return;
+  }
+  if (!state.selectedKey) {
+    state.selectedKey = key;
+    updateSelectionHighlight();
+    return;
+  }
+  const [selRow, selCol] = parseKey(state.selectedKey);
+  if (!isAdjacent(selRow, selCol, row, col)) {
+    state.selectedKey = key;
+    updateSelectionHighlight();
+    return;
+  }
+  attemptSwap({ row: selRow, col: selCol }, { row, col });
+  clearSelection();
+}
+
+function attemptSwap(a, b) {
+  swapPieces(a, b);
+  renderCell(a.row, a.col);
+  renderCell(b.row, b.col);
+  const matches = findMatches();
+  if (matches.length === 0) {
+    swapPieces(a, b);
+    renderCell(a.row, a.col);
+    renderCell(b.row, b.col);
+    addLog("No claim satisfied.");
+    return false;
+  }
+  resolveMatches(matches);
+  return true;
+}
+
+function resolveMatches(initialMatches) {
+  let cascade = 0;
+  let matches = initialMatches;
+  while (matches.length > 0) {
+    cascade += 1;
+    const cleared = new Set();
+    const conversions = {
+      barbara: new Map(),
+      oliver: new Map(),
+    };
+
+    matches.forEach((match) => {
+      const info = PIECE_INFO.get(match.type);
+      if (!info) {
+        return;
+      }
+      match.cells.forEach(({ row, col }) => {
+        const key = keyFrom(row, col);
+        cleared.add(key);
+      });
+      if (info.side === "barbara" || info.side === "oliver") {
+        match.cells.forEach(({ row, col }) => {
+          applyConversion(row, col, info.side, conversions);
+          DIRECTIONS.forEach((offset) => {
+            applyConversion(row + offset.row, col + offset.col, info.side, conversions);
+          });
+        });
+      }
+    });
+
+    cleared.forEach((key) => {
+      const { row, col } = parseKey(key);
+      state.pieces[row][col] = null;
+    });
+
+    const locked = handleDestruction(conversions);
+    handleLegalVictories(conversions, locked);
+
+    dropPieces();
+    fillPieces();
+    renderBoard();
+    updateStatus();
+
+    if (cascade === 1) {
+      if (locked > 0) {
+        addLog(`Contested filings collided. ${locked} room${locked === 1 ? "" : "s"} locked.`);
+      } else {
+        addLog("Claims processed.");
+      }
+    } else if (locked > 0) {
+      addLog(`Cascade conflict triggered ${locked} new ruins.`);
+    } else {
+      addLog("Cascade cleared additional claims.");
+    }
+
+    matches = findMatches();
+  }
+}
+
+function applyConversion(row, col, side, conversions) {
+  if (!inBounds(row, col)) {
+    return;
+  }
+  const ownership = state.board[row][col];
+  if (!ownership || ownership.owner === "destruction") {
+    return;
+  }
+  if (ownership.owner !== side) {
+    ownership.owner = side;
+  }
+  const key = keyFrom(row, col);
+  conversions[side].set(key, { row, col });
+  const otherSide = side === "barbara" ? "oliver" : "barbara";
+  conversions[otherSide].delete(key);
+}
+
+function handleDestruction(conversions) {
+  const barbaraCells = Array.from(conversions.barbara.values());
+  const oliverCells = Array.from(conversions.oliver.values());
+  if (barbaraCells.length === 0 || oliverCells.length === 0) {
+    return 0;
+  }
+  const locked = new Set();
+  barbaraCells.forEach((bCell) => {
+    oliverCells.forEach((oCell) => {
+      if (Math.abs(bCell.row - oCell.row) + Math.abs(bCell.col - oCell.col) === 1) {
+        lockCell(bCell.row, bCell.col, locked, conversions);
+        lockCell(oCell.row, oCell.col, locked, conversions);
+      }
+    });
+  });
+  return locked.size;
+}
+
+function lockCell(row, col, lockedSet, conversions) {
+  if (!inBounds(row, col)) {
+    return;
+  }
+  const key = keyFrom(row, col);
+  const ownership = state.board[row][col];
+  if (!ownership || ownership.owner === "destruction") {
+    return;
+  }
+  ownership.owner = "destruction";
+  state.destruction.add(key);
+  conversions.barbara.delete(key);
+  conversions.oliver.delete(key);
+  lockedSet.add(key);
+}
+
+function handleLegalVictories(conversions, lockedCount) {
+  ["barbara", "oliver"].forEach((side) => {
+    const cells = Array.from(conversions[side].values());
+    if (cells.length < LEGAL_VICTORY_THRESHOLD) {
+      return;
+    }
+    const cluster = largestCluster(cells);
+    if (cluster.length >= LEGAL_VICTORY_THRESHOLD) {
+      const freed = releaseDestruction(side, cluster);
+      if (freed > 0) {
+        addLog(`Legal Victory for ${capitalize(side)} freed ${freed} ruin${freed === 1 ? "" : "s"}.`);
+      }
+    }
+  });
+  if (lockedCount > 0) {
+    particleSystem?.burst?.({ palette: ["#f87171", "#38bdf8"], count: lockedCount * 6 });
+  }
+}
+
+function largestCluster(cells) {
+  const visited = new Set();
+  let best = [];
+  const cellSet = new Set(cells.map((cell) => keyFrom(cell.row, cell.col)));
+  cells.forEach((cell) => {
+    const key = keyFrom(cell.row, cell.col);
+    if (visited.has(key)) {
+      return;
+    }
+    const cluster = [];
+    const stack = [cell];
+    visited.add(key);
+    while (stack.length > 0) {
+      const current = stack.pop();
+      cluster.push(current);
+      DIRECTIONS.forEach((offset) => {
+        const nextRow = current.row + offset.row;
+        const nextCol = current.col + offset.col;
+        const nextKey = keyFrom(nextRow, nextCol);
+        if (cellSet.has(nextKey) && !visited.has(nextKey)) {
+          visited.add(nextKey);
+          stack.push({ row: nextRow, col: nextCol });
+        }
+      });
+    }
+    if (cluster.length > best.length) {
+      best = cluster;
+    }
+  });
+  return best;
+}
+
+function releaseDestruction(side, cluster) {
+  const clusterKeys = new Set(cluster.map((cell) => keyFrom(cell.row, cell.col)));
+  const clusterCells = cluster.map((cell) => ({ row: cell.row, col: cell.col }));
+  const freed = [];
+  const candidates = Array.from(state.destruction);
+  for (const key of candidates) {
+    if (freed.length >= 2) {
+      break;
+    }
+    if (clusterKeys.has(key)) {
+      continue;
+    }
+    const { row, col } = parseKey(key);
+    const nearCluster = clusterCells.some((cell) => Math.abs(cell.row - row) + Math.abs(cell.col - col) <= 1);
+    if (nearCluster) {
+      continue;
+    }
+    freed.push({ key, row, col });
+  }
+  freed.forEach((entry) => {
+    state.destruction.delete(entry.key);
+    state.board[entry.row][entry.col].owner = side;
+  });
+  return freed.length;
+}
+
+function dropPieces() {
+  for (let col = 0; col < COLS; col += 1) {
+    let targetRow = ROWS - 1;
+    for (let row = ROWS - 1; row >= 0; row -= 1) {
+      const type = state.pieces[row][col];
+      if (type) {
+        if (row !== targetRow) {
+          state.pieces[targetRow][col] = type;
+          state.pieces[row][col] = null;
+        }
+        targetRow -= 1;
+      }
+    }
+    for (let fillRow = targetRow; fillRow >= 0; fillRow -= 1) {
+      state.pieces[fillRow][col] = null;
+    }
+  }
+}
+
+function fillPieces() {
+  for (let row = 0; row < ROWS; row += 1) {
+    for (let col = 0; col < COLS; col += 1) {
+      if (!state.pieces[row][col]) {
+        state.pieces[row][col] = generatePiece(row, col, state.pieces);
+      }
+    }
+  }
+}
+
+function findMatches() {
+  const matches = [];
+  // Horizontal
+  for (let row = 0; row < ROWS; row += 1) {
+    let runType = null;
+    let runStart = 0;
+    for (let col = 0; col <= COLS; col += 1) {
+      const type = col < COLS ? state.pieces[row][col] : null;
+      if (type && type === runType) {
+        continue;
+      }
+      if (runType && col - runStart >= 3) {
+        matches.push({
+          type: runType,
+          cells: Array.from({ length: col - runStart }, (_, index) => ({ row, col: runStart + index })),
+        });
+      }
+      runType = type;
+      runStart = col;
+    }
+  }
+  // Vertical
+  for (let col = 0; col < COLS; col += 1) {
+    let runType = null;
+    let runStart = 0;
+    for (let row = 0; row <= ROWS; row += 1) {
+      const type = row < ROWS ? state.pieces[row][col] : null;
+      if (type && type === runType) {
+        continue;
+      }
+      if (runType && row - runStart >= 3) {
+        matches.push({
+          type: runType,
+          cells: Array.from({ length: row - runStart }, (_, index) => ({ row: runStart + index, col })),
+        });
+      }
+      runType = type;
+      runStart = row;
+    }
+  }
+  return matches.filter((match) => PIECE_INFO.has(match.type));
+}
+
+function swapPieces(a, b) {
+  const temp = state.pieces[a.row][a.col];
+  state.pieces[a.row][a.col] = state.pieces[b.row][b.col];
+  state.pieces[b.row][b.col] = temp;
+}
+
+function renderCell(row, col) {
+  updateCell(row, col);
+}
+
+function updateStatus() {
+  let barbara = 0;
+  let oliver = 0;
+  let destruction = 0;
+  for (let row = 0; row < ROWS; row += 1) {
+    for (let col = 0; col < COLS; col += 1) {
+      const owner = state.board[row][col].owner;
+      if (owner === "barbara") {
+        barbara += 1;
+      } else if (owner === "oliver") {
+        oliver += 1;
+      } else if (owner === "destruction") {
+        destruction += 1;
+      }
+    }
+  }
+  const total = ROWS * COLS;
+  const barbaraPercent = Math.round((barbara / total) * 100);
+  const oliverPercent = Math.round((oliver / total) * 100);
+  barbaraShareText.textContent = String(barbaraPercent);
+  barbaraTilesText.textContent = String(barbara);
+  oliverShareText.textContent = String(oliverPercent);
+  oliverTilesText.textContent = String(oliver);
+  destructionCountText.textContent = String(destruction);
+  barbaraMeterFill.style.width = `${barbaraPercent}%`;
+  oliverMeterFill.style.width = `${oliverPercent}%`;
+  barbaraMeter.setAttribute("aria-valuenow", String(barbaraPercent));
+  oliverMeter.setAttribute("aria-valuenow", String(oliverPercent));
+  if (barbaraPercent >= TARGET_PERCENT && destruction <= MAX_DESTRUCTION) {
+    highScore.submit(barbaraPercent, { destruction });
+  }
+}
+
+function addLog(message) {
+  const entry = document.createElement("li");
+  entry.textContent = message;
+  eventList.prepend(entry);
+  while (eventList.children.length > MAX_LOG_ENTRIES) {
+    eventList.removeChild(eventList.lastChild);
+  }
+}
+
+function focusCell(row, col) {
+  if (!inBounds(row, col)) {
+    return;
+  }
+  state.cursor = { row, col };
+  const key = keyFrom(row, col);
+  const cell = cellsByKey.get(key);
+  cell?.focus();
+}
+
+function moveCursor(rowOffset, colOffset) {
+  let { row, col } = state.cursor;
+  row = clamp(row + rowOffset, 0, ROWS - 1);
+  col = clamp(col + colOffset, 0, COLS - 1);
+  focusCell(row, col);
+}
+
+function clearSelection() {
+  state.selectedKey = null;
+  updateSelectionHighlight();
+}
+
+function inBounds(row, col) {
+  return row >= 0 && row < ROWS && col >= 0 && col < COLS;
+}
+
+function isAdjacent(aRow, aCol, bRow, bCol) {
+  return Math.abs(aRow - bRow) + Math.abs(aCol - bCol) === 1;
+}
+
+function keyFrom(row, col) {
+  return `${row},${col}`;
+}
+
+function parseKey(key) {
+  const [row, col] = key.split(",").map((value) => Number.parseInt(value, 10));
+  return [row, col];
+}
+
+function formatAriaLabel(row, col, ownerLabel, pieceType) {
+  const info = PIECE_INFO.get(pieceType);
+  const pieceText = info ? info.longName : "empty";
+  const room = ROOMS[state.board[row][col].room];
+  const cellName = `${String.fromCharCode(65 + col)}${row + 1}`;
+  return `${cellName}, ${room?.name ?? "Unknown room"}. ${ownerLabel}. Piece: ${pieceText}.`;
+}
+
+function capitalize(value) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function shuffle(values) {
+  const copy = [...values];
+  for (let index = copy.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(Math.random() * (index + 1));
+    const temp = copy[index];
+    copy[index] = copy[swapIndex];
+    copy[swapIndex] = temp;
+  }
+  return copy;
+}
+
+function isRoomUsed(id) {
+  return FLOOR_PLAN.some((row) => row.includes(id));
+}
+
+window.addEventListener("beforeunload", () => {
+  particleSystem?.destroy?.();
+});

--- a/madia.new/public/secret/1989/gilded-partition/index.html
+++ b/madia.new/public/secret/1989/gilded-partition/index.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Gilded Partition</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="gilded-partition.css" />
+  </head>
+  <body class="secret-annex-snes">
+    <a class="skip-link" href="#main-content">Skip to game</a>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 30 · 1989 Arcade</p>
+      <h1>Gilded Partition</h1>
+      <p class="subtitle">
+        Broker the split of the Van Rose estate by chaining floor-plan gambits while keeping the house from literally cracking in
+        half.
+      </p>
+    </header>
+    <main id="main-content" class="page-layout">
+      <section class="briefing" aria-labelledby="briefing-title">
+        <h2 id="briefing-title">Estate Brief</h2>
+        <p>
+          The manor's title is split between Barbara's crimson claims and Oliver's cobalt counters. Each match-three pull lets
+          you tug nearby Ownership Tiles to your chosen side, but when both sides fire in the same beat the house retaliates with
+          a Destruction clause that locks rooms forever.
+        </p>
+        <ul class="callouts">
+          <li><strong>Ownership tiles:</strong> Every cell has an active deed that can favor Barbara, Oliver, or go scorched.</li>
+          <li><strong>Match pieces:</strong> Granite and slate feed Barbara's attorneys; marble and quartz empower Oliver's.</li>
+          <li><strong>Destruction:</strong> Simultaneous red and blue swings collide to spawn unflippable ruins.</li>
+          <li><strong>Legal victory:</strong> Sweep an entire room to void Destruction elsewhere via court order.</li>
+        </ul>
+        <section class="key-guide" aria-labelledby="estate-controls">
+          <h3 id="estate-controls">Controls</h3>
+          <dl>
+            <div>
+              <dt>Swap focus</dt>
+              <dd>Select one tile, then another adjacent tile, or press the arrow keys to move the cursor.</dd>
+            </div>
+            <div>
+              <dt>Confirm swap</dt>
+              <dd><span class="key-label">Enter</span> or click the highlighted neighbor.</dd>
+            </div>
+            <div>
+              <dt>Clear estate</dt>
+              <dd><span class="key-label">R</span> to reseed the deed grid with a new shuffle.</dd>
+            </div>
+          </dl>
+        </section>
+      </section>
+      <section class="simulator" aria-labelledby="simulator-title">
+        <div class="simulator-header">
+          <h2 id="simulator-title">Partition Simulator</h2>
+          <div class="simulator-controls">
+            <button type="button" class="action-button" id="reset-estate">Reseed Estate</button>
+            <button type="button" class="action-button" id="hint-toggle">Toggle Risk Hints</button>
+          </div>
+        </div>
+        <p class="simulator-help">
+          Match three or more like pieces by swapping neighbors. Converted Ownership Tiles swing toward the matching party unless
+          Destruction freezes the floor. Hold 65% of the estate for Barbara while keeping fewer than eight Destruction blocks.
+        </p>
+        <div class="estate-status" role="group" aria-label="Estate status">
+          <div class="status-card">
+            <h3>Barbara Control</h3>
+            <div class="meter" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" id="barbara-meter">
+              <div class="meter-fill" id="barbara-meter-fill" style="width: 0%"></div>
+            </div>
+            <p class="status-value"><span id="barbara-share">0</span>% (<span id="barbara-tiles">0</span> tiles)</p>
+          </div>
+          <div class="status-card">
+            <h3>Oliver Control</h3>
+            <div class="meter" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" id="oliver-meter">
+              <div class="meter-fill" id="oliver-meter-fill" style="width: 0%"></div>
+            </div>
+            <p class="status-value"><span id="oliver-share">0</span>% (<span id="oliver-tiles">0</span> tiles)</p>
+          </div>
+          <div class="status-card">
+            <h3>Destruction</h3>
+            <p class="status-value"><span id="destruction-count">0</span> locked rooms</p>
+            <p class="status-note">Limit 7 to keep the truce intact.</p>
+          </div>
+        </div>
+        <div class="estate-board" id="estate-board" role="grid" aria-label="Shared ownership floor plan"></div>
+        <section class="estate-rooms" aria-labelledby="rooms-title">
+          <h3 id="rooms-title">Known Rooms</h3>
+          <dl id="room-list"></dl>
+        </section>
+        <section class="event-log" aria-labelledby="event-log-title">
+          <h3 id="event-log-title">Docket Log</h3>
+          <ul id="event-list"></ul>
+        </section>
+      </section>
+    </main>
+    <footer class="page-footer">
+      <p>Tip: Clearing the Chandelier Room in one sweep triggers a Legal Victory that vacates ruin elsewhere.</p>
+    </footer>
+    <script type="module" src="gilded-partition.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/1989/score-config.js
+++ b/madia.new/public/secret/1989/score-config.js
@@ -44,6 +44,15 @@ export const scoreConfigs = {
     empty: "No study sessions yet.",
     format: ({ value }) => `${value ?? 0} / 120`,
   },
+  "gilded-partition": {
+    label: "Estate Claim",
+    empty: "No estate claim recorded yet.",
+    format: ({ value, meta }) => {
+      const ruins = Number(meta?.destruction ?? 0);
+      const ruinLabel = ruins === 1 ? "ruin" : "ruins";
+      return `${value ?? 0}% estate · ${ruins} ${ruinLabel}`;
+    },
+  },
   "halo-hustle": {
     label: "Life Chips Banked",
     empty: "No life chips deposited yet.",


### PR DESCRIPTION
## Summary
- add the Gilded Partition match-three estate level with destruction mechanics, legal victories, and accessibility affordances
- wire the new level into the 1989 arcade catalog with a bespoke thumbnail and estate-claim high score config
- provide UI chrome for estate status, room lore, event logging, and risk hints within the new level

## Testing
- python -m http.server 5000 (manual preview)


------
https://chatgpt.com/codex/tasks/task_e_68e00cbd2f9c83288900ed51182e01a8