### PR TITLE
Add Flapjack Flip-Out physics cabinet

### DIFF
--- a/docs/1989/movie-coverage.md
+++ b/docs/1989/movie-coverage.md
@@ -2,7 +2,7 @@
 
 This reference tracks how the 1989 arcade cabinets map to their source films and how far the ladder has progressed up the 1989 domestic box office chart.
 
-Three Fugitives now anchors Level 32, covering the next-highest new release still on the chart while the rest of the ladder continues to backfill the remaining Top 50 slots.
+Three Fugitives now anchors Level 32, covering the next-highest new release still on the chart while the rest of the ladder continues to backfill the remaining Top 50 slots. Flapjack Flip-Out joins the lineup at Level 29, paying tribute to *Uncle Buck* and nudging the ladder deeper into the domestic Top 15.
 
 ## Covered Films
 
@@ -29,6 +29,7 @@ Three Fugitives now anchors Level 32, covering the next-highest new release stil
 | 32 | Three Fugitives | *Three Fugitives* | #31 |
 | 31 | Nose for Trouble | *K-9* | #30 |
 | 30 | Gilded Partition | *The War of the Roses* | #12 |
+| 29 | Flapjack Flip-Out | *Uncle Buck* | #13 |
 
 Remaining:
 ## Remaining Targets to Reach #1
@@ -62,7 +63,6 @@ Remaining:
 | **25** | Parenthood | #9 | Rollercoaster of Life | A fast-paced decision-making game, quickly choosing the 'right' or 'wrong' answer to various parental/family dilemmas. |
 | **24** | When Harry Met Sally... | #11 | The Diner Debate | A reaction game where you have to perfectly time a very convincing vocal display in a crowded diner (like a rhythm or memory sequence). |
 | **23** | Turner & Hooch | #12 | Tailing the Trash | A stealth/clean-up mission where you follow a key item (or suspect) without leaving any messy dog-related evidence behind. |
-| **22** | Uncle Buck | #13 | Flapjack Flip-Out | A physics/timing game where you try to stack giant, burned pancakes without them collapsing. |
 | **21** | Field of Dreams | #14 | Whisper's Garden | A meditative game where you follow subtle auditory cues ("If you build it...") to find and plant crops on a field before time runs out. |
 | **20** | National Lampoon's Christmas Vacation | #15 | Twenty-Five Thousand Bulbs | An electrical circuit puzzle where you must connect all the wires in the neighborhood to light up the house. |
 | **19** | Sea of Love | #16 | The Personal Ad Trap | A deductive game where you cross-reference different clues and profiles to find a killer who connects through newspaper personal ads. |

--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -171,6 +171,53 @@ const games = [
     `,
   },
   {
+    id: "flapjack-flip-out",
+    name: "Flapjack Flip-Out",
+    description: "Juggle Uncle Buck's oversized flapjacks and gamble on nudges to keep the stack sky-high.",
+    url: "./flapjack-flip-out/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Flapjack Flip-Out preview">
+        <defs>
+          <linearGradient id="flapjackSky" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(15,23,42,0.95)" />
+            <stop offset="100%" stop-color="rgba(8,13,28,0.92)" />
+          </linearGradient>
+          <linearGradient id="flapjackPlate" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="rgba(56,189,248,0.75)" />
+            <stop offset="100%" stop-color="rgba(37,99,235,0.55)" />
+          </linearGradient>
+          <linearGradient id="flapjackStack" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#fde68a" />
+            <stop offset="100%" stop-color="#f97316" />
+          </linearGradient>
+        </defs>
+        <rect x="10" y="10" width="140" height="100" rx="18" fill="rgba(6,10,22,0.95)" stroke="rgba(148,163,184,0.35)" />
+        <rect x="18" y="18" width="124" height="84" rx="16" fill="url(#flapjackSky)" stroke="rgba(148,163,184,0.28)" />
+        <g transform="translate(0 6)">
+          <rect x="32" y="70" width="96" height="18" rx="9" fill="url(#flapjackPlate)" stroke="rgba(148,163,184,0.4)" />
+          <ellipse cx="80" cy="79" rx="32" ry="6" fill="rgba(14,116,144,0.35)" />
+        </g>
+        <g transform="translate(0 -2)">
+          <g>
+            <rect x="60" y="60" width="40" height="10" rx="4" fill="#f97316" stroke="rgba(148,163,184,0.3)" />
+            <ellipse cx="80" cy="58" rx="32" ry="12" fill="url(#flapjackStack)" stroke="rgba(148,163,184,0.3)" />
+            <ellipse cx="80" cy="50" rx="28" ry="10" fill="#fde68a" stroke="rgba(148,163,184,0.28)" />
+            <ellipse cx="80" cy="42" rx="24" ry="9" fill="#fbbf24" stroke="rgba(148,163,184,0.26)" />
+            <ellipse cx="80" cy="34" rx="20" ry="8" fill="#fb7185" stroke="rgba(148,163,184,0.25)" />
+          </g>
+          <path d="M110 24 L142 16" stroke="rgba(59,130,246,0.65)" stroke-width="4" stroke-linecap="round" />
+          <path d="M112 24 L134 34" stroke="rgba(248,113,113,0.8)" stroke-width="5" stroke-linecap="round" />
+          <circle cx="134" cy="34" r="6" fill="#facc15" stroke="rgba(248,250,252,0.6)" stroke-width="2" />
+        </g>
+        <g>
+          <circle cx="44" cy="90" r="4" fill="#38bdf8" />
+          <circle cx="116" cy="90" r="4" fill="#f97316" />
+          <circle cx="80" cy="22" r="3" fill="#facc15" />
+        </g>
+      </svg>
+    `,
+  },
+  {
     id: "cable-clash",
     name: "The Cable Clash",
     description: "Route the cobalt line across the ring while juking roaming rivals.",

--- a/madia.new/public/secret/1989/flapjack-flip-out/flapjack-flip-out.css
+++ b/madia.new/public/secret/1989/flapjack-flip-out/flapjack-flip-out.css
@@ -1,0 +1,371 @@
+:root {
+  --pancake-amber: #facc15;
+  --pancake-burnt: #fb7185;
+  --pancake-plate: #38bdf8;
+  --pancake-shadow: rgba(2, 6, 23, 0.55);
+  --pancake-stage: radial-gradient(circle at top, rgba(15, 23, 42, 0.92), rgba(3, 7, 18, 0.96));
+  --accent: #f97316;
+  --accent-secondary: #38bdf8;
+  --accent-strong: #facc15;
+  --glow: rgba(249, 115, 22, 0.55);
+  --highlight: rgba(56, 189, 248, 0.35);
+}
+
+.flapjack-cabinet {
+  background: linear-gradient(160deg, rgba(2, 6, 23, 0.96), rgba(5, 12, 34, 0.94));
+  color: #f1f5f9;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.page-header .subtitle {
+  max-width: 52rem;
+  margin: 0.75rem auto 0;
+}
+
+.page-layout {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(18rem, 26rem) 1fr;
+  align-items: start;
+}
+
+@media (max-width: 1120px) {
+  .page-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.briefing {
+  background: rgba(15, 23, 42, 0.68);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 28px 48px rgba(2, 6, 23, 0.45);
+  backdrop-filter: blur(10px);
+}
+
+.briefing .controls dl {
+  display: grid;
+  gap: 0.75rem 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+}
+
+.arena {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 22px;
+  padding: 1.75rem;
+  box-shadow: 0 32px 60px rgba(2, 6, 23, 0.5);
+}
+
+.arena-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.arena-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.action-button {
+  border: 1px solid rgba(56, 189, 248, 0.4);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(37, 99, 235, 0.25));
+  border-radius: 999px;
+  padding: 0.65rem 1.4rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #e0f2fe;
+  box-shadow: 0 12px 24px rgba(3, 7, 18, 0.4);
+}
+
+.action-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.status-rail {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+}
+
+.score-card {
+  background: linear-gradient(140deg, rgba(2, 6, 23, 0.92), rgba(30, 41, 59, 0.88));
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 18px;
+  padding: 1rem 1.25rem;
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.2), 0 18px 28px rgba(2, 6, 23, 0.4);
+}
+
+.score-card-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.score-card-header h3 {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.score-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.78);
+}
+
+.score-value {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin: 0;
+  color: #facc15;
+}
+
+.score-note {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.stability-meter {
+  position: relative;
+  width: 100%;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  overflow: hidden;
+}
+
+.stability-fill {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  background: linear-gradient(90deg, rgba(56, 189, 248, 0.85), rgba(249, 115, 22, 0.85));
+  transition: width 0.25s ease;
+}
+
+.status-bar {
+  padding: 0.9rem 1.1rem;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.85));
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  box-shadow: 0 24px 38px rgba(2, 6, 23, 0.38);
+}
+
+.kitchen-stage {
+  position: relative;
+  border-radius: 24px;
+  overflow: hidden;
+  background: var(--pancake-stage);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.18), 0 32px 62px rgba(2, 6, 23, 0.55);
+}
+
+.kitchen-stage.is-shaking {
+  animation: kitchen-shake 0.6s ease;
+}
+
+@keyframes kitchen-shake {
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  20% {
+    transform: translate3d(6px, -4px, 0);
+  }
+  40% {
+    transform: translate3d(-7px, 3px, 0);
+  }
+  60% {
+    transform: translate3d(5px, -3px, 0);
+  }
+  80% {
+    transform: translate3d(-4px, 2px, 0);
+  }
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+#stack-canvas {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: transparent;
+}
+
+.stage-overlay {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 1rem;
+}
+
+.tempo {
+  font-family: "Press Start 2P", monospace;
+  font-size: 0.85rem;
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  background: rgba(2, 6, 23, 0.78);
+  border: 1px solid rgba(56, 189, 248, 0.45);
+  color: #38bdf8;
+  box-shadow: 0 16px 24px rgba(2, 6, 23, 0.45);
+}
+
+.pancake-callout {
+  font-size: 0.9rem;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(250, 204, 21, 0.5);
+  color: #facc15;
+  box-shadow: 0 18px 28px rgba(2, 6, 23, 0.4);
+}
+
+.log {
+  background: rgba(2, 6, 23, 0.75);
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  padding: 1.1rem 1.25rem;
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.16);
+}
+
+.log ul {
+  max-height: 12rem;
+  overflow-y: auto;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.log li + li {
+  margin-top: 0.6rem;
+}
+
+.page-footer {
+  text-align: center;
+  margin-top: 1rem;
+  color: rgba(148, 163, 184, 0.78);
+}
+
+.wrapup {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(2, 6, 23, 0.75);
+  z-index: 50;
+}
+
+.wrapup-panel {
+  background: rgba(2, 6, 23, 0.95);
+  border-radius: 26px;
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  padding: 2rem;
+  max-width: 38rem;
+  width: min(90vw, 38rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  box-shadow: 0 42px 86px rgba(3, 7, 18, 0.7);
+}
+
+.wrapup-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.wrapup-body {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: 1fr;
+}
+
+.wrapup-stats {
+  display: grid;
+  gap: 0.75rem 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  margin: 0;
+}
+
+.wrapup-stats dt {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.wrapup-stats dd {
+  margin: 0.25rem 0 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: #facc15;
+}
+
+.wrapup-photo {
+  margin: 0;
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 18px;
+  padding: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  text-align: center;
+}
+
+.wrapup-photo img {
+  width: 100%;
+  border-radius: 12px;
+  background: rgba(2, 6, 23, 0.8);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.18);
+}
+
+.wrapup-photo figcaption {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.wrapup-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+@media (max-width: 720px) {
+  .arena {
+    padding: 1.25rem;
+  }
+
+  .stage-overlay {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .wrapup-panel {
+    padding: 1.5rem;
+  }
+}
+
+.feedback-status {
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.88));
+}

--- a/madia.new/public/secret/1989/flapjack-flip-out/flapjack-flip-out.js
+++ b/madia.new/public/secret/1989/flapjack-flip-out/flapjack-flip-out.js
@@ -1,0 +1,883 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+import { mountParticleField } from "../particles.js";
+import { createStatusChannel, createLogChannel, autoEnhanceFeedback } from "../feedback.js";
+
+const particleSystem = mountParticleField({
+  effects: {
+    palette: ["#facc15", "#f97316", "#fb7185", "#38bdf8"],
+    ambientDensity: 0.55,
+  },
+});
+
+const scoreConfig = getScoreConfig("flapjack-flip-out");
+const highScore = initHighScoreBanner({
+  gameId: "flapjack-flip-out",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
+const canvas = document.getElementById("stack-canvas");
+const ctx = canvas.getContext("2d");
+
+const startButton = document.getElementById("start-service");
+const nudgeButton = document.getElementById("nudge-stack");
+const resetButton = document.getElementById("reset-kitchen");
+const statusBar = document.getElementById("status-bar");
+const logList = document.getElementById("service-log");
+const heightDisplay = document.getElementById("height-display");
+const peakDisplay = document.getElementById("peak-display");
+const countDisplay = document.getElementById("count-display");
+const typeDisplay = document.getElementById("type-display");
+const stabilityFill = document.getElementById("stability-fill");
+const stabilityMeter = stabilityFill.parentElement;
+const stabilityNote = document.getElementById("stability-note");
+const tempoIndicator = document.getElementById("tempo-indicator");
+const nextCallout = document.getElementById("next-callout");
+const wrapup = document.getElementById("wrapup");
+const wrapupSubtitle = document.getElementById("wrapup-subtitle");
+const wrapupHeight = document.getElementById("wrapup-height");
+const wrapupTotal = document.getElementById("wrapup-total");
+const wrapupRisk = document.getElementById("wrapup-risk");
+const wrapupPhoto = document.getElementById("wrapup-photo");
+const wrapupPhotoCaption = document.getElementById("wrapup-photo-caption");
+const wrapupRematch = document.getElementById("wrapup-rematch");
+const wrapupClose = document.getElementById("wrapup-close");
+const kitchenStage = document.querySelector(".kitchen-stage");
+
+const statusChannel = createStatusChannel(statusBar);
+const logChannel = createLogChannel(logList, { limit: 18 });
+
+autoEnhanceFeedback({ statusSelectors: ["#status-bar"], logSelectors: ["#service-log"] });
+
+if (!ctx) {
+  throw new Error("Canvas context not available for Flapjack Flip-Out");
+}
+
+const PX_PER_CM = 4;
+const FLOOR_Y = canvas.height - 70;
+const PLATE_WIDTH = 240;
+const PLATE_HEIGHT = 18;
+const PLATE_SPEED = 0.38; // px per ms when using keys
+const GRAVITY = 0.0011; // px per ms^2
+const WOBBLE_MAX = 100;
+const STACK_LEAN_LIMIT = 190;
+const STACK_SHAKE_THRESHOLD = 82;
+
+const PANCAKE_TYPES = [
+  {
+    id: "classic",
+    name: "Classic Round",
+    callout: "Classic",
+    width: 180,
+    thickness: 28,
+    mass: 1,
+    wobbleImpact: 9,
+    compressionCap: 0.16,
+    colors: {
+      top: "#fde68a",
+      sideTop: "#facc15",
+      sideBottom: "#f97316",
+      rim: "#fcd34d",
+      scorch: "#b45309",
+    },
+  },
+  {
+    id: "hefty",
+    name: "Griddle Titan",
+    callout: "Heavy",
+    width: 220,
+    thickness: 34,
+    mass: 1.6,
+    wobbleImpact: 14,
+    compressionCap: 0.22,
+    colors: {
+      top: "#fbbf24",
+      sideTop: "#f59e0b",
+      sideBottom: "#d97706",
+      rim: "#fcd34d",
+      scorch: "#92400e",
+    },
+  },
+  {
+    id: "mini",
+    name: "Silver Dollar Scatter",
+    callout: "Mini",
+    width: 130,
+    thickness: 22,
+    mass: 0.6,
+    wobbleImpact: 7,
+    compressionCap: 0.12,
+    colors: {
+      top: "#fef9c3",
+      sideTop: "#fcd34d",
+      sideBottom: "#f59e0b",
+      rim: "#fde68a",
+      scorch: "#9a3412",
+    },
+  },
+  {
+    id: "burnt",
+    name: "Burnt Brittle",
+    callout: "Brittle",
+    width: 170,
+    thickness: 26,
+    mass: 1.1,
+    wobbleImpact: 12,
+    compressionCap: 0.14,
+    brittle: true,
+    colors: {
+      top: "#fed7aa",
+      sideTop: "#fb7185",
+      sideBottom: "#c2410c",
+      rim: "#fecdd3",
+      scorch: "#7f1d1d",
+    },
+  },
+];
+
+const pancakeById = new Map(PANCAKE_TYPES.map((type) => [type.id, type]));
+
+const inputState = {
+  left: false,
+  right: false,
+};
+
+const pointerState = {
+  active: false,
+  pointerId: null,
+  targetX: null,
+};
+
+const state = {
+  running: false,
+  started: false,
+  round: 0,
+  tempo: 1,
+  plateX: canvas.width / 2,
+  previousPlateX: canvas.width / 2,
+  stack: [],
+  stackLean: 0,
+  stackLeanVelocity: 0,
+  wobble: 0,
+  wobblePeak: 0,
+  pancakesServed: 0,
+  pancakeTypes: new Map(),
+  falling: null,
+  launchTimer: 0,
+  pendingType: PANCAKE_TYPES[0],
+  bestSnapshot: null,
+  snapshotPending: false,
+  highestHeightCm: 0,
+  nudgeCount: 0,
+  riskyNudges: 0,
+  collapseReason: null,
+};
+
+let animationId = null;
+let lastTimestamp = performance.now();
+
+resetKitchen();
+startAnimation();
+wireControls();
+
+function startAnimation() {
+  if (animationId !== null) {
+    return;
+  }
+  const step = (timestamp) => {
+    const deltaMs = Math.min(timestamp - lastTimestamp, 48);
+    lastTimestamp = timestamp;
+    update(deltaMs);
+    render();
+    if (state.snapshotPending) {
+      captureSnapshot();
+      state.snapshotPending = false;
+    }
+    animationId = window.requestAnimationFrame(step);
+  };
+  animationId = window.requestAnimationFrame(step);
+}
+
+function wireControls() {
+  startButton.addEventListener("click", () => {
+    if (!state.running) {
+      beginService();
+    }
+  });
+
+  nudgeButton.addEventListener("click", () => {
+    performNudge();
+  });
+
+  resetButton.addEventListener("click", () => {
+    addLog("Kitchen reset. Plate re-centered.");
+    resetKitchen();
+  });
+
+  wrapupRematch.addEventListener("click", () => {
+    hideWrapup();
+    resetKitchen();
+    beginService();
+  });
+
+  wrapupClose.addEventListener("click", () => {
+    hideWrapup();
+    resetKitchen();
+    try {
+      window.parent?.postMessage({ type: "1989:return-to-menu", game: "flapjack-flip-out" }, "*");
+    } catch (error) {
+      // ignore cross-origin issues
+    }
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+      return;
+    }
+    const { key } = event;
+    if (["ArrowLeft", "a", "A"].includes(key)) {
+      inputState.left = true;
+      event.preventDefault();
+    } else if (["ArrowRight", "d", "D"].includes(key)) {
+      inputState.right = true;
+      event.preventDefault();
+    } else if (key === "n" || key === "N") {
+      event.preventDefault();
+      performNudge();
+    } else if (key === "r" || key === "R") {
+      event.preventDefault();
+      addLog("Manual reset requested.");
+      resetKitchen();
+    } else if (key === " ") {
+      if (!state.running) {
+        event.preventDefault();
+        beginService();
+      }
+    }
+  });
+
+  document.addEventListener("keyup", (event) => {
+    const { key } = event;
+    if (["ArrowLeft", "a", "A"].includes(key)) {
+      inputState.left = false;
+    } else if (["ArrowRight", "d", "D"].includes(key)) {
+      inputState.right = false;
+    }
+  });
+
+  const stage = kitchenStage;
+  stage.addEventListener("pointerdown", (event) => {
+    stage.setPointerCapture(event.pointerId);
+    pointerState.active = true;
+    pointerState.pointerId = event.pointerId;
+    updatePointerTarget(event);
+  });
+
+  stage.addEventListener("pointermove", (event) => {
+    if (!pointerState.active || pointerState.pointerId !== event.pointerId) {
+      return;
+    }
+    updatePointerTarget(event);
+  });
+
+  stage.addEventListener("pointerup", (event) => {
+    if (pointerState.pointerId === event.pointerId) {
+      pointerState.active = false;
+      pointerState.pointerId = null;
+      pointerState.targetX = null;
+    }
+  });
+
+  stage.addEventListener("pointercancel", () => {
+    pointerState.active = false;
+    pointerState.pointerId = null;
+    pointerState.targetX = null;
+  });
+}
+
+function updatePointerTarget(event) {
+  const rect = canvas.getBoundingClientRect();
+  const relativeX = ((event.clientX - rect.left) / rect.width) * canvas.width;
+  pointerState.targetX = clamp(relativeX, PLATE_WIDTH * 0.35, canvas.width - PLATE_WIDTH * 0.35);
+}
+
+function resetKitchen() {
+  state.running = false;
+  state.started = false;
+  state.round = 0;
+  state.tempo = 1;
+  state.stack = [];
+  state.stackLean = 0;
+  state.stackLeanVelocity = 0;
+  state.wobble = 0;
+  state.wobblePeak = 0;
+  state.pancakesServed = 0;
+  state.pancakeTypes.clear();
+  state.falling = null;
+  state.launchTimer = 0;
+  state.pendingType = PANCAKE_TYPES[0];
+  state.bestSnapshot = null;
+  state.snapshotPending = false;
+  state.highestHeightCm = 0;
+  state.nudgeCount = 0;
+  state.riskyNudges = 0;
+  state.collapseReason = null;
+  state.plateX = canvas.width / 2;
+  state.previousPlateX = state.plateX;
+  pointerState.active = false;
+  pointerState.pointerId = null;
+  pointerState.targetX = null;
+  startButton.disabled = false;
+  nudgeButton.disabled = true;
+  if (kitchenStage) {
+    kitchenStage.classList.remove("is-shaking");
+  }
+  hideWrapup();
+  updateTempoIndicator();
+  updateNextCallout();
+  updateHud();
+  statusChannel("Slide into position and begin service when ready.", "info");
+}
+
+function beginService() {
+  state.running = true;
+  state.started = true;
+  state.round = 0;
+  startButton.disabled = true;
+  nudgeButton.disabled = false;
+  queueNextPancake(true);
+  statusChannel("Classic batter inbound. Center the plate for the first catch!", "info");
+  addLog("Service opened. First pancake en route.");
+}
+
+function queueNextPancake(initial = false) {
+  if (!state.running) {
+    updateNextCallout();
+    return;
+  }
+  const nextRound = state.round + 1;
+  state.pendingType = choosePancakeType(nextRound);
+  const baseDelay = initial ? 850 : Math.max(520, 1200 - nextRound * 55);
+  state.launchTimer = baseDelay;
+  state.tempo = Math.min(6, 1 + Math.floor((nextRound - 1) / 3));
+  updateTempoIndicator();
+  updateNextCallout();
+}
+
+function choosePancakeType(round) {
+  if (round <= 2) {
+    return PANCAKE_TYPES[0];
+  }
+  const pool = [];
+  PANCAKE_TYPES.forEach((type) => {
+    let weight = 1;
+    if (type.id === "classic") {
+      weight = 3;
+    } else if (type.id === "hefty") {
+      weight = round >= 4 ? 2 : 0;
+    } else if (type.id === "mini") {
+      weight = round >= 5 ? 2 : 0;
+    } else if (type.id === "burnt") {
+      weight = round >= 7 ? 1.6 : 0;
+    }
+    if (weight > 0) {
+      pool.push({ type, weight });
+    }
+  });
+  const totalWeight = pool.reduce((sum, entry) => sum + entry.weight, 0);
+  const roll = Math.random() * totalWeight;
+  let acc = 0;
+  for (const entry of pool) {
+    acc += entry.weight;
+    if (roll <= acc) {
+      return entry.type;
+    }
+  }
+  return PANCAKE_TYPES[0];
+}
+
+function update(deltaMs) {
+  state.previousPlateX = state.plateX;
+  updatePlate(deltaMs);
+  settleStack(deltaMs);
+  easeWobble(deltaMs);
+  if (!state.running) {
+    updateNextCallout();
+    updateHud();
+    return;
+  }
+
+  if (!state.falling) {
+    state.launchTimer -= deltaMs;
+    updateNextCallout();
+    if (state.launchTimer <= 0) {
+      launchPancake();
+    }
+  }
+
+  if (state.falling) {
+    updateFallingPancake(state.falling, deltaMs);
+  }
+
+  updateStackStress(deltaMs);
+  detectInstability();
+  updateHud();
+}
+
+function updatePlate(deltaMs) {
+  const direction = (inputState.right ? 1 : 0) - (inputState.left ? 1 : 0);
+  if (pointerState.active && pointerState.targetX !== null) {
+    const followRate = Math.min(1, deltaMs / 90);
+    state.plateX += (pointerState.targetX - state.plateX) * followRate;
+  } else if (direction !== 0) {
+    state.plateX += direction * PLATE_SPEED * deltaMs * Math.max(1, state.tempo * 0.85);
+  }
+  state.plateX = clamp(state.plateX, PLATE_WIDTH * 0.35, canvas.width - PLATE_WIDTH * 0.35);
+  const deltaX = state.plateX - state.previousPlateX;
+  state.stackLean -= deltaX * 0.35;
+}
+
+function launchPancake() {
+  const type = state.pendingType ?? PANCAKE_TYPES[0];
+  const entryX = canvas.width * (0.25 + Math.random() * 0.5);
+  const baseVy = 0.26 + state.tempo * 0.02 + Math.random() * 0.05;
+  const baseVx = (Math.random() - 0.5) * (0.18 + state.tempo * 0.04);
+  state.falling = {
+    type,
+    x: entryX,
+    y: -type.thickness - 60,
+    vx: baseVx,
+    vy: baseVy,
+    rotation: (Math.random() - 0.5) * 0.15,
+    spin: (Math.random() - 0.5) * 0.0018,
+  };
+  state.round += 1;
+  addLog(`Launch ${state.round}: ${type.name} incoming.`);
+  statusChannel(`${type.name} incoming! Position the plate.`, "info");
+  state.pendingType = choosePancakeType(state.round + 1);
+  state.launchTimer = Math.max(480, 1150 - state.round * 55);
+  updateTempoIndicator();
+  updateNextCallout();
+}
+
+function updateFallingPancake(pancake, deltaMs) {
+  pancake.vy += GRAVITY * deltaMs;
+  pancake.x += pancake.vx * deltaMs;
+  pancake.y += pancake.vy * deltaMs;
+  pancake.rotation += pancake.spin * deltaMs;
+
+  const stackHeight = getStackHeightPx();
+  const catchY = FLOOR_Y - stackHeight - pancake.type.thickness * 0.5;
+  if (pancake.y >= catchY) {
+    attemptCatch(pancake);
+  } else if (pancake.y > FLOOR_Y + 140) {
+    collapseTower("The pancake splats on the floor. Service over!", "danger");
+    addLog("Dropped pancake. Tower lost.", "danger");
+  }
+}
+
+function attemptCatch(pancake) {
+  const stackCenter = state.plateX + state.stackLean;
+  const catchWindow = (PLATE_WIDTH + pancake.type.width) * 0.5;
+  const offset = pancake.x - stackCenter;
+  if (Math.abs(offset) <= catchWindow) {
+    lockPancake(pancake, offset, catchWindow);
+  } else {
+    collapseTower("Missed the catch—tower topples.", "danger");
+    addLog("Missed catch. The stack crashes down!", "danger");
+  }
+}
+
+function lockPancake(pancake, offset, catchWindow) {
+  state.falling = null;
+  const type = pancake.type;
+  const compressionBase = Math.min(type.compressionCap, 0.06 * state.stack.length * type.mass + Math.abs(offset) / 620);
+  const entry = {
+    type,
+    offset,
+    compression: compressionBase,
+    rotation: clamp(offset / 320, -0.3, 0.3),
+    stress: 0,
+  };
+  state.stack.push(entry);
+  state.pancakesServed += 1;
+  const currentCount = state.pancakeTypes.get(type.id) ?? 0;
+  state.pancakeTypes.set(type.id, currentCount + 1);
+
+  const wobbleGain = Math.abs(offset) / (type.width * 0.5) * type.wobbleImpact * (1 + state.tempo * 0.15);
+  state.wobble = clamp(state.wobble + wobbleGain + type.mass * 4.2, 0, WOBBLE_MAX);
+  state.wobblePeak = Math.max(state.wobblePeak, state.wobble);
+  state.stackLeanVelocity += offset * 0.008 * type.mass;
+  state.stackLean += offset * 0.12;
+
+  const heightCm = Math.round(getStackHeightPx() / PX_PER_CM);
+  heightDisplay.textContent = `${heightCm} cm`;
+  if (heightCm > state.highestHeightCm) {
+    state.highestHeightCm = heightCm;
+    peakDisplay.textContent = `${heightCm} cm`;
+    state.snapshotPending = true;
+    particleSystem.emitSparkle(1);
+    addLog(`New peak height: ${heightCm} cm!`, "success");
+  }
+
+  if (Math.abs(offset) <= 12) {
+    state.wobble = Math.max(0, state.wobble - 12);
+    statusChannel("Perfect catch! Stack steadies.", "success");
+    addLog("Perfect center catch. Stack tightens.", "success");
+    particleSystem.emitSparkle(0.9);
+  } else if (Math.abs(offset) > catchWindow * 0.75) {
+    statusChannel("Wild catch! Tower lurches hard.", "warning");
+    addLog("Severe off-center catch. Tower sways dangerously.", "warning");
+  } else {
+    statusChannel("Off-center catch. Wobble climbing.", "info");
+    addLog("Stack wobbles from an off-center catch.");
+  }
+
+  if (type.brittle && state.wobble > 68) {
+    collapseTower("The burnt pancake fractures under pressure!", "danger");
+    addLog("Brittle pancake shattered—stack collapses!", "danger");
+    return;
+  }
+
+  queueNextPancake();
+}
+
+function settleStack(deltaMs) {
+  const delta = deltaMs / 16.6667;
+  state.stackLean += state.stackLeanVelocity * delta;
+  const spring = -state.stackLean * 0.0024;
+  state.stackLeanVelocity += spring * delta;
+  state.stackLeanVelocity *= 0.96;
+}
+
+function easeWobble(deltaMs) {
+  const decay = deltaMs * 0.012;
+  state.wobble = Math.max(0, state.wobble - decay);
+}
+
+function updateStackStress(deltaMs) {
+  const wobbleRatio = state.wobble / WOBBLE_MAX;
+  state.stack.forEach((pancake, index) => {
+    const massFactor = pancake.type.mass * (index + 1) * 0.75;
+    const offsetFactor = Math.abs(pancake.offset) / Math.max(1, pancake.type.width * 0.5);
+    const compressionGain = Math.min(
+      pancake.type.compressionCap,
+      pancake.compression + wobbleRatio * 0.06 * pancake.type.mass + offsetFactor * 0.04,
+    );
+    pancake.compression = compressionGain;
+    const stressValue = wobbleRatio * 100 + offsetFactor * 60 + massFactor * 4;
+    pancake.stress = stressValue;
+    pancake.rotation += state.stackLeanVelocity * 0.0004 * deltaMs;
+  });
+}
+
+function detectInstability() {
+  const leanRisk = Math.abs(state.stackLean) / STACK_LEAN_LIMIT;
+  if (leanRisk > 1) {
+    collapseTower("The tower leans too far and avalanches!", "danger");
+    addLog("Lean exceeded the plate edge—tower avalanches.", "danger");
+    return;
+  }
+  const highestStress = state.stack.reduce((max, pancake) => Math.max(max, pancake.stress ?? 0), 0);
+  if (highestStress > 110) {
+    collapseTower("Stack stress maxes out—the tower buckles.", "danger");
+    addLog("Stress overload snaps the stack.", "danger");
+  } else if (highestStress > STACK_SHAKE_THRESHOLD && state.running) {
+    statusChannel("Stack groans under pressure. Consider nudging!", "warning");
+  }
+
+  if (state.wobble >= WOBBLE_MAX) {
+    collapseTower("Wobble maxes out. Tower tumbles!", "danger");
+    addLog("Wobble peaked at maximum. Collapse inevitable.", "danger");
+  }
+}
+
+function updateHud() {
+  const heightCm = Math.round(getStackHeightPx() / PX_PER_CM);
+  heightDisplay.textContent = `${heightCm} cm`;
+  peakDisplay.textContent = `${state.highestHeightCm} cm`;
+  countDisplay.textContent = String(state.pancakesServed);
+  const typeLabels = Array.from(state.pancakeTypes.entries()).map(([id, count]) => {
+    const type = pancakeById.get(id);
+    if (!type) {
+      return `${count}`;
+    }
+    return `${type.callout}×${count}`;
+  });
+  typeDisplay.textContent = typeLabels.length > 0 ? typeLabels.join(" · ") : "—";
+  const wobblePercent = Math.round((state.wobble / WOBBLE_MAX) * 100);
+  stabilityFill.style.width = `${Math.min(100, wobblePercent)}%`;
+  stabilityMeter.setAttribute("aria-valuenow", String(Math.min(100, wobblePercent)));
+  if (wobblePercent < 20) {
+    stabilityNote.textContent = "Plate is steady.";
+  } else if (wobblePercent < 55) {
+    stabilityNote.textContent = "Gentle sway building.";
+  } else if (wobblePercent < 80) {
+    stabilityNote.textContent = "Tower is tense—prep a nudge.";
+  } else {
+    stabilityNote.textContent = "Critical wobble! Immediate action.";
+  }
+}
+
+function updateTempoIndicator() {
+  tempoIndicator.textContent = `Tempo: ${state.tempo}`;
+}
+
+function updateNextCallout() {
+  if (!state.running) {
+    nextCallout.hidden = state.stack.length === 0;
+    if (state.stack.length === 0) {
+      nextCallout.hidden = true;
+    } else {
+      nextCallout.textContent = "Service paused.";
+    }
+    return;
+  }
+  if (!state.pendingType) {
+    nextCallout.hidden = true;
+    return;
+  }
+  const seconds = Math.max(0, state.launchTimer) / 1000;
+  const eta = seconds > 0.2 ? `${seconds.toFixed(1)}s` : "now";
+  nextCallout.textContent = `Next: ${state.pendingType.name} (${state.pendingType.callout}) in ${eta}`;
+  nextCallout.hidden = false;
+}
+
+function performNudge() {
+  if (!state.running || state.stack.length === 0) {
+    statusChannel("No stack to nudge yet—catch a pancake first!", "info");
+    return;
+  }
+  state.nudgeCount += 1;
+  const wobbleRatio = state.wobble / WOBBLE_MAX;
+  const failureChance = Math.max(0.08, 0.22 + wobbleRatio * 0.5);
+  const roll = Math.random();
+  if (roll < failureChance) {
+    state.riskyNudges += 1;
+    collapseTower("Nudge backfires—the tower snaps!", "danger");
+    addLog("Nudge failed. Stack crashes instantly!", "danger");
+    return;
+  }
+  const correction = state.stackLean * 0.6;
+  state.stackLean -= correction;
+  state.stackLeanVelocity *= 0.2;
+  const wobbleDrop = 18 + wobbleRatio * 22;
+  state.wobble = Math.max(0, state.wobble - wobbleDrop);
+  state.wobblePeak = Math.max(state.wobblePeak, state.wobble);
+  statusChannel("Nudge lands. Stack steadies for a beat.", "success");
+  addLog(`Nudge success. Wobble eased by ${Math.round(wobbleDrop)}%.`, "success");
+  particleSystem.emitSparkle(0.95);
+}
+
+function collapseTower(message, tone = "danger") {
+  if (!state.running) {
+    return;
+  }
+  state.running = false;
+  nudgeButton.disabled = true;
+  startButton.disabled = false;
+  state.collapseReason = message;
+  statusChannel(message, tone);
+  addLog("Service complete. Cleaning syrup everywhere.");
+  particleSystem.emitBurst(1.6);
+  particleSystem.emitSparkle(1.1);
+  if (kitchenStage) {
+    kitchenStage.classList.remove("is-shaking");
+    void kitchenStage.offsetWidth; // reflow
+    kitchenStage.classList.add("is-shaking");
+  }
+  window.setTimeout(() => {
+    showWrapup();
+  }, 620);
+}
+
+function showWrapup() {
+  const finalHeight = Math.round(getStackHeightPx() / PX_PER_CM);
+  wrapupHeight.textContent = `${finalHeight} cm`;
+  wrapupTotal.textContent = String(state.pancakesServed);
+  wrapupRisk.textContent = state.nudgeCount > 0 ? `${state.nudgeCount} nudges` : "None";
+  wrapupSubtitle.textContent = state.collapseReason ?? "Service closed.";
+  wrapupPhoto.hidden = !state.bestSnapshot;
+  wrapupPhoto.src = state.bestSnapshot ?? "";
+  wrapupPhotoCaption.textContent = state.bestSnapshot
+    ? `Tallest tower: ${state.highestHeightCm} cm`
+    : "No tower captured.";
+  wrapup.hidden = false;
+  const meta = {
+    pancakes: state.pancakesServed,
+    nudges: state.nudgeCount,
+    tempo: state.tempo,
+  };
+  highScore.submit(state.highestHeightCm, meta);
+}
+
+function hideWrapup() {
+  wrapup.hidden = true;
+}
+
+function getStackHeightPx() {
+  return state.stack.reduce((sum, pancake) => sum + pancake.type.thickness * (1 - pancake.compression), 0);
+}
+
+function captureSnapshot() {
+  try {
+    state.bestSnapshot = canvas.toDataURL("image/png");
+  } catch (error) {
+    // ignore capture errors (e.g., memory pressure)
+  }
+}
+
+function render() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  drawBackground();
+  drawKitchenElements();
+  drawStack();
+  drawFalling();
+}
+
+function drawBackground() {
+  const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
+  gradient.addColorStop(0, "#0f172a");
+  gradient.addColorStop(0.4, "#111827");
+  gradient.addColorStop(1, "#1f2937");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+function drawKitchenElements() {
+  ctx.save();
+  ctx.fillStyle = "rgba(15, 23, 42, 0.85)";
+  ctx.fillRect(0, FLOOR_Y + 8, canvas.width, canvas.height - FLOOR_Y - 8);
+  const counterGrad = ctx.createLinearGradient(0, FLOOR_Y - 16, 0, FLOOR_Y + 32);
+  counterGrad.addColorStop(0, "#f97316");
+  counterGrad.addColorStop(1, "#7c2d12");
+  ctx.fillStyle = counterGrad;
+  ctx.fillRect(-20, FLOOR_Y - 12, canvas.width + 40, 60);
+  ctx.restore();
+  drawPlate();
+}
+
+function drawRoundedRect(context, x, y, width, height, radius) {
+  const r = Math.min(radius, Math.abs(width) / 2, Math.abs(height) / 2);
+  context.beginPath();
+  context.moveTo(x + r, y);
+  context.lineTo(x + width - r, y);
+  context.quadraticCurveTo(x + width, y, x + width, y + r);
+  context.lineTo(x + width, y + height - r);
+  context.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+  context.lineTo(x + r, y + height);
+  context.quadraticCurveTo(x, y + height, x, y + height - r);
+  context.lineTo(x, y + r);
+  context.quadraticCurveTo(x, y, x + r, y);
+  context.closePath();
+}
+
+function drawPlate() {
+  ctx.save();
+  ctx.translate(state.plateX, FLOOR_Y);
+  const plateGradient = ctx.createLinearGradient(-PLATE_WIDTH / 2, 0, PLATE_WIDTH / 2, PLATE_HEIGHT);
+  plateGradient.addColorStop(0, "rgba(56, 189, 248, 0.7)");
+  plateGradient.addColorStop(1, "rgba(59, 130, 246, 0.45)");
+  ctx.fillStyle = plateGradient;
+  drawRoundedRect(ctx, -PLATE_WIDTH / 2, -PLATE_HEIGHT, PLATE_WIDTH, PLATE_HEIGHT * 1.2, 12);
+  ctx.fill();
+  ctx.fillStyle = "rgba(30, 64, 175, 0.25)";
+  drawRoundedRect(ctx, -PLATE_WIDTH / 2 + 12, -PLATE_HEIGHT * 0.9, PLATE_WIDTH - 24, PLATE_HEIGHT * 0.7, 10);
+  ctx.fill();
+  ctx.restore();
+}
+
+function drawStack() {
+  let stackY = FLOOR_Y;
+  state.stack.forEach((pancake) => {
+    const effectiveThickness = pancake.type.thickness * (1 - pancake.compression);
+    stackY -= effectiveThickness;
+    const centerX = state.plateX + state.stackLean + pancake.offset;
+    drawPancake(centerX, stackY, pancake);
+  });
+}
+
+function drawPancake(x, y, pancake) {
+  const { type } = pancake;
+  const width = type.width * (1 - pancake.compression * 0.2);
+  const height = type.thickness * (1 - pancake.compression * 0.5);
+  const ellipseHeight = height * 0.45;
+  ctx.save();
+  ctx.translate(x, y);
+  ctx.rotate(pancake.rotation ?? 0);
+  const sideGradient = ctx.createLinearGradient(0, -height / 2, 0, height / 2);
+  sideGradient.addColorStop(0, type.colors.sideTop);
+  sideGradient.addColorStop(1, type.colors.sideBottom);
+  ctx.fillStyle = sideGradient;
+  ctx.fillRect(-width / 2, -height / 2, width, height);
+  ctx.fillStyle = type.colors.bottom ?? type.colors.sideBottom;
+  ctx.beginPath();
+  ctx.ellipse(0, height / 2, width / 2, ellipseHeight, 0, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.fillStyle = type.colors.top;
+  ctx.beginPath();
+  ctx.ellipse(0, -height / 2, width / 2, ellipseHeight, 0, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.strokeStyle = "rgba(15, 23, 42, 0.18)";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.ellipse(0, -height / 2, width / 2, ellipseHeight, 0, 0, Math.PI * 2);
+  ctx.stroke();
+  if ((pancake.stress ?? 0) > STACK_SHAKE_THRESHOLD) {
+    drawStressLines(width, height, pancake);
+  }
+  ctx.restore();
+}
+
+function drawStressLines(width, height, pancake) {
+  ctx.save();
+  ctx.strokeStyle = "rgba(248, 113, 113, 0.7)";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  const segments = 3;
+  for (let i = 0; i < segments; i += 1) {
+    const offsetX = -width / 2 + (i + 0.5) * (width / segments);
+    ctx.moveTo(offsetX, -height / 2);
+    ctx.lineTo(offsetX + (Math.random() - 0.5) * 8, -height / 2 - 10);
+  }
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawFalling() {
+  if (!state.falling) {
+    return;
+  }
+  const pancake = state.falling;
+  const width = pancake.type.width;
+  const height = pancake.type.thickness;
+  const ellipseHeight = height * 0.45;
+  ctx.save();
+  ctx.translate(pancake.x, pancake.y);
+  ctx.rotate(pancake.rotation);
+  const sideGradient = ctx.createLinearGradient(0, -height / 2, 0, height / 2);
+  sideGradient.addColorStop(0, pancake.type.colors.sideTop);
+  sideGradient.addColorStop(1, pancake.type.colors.sideBottom);
+  ctx.fillStyle = sideGradient;
+  ctx.fillRect(-width / 2, -height / 2, width, height);
+  ctx.fillStyle = pancake.type.colors.bottom ?? pancake.type.colors.sideBottom;
+  ctx.beginPath();
+  ctx.ellipse(0, height / 2, width / 2, ellipseHeight, 0, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.fillStyle = pancake.type.colors.top;
+  ctx.beginPath();
+  ctx.ellipse(0, -height / 2, width / 2, ellipseHeight, 0, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+}
+
+function addLog(message, tone = "info") {
+  logChannel.push(message, tone);
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+*** End of File ***

--- a/madia.new/public/secret/1989/flapjack-flip-out/index.html
+++ b/madia.new/public/secret/1989/flapjack-flip-out/index.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Flapjack Flip-Out</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="flapjack-flip-out.css" />
+  </head>
+  <body class="secret-annex-snes flapjack-cabinet">
+    <a class="skip-link" href="#main-content">Skip to game</a>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 29 · 1989 Arcade</p>
+      <h1>Flapjack Flip-Out</h1>
+      <p class="subtitle">
+        Balance a teetering tower of skillet-sized pancakes while Uncle Buck's mystery spatula keeps the brunch rush rolling.
+      </p>
+    </header>
+    <main id="main-content" class="page-layout">
+      <section class="briefing" aria-labelledby="briefing-title">
+        <h2 id="briefing-title">Kitchen Briefing</h2>
+        <p>
+          Welcome to the late-night pancake line. You steer the plate while the unseen spatula flings flapjacks from offstage.
+          A centered catch keeps the stack tidy. Slide even a little and the wobble ripples through every layer of batter.
+        </p>
+        <ul class="callouts">
+          <li>
+            <strong>Setup phase:</strong> Start with a calm plate and perfectly circular pancakes. Get your footing before the
+            tempo spikes.
+          </li>
+          <li>
+            <strong>Action phase:</strong> Each launch arrives faster with weirder sizes—hefty griddles, mini silver dollars, and
+            burnt brittle discs that can shatter if squeezed too hard.
+          </li>
+          <li>
+            <strong>Risk vs. reward:</strong> Off-center stacks wobble. Tap <em>Nudge</em> to re-center, but overdo it and the
+            whole tower cascades into syrupy chaos.
+          </li>
+          <li>
+            <strong>Win condition:</strong> Chase the tallest possible stack height before you drop a pancake or collapse the
+            tower. Height is king; total pancakes is your flair bonus.
+          </li>
+        </ul>
+        <section class="controls" aria-labelledby="controls-title">
+          <h3 id="controls-title">Controls</h3>
+          <dl>
+            <div>
+              <dt>Move plate</dt>
+              <dd>Arrow keys or <strong>A/D</strong> to slide. Mouse or touch drag inside the kitchen works too.</dd>
+            </div>
+            <div>
+              <dt>Start round</dt>
+              <dd>Press <strong>Begin Service</strong> to cue the spatula.</dd>
+            </div>
+            <div>
+              <dt>Nudge stack</dt>
+              <dd>
+                Tap <strong>N</strong> or the <strong>Nudge</strong> button to gamble on re-centering. Higher wobble means higher
+                bust odds.
+              </dd>
+            </div>
+            <div>
+              <dt>Reset</dt>
+              <dd>Press <strong>Reset Kitchen</strong> or hit <strong>R</strong> to start a fresh service.</dd>
+            </div>
+          </dl>
+        </section>
+      </section>
+      <section class="arena" aria-labelledby="arena-title">
+        <div class="arena-header">
+          <h2 id="arena-title">Buck's Midnight Kitchen</h2>
+          <div class="arena-controls" role="group" aria-label="Action controls">
+            <button type="button" class="action-button" id="start-service">Begin Service</button>
+            <button type="button" class="action-button" id="nudge-stack" disabled>Nudge</button>
+            <button type="button" class="action-button" id="reset-kitchen">Reset Kitchen</button>
+          </div>
+        </div>
+        <div class="status-rail">
+          <div class="score-card" aria-live="polite">
+            <header class="score-card-header">
+              <h3>Stack Height</h3>
+              <span class="score-label">Current</span>
+            </header>
+            <p class="score-value" id="height-display">0 cm</p>
+            <p class="score-note">Peak: <span id="peak-display">0 cm</span></p>
+          </div>
+          <div class="score-card" aria-live="polite">
+            <header class="score-card-header">
+              <h3>Pancake Count</h3>
+              <span class="score-label">Served</span>
+            </header>
+            <p class="score-value" id="count-display">0</p>
+            <p class="score-note">Types: <span id="type-display">—</span></p>
+          </div>
+          <div class="score-card" aria-live="polite">
+            <header class="score-card-header">
+              <h3>Stability</h3>
+              <span class="score-label">Risk Meter</span>
+            </header>
+            <div class="stability-meter" role="meter" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Stack wobble">
+              <div class="stability-fill" id="stability-fill"></div>
+            </div>
+            <p class="score-note" id="stability-note">Plate is steady.</p>
+          </div>
+        </div>
+        <div class="status-bar" id="status-bar">Slide into position and begin service when ready.</div>
+        <div class="kitchen-stage">
+          <canvas id="stack-canvas" width="900" height="540" aria-label="Pancake stacking stage"></canvas>
+          <div class="stage-overlay">
+            <div class="tempo" id="tempo-indicator">Tempo: 1</div>
+            <div class="pancake-callout" id="next-callout" hidden></div>
+          </div>
+        </div>
+        <section class="log" aria-labelledby="log-title">
+          <h3 id="log-title">Service Log</h3>
+          <ul id="service-log"></ul>
+        </section>
+      </section>
+    </main>
+    <footer class="page-footer">
+      <p>
+        Tip: Burnt pancakes hate compression. If you catch one off-center, either nudge immediately or prepare for a crunchy
+        collapse.
+      </p>
+    </footer>
+    <div class="wrapup" id="wrapup" hidden role="dialog" aria-modal="true" aria-labelledby="wrapup-title">
+      <div class="wrapup-panel">
+        <header class="wrapup-header">
+          <h2 id="wrapup-title">Service Complete</h2>
+          <p id="wrapup-subtitle"></p>
+        </header>
+        <div class="wrapup-body">
+          <dl class="wrapup-stats">
+            <div>
+              <dt>Final Height</dt>
+              <dd id="wrapup-height">0 cm</dd>
+            </div>
+            <div>
+              <dt>Total Pancakes</dt>
+              <dd id="wrapup-total">0</dd>
+            </div>
+            <div>
+              <dt>Risk Taken</dt>
+              <dd id="wrapup-risk">None</dd>
+            </div>
+          </dl>
+          <figure class="wrapup-photo">
+            <img id="wrapup-photo" alt="Photo of the tallest pancake tower" />
+            <figcaption id="wrapup-photo-caption">Tallest tower snapshot</figcaption>
+          </figure>
+        </div>
+        <footer class="wrapup-footer">
+          <button type="button" class="action-button" id="wrapup-rematch">Run It Back</button>
+          <button type="button" class="action-button" id="wrapup-close">Return to Cabinet</button>
+        </footer>
+      </div>
+    </div>
+    <script type="module" src="flapjack-flip-out.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/1989/score-config.js
+++ b/madia.new/public/secret/1989/score-config.js
@@ -84,6 +84,11 @@ export const scoreConfigs = {
     format: ({ value }) =>
       value === 1 ? "1 cooled" : `${value ?? 0} cooled`,
   },
+  "flapjack-flip-out": {
+    label: "Stack Height",
+    empty: "No stacks flipped yet.",
+    format: ({ value }) => `${value ?? 0} cm`,
+  },
   "kodiak-covenant": {
     label: "Traps Cleared",
     empty: "No traps cleared yet.",


### PR DESCRIPTION
## Summary
- add the Flapjack Flip-Out cabinet with physics-driven pancake stacking, HUD feedback, and wrap-up flow
- wire the cabinet into the 1989 arcade catalog and scoring config with a new thumbnail entry
- update the 1989 coverage doc to mark Uncle Buck as fulfilled at Level 29

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e02acca88483288cd9df83e902c9ac