### PR TITLE
Refresh 1989 movie coverage doc and add maintenance guidance

### DIFF
--- a/docs/1989/AGENTS.md
+++ b/docs/1989/AGENTS.md
@@ -1,0 +1,5 @@
+# Documentation Guidelines for 1989 Coverage
+
+- Keep `movie-coverage.md` aligned with the current set of cabinets in `madia.new/public/secret/1989/`.
+  - Add a new row to the coverage table whenever you ship or rename a cabinet.
+  - Update the "Remaining Targets" list after every new addition so it continues to reflect the unreleased top-50 films.

--- a/docs/1989/movie-coverage.md
+++ b/docs/1989/movie-coverage.md
@@ -7,12 +7,12 @@ This reference tracks how the 1989 arcade cabinets map to their source films and
 | Level | Game | Film Inspiration | 1989 Domestic Gross Rank |
 | --- | --- | --- | --- |
 | 50 | The Cable Clash | *No Holds Barred* | #68 |
-| 49 | Dream Team Breakout | *The Dream Team* | #38 |
+| 49 | Wardline Breakout | *The Dream Team* | #38 |
 | 48 | Amore Express | *Loverboy* | #83 |
 | 47 | Velvet Syncopation | *The Fabulous Baker Boys* | #57 |
 | 46 | Speed Zone | *Speed Zone!* | #122 |
 | 45 | Paper Trail Blaze | *Blaze* | #52 |
-| 44 | Say Anything Sync | *Say Anything...* | #43 |
+| 44 | Boombox Serenade | *Say Anything...* | #43 |
 | 43 | Halo Hustle | *All Dogs Go to Heaven* | #40 |
 | 42 | Heatwave Block Party | *Do the Right Thing* | #39 |
 | 41 | Second Star Flight | *Peter Pan* (1989 re-issue) | #61 |
@@ -22,18 +22,45 @@ This reference tracks how the 1989 arcade cabinets map to their source films and
 | 37 | Gates of Eastside | *Lean on Me* | #36 |
 | 36 | Vendetta Convoy | *Licence to Kill* | #24 |
 | 35 | Cul-de-sac Curiosity | *The 'Burbs* | #23 |
+| 34 | Dojo Duality | *The Karate Kid Part III* | #41 |
+| 33 | Dialtone Honor Roll | *Bill & Ted's Excellent Adventure* | #32 |
+| 31 | Nose for Trouble | *K-9* | #31 |
+| 30 | Gilded Partition | *The War of the Roses* | #26 |
 
 ## Remaining Targets to Reach #1
 
-Dead Poets Society currently marks our highest climb at #10 on the 1989 chart, so the next cabinets should honor the movies ranked 9 through 1:
+Dead Poets Society remains our highest-ranked adaptation at #10. The table below captures the top 50 domestic hits from 1989 that still need bespoke cabinets (ordered by their chart position):
 
-1. *Parenthood* (#9)
-2. *Driving Miss Daisy* (#8)
-3. *Ghostbusters II* (#7)
-4. *Back to the Future Part II* (#6)
-5. *Honey, I Shrunk the Kids* (#5)
-6. *Look Who's Talking* (#4)
-7. *Lethal Weapon 2* (#3)
-8. *Indiana Jones and the Last Crusade* (#2)
-9. *Batman* (#1)
+| Rank | Film |
+| --- | --- |
+| #1 | *Batman* |
+| #2 | *Indiana Jones and the Last Crusade* |
+| #3 | *Lethal Weapon 2* |
+| #4 | *Look Who's Talking* |
+| #5 | *Honey, I Shrunk the Kids* |
+| #6 | *Back to the Future Part II* |
+| #7 | *Ghostbusters II* |
+| #8 | *Driving Miss Daisy* |
+| #9 | *Parenthood* |
+| #11 | *When Harry Met Sally...* |
+| #12 | *The Little Mermaid* |
+| #13 | *Uncle Buck* |
+| #14 | *Field of Dreams* |
+| #15 | *Born on the Fourth of July* |
+| #16 | *National Lampoon's Christmas Vacation* |
+| #17 | *Turner & Hooch* |
+| #18 | *Harlem Nights* |
+| #19 | *Major League* |
+| #20 | *Pet Sematary* |
+| #21 | *Sea of Love* |
+| #22 | *Tango & Cash* |
+| #25 | *Star Trek V: The Final Frontier* |
+| #27 | *Black Rain* |
+| #28 | *The Abyss* |
+| #29 | *See No Evil, Hear No Evil* |
+| #34 | *Weekend at Bernie's* |
+| #35 | *Steel Magnolias* |
+| #37 | *Glory* |
+| #42 | *Fletch Lives* |
+| #44 | *Chances Are* |
 


### PR DESCRIPTION
## Summary
- update the 1989 coverage table with the renamed cabinets and newly shipped levels
- list the remaining top-50 films still awaiting cabinet designs in a dedicated table
- add documentation guidance reminding contributors to keep the coverage doc in sync with new releases

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e01132db4483288a0da04e41102dd7