### PR TITLE
feat: add diner debate cabinet

### DIFF
--- a/docs/1989/movie-coverage.md
+++ b/docs/1989/movie-coverage.md
@@ -2,7 +2,7 @@
 
 This reference tracks how the 1989 arcade cabinets map to their source films and how far the ladder has progressed up the 1989 domestic box office chart.
 
-Three Fugitives now anchors Level 32, covering the next-highest new release still on the chart while the rest of the ladder continues to backfill the remaining Top 50 slots.
+Three Fugitives now anchors Level 32, covering the next-highest new release still on the chart while the rest of the ladder continues to backfill the remaining Top 50 slots. The Diner Debate locks in Level 24 with a booth-shaking homage to *When Harry Met Sally...*.
 
 ## Covered Films
 
@@ -29,6 +29,7 @@ Three Fugitives now anchors Level 32, covering the next-highest new release stil
 | 32 | Three Fugitives | *Three Fugitives* | #31 |
 | 31 | Nose for Trouble | *K-9* | #30 |
 | 30 | Gilded Partition | *The War of the Roses* | #12 |
+| 24 | The Diner Debate | *When Harry Met Sally...* | #11 |
 
 Remaining:
 ## Remaining Targets to Reach #1
@@ -60,7 +61,6 @@ Remaining:
 | **27** | Ghostbusters II | #7 | River of Slime Escape | A frantic action level where you navigate a maze while avoiding a rising, negative pink slime that reacts to bad vibes. |
 | **26** | Back to the Future Part II | #8 | Hoverboard Pursuit | A time-trial race level using a hoverboard to navigate future (2015) traffic and obstacles. |
 | **25** | Parenthood | #9 | Rollercoaster of Life | A fast-paced decision-making game, quickly choosing the 'right' or 'wrong' answer to various parental/family dilemmas. |
-| **24** | When Harry Met Sally... | #11 | The Diner Debate | A reaction game where you have to perfectly time a very convincing vocal display in a crowded diner (like a rhythm or memory sequence). |
 | **23** | Turner & Hooch | #12 | Tailing the Trash | A stealth/clean-up mission where you follow a key item (or suspect) without leaving any messy dog-related evidence behind. |
 | **22** | Uncle Buck | #13 | Flapjack Flip-Out | A physics/timing game where you try to stack giant, burned pancakes without them collapsing. |
 | **21** | Field of Dreams | #14 | Whisper's Garden | A meditative game where you follow subtle auditory cues ("If you build it...") to find and plant crops on a field before time runs out. |

--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -615,6 +615,56 @@ const games = [
     `,
   },
   {
+    id: "diner-debate",
+    name: "The Diner Debate",
+    description: "Time every cue, shatter the doubts, and choose the perfect moment for the neon climax.",
+    url: "./diner-debate/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="The Diner Debate preview">
+        <defs>
+          <linearGradient id="dinerBackdrop" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#1e293b" />
+            <stop offset="100%" stop-color="#0f172a" />
+          </linearGradient>
+          <linearGradient id="boothGlow" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(244,114,182,0.65)" />
+            <stop offset="100%" stop-color="rgba(56,189,248,0.45)" />
+          </linearGradient>
+          <linearGradient id="timelineSweep" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stop-color="#38bdf8" />
+            <stop offset="50%" stop-color="#facc15" />
+            <stop offset="100%" stop-color="#f472b6" />
+          </linearGradient>
+        </defs>
+        <rect x="8" y="10" width="144" height="100" rx="18" fill="rgba(8,11,22,0.94)" stroke="rgba(148,163,184,0.35)" />
+        <rect x="16" y="18" width="128" height="84" rx="16" fill="url(#dinerBackdrop)" stroke="rgba(148,163,184,0.28)" />
+        <g>
+          <rect x="24" y="32" width="44" height="52" rx="16" fill="rgba(244,114,182,0.3)" stroke="rgba(244,114,182,0.55)" />
+          <rect x="92" y="32" width="44" height="52" rx="16" fill="rgba(56,189,248,0.28)" stroke="rgba(56,189,248,0.5)" />
+        </g>
+        <rect x="50" y="56" width="60" height="26" rx="12" fill="rgba(15,23,42,0.9)" stroke="rgba(148,163,184,0.45)" />
+        <rect x="62" y="44" width="36" height="12" rx="6" fill="url(#boothGlow)" stroke="rgba(248,250,252,0.35)" />
+        <g>
+          <rect x="24" y="84" width="112" height="18" rx="9" fill="rgba(15,23,42,0.9)" stroke="rgba(56,189,248,0.4)" />
+          <rect x="28" y="88" width="104" height="10" rx="5" fill="rgba(15,23,42,0.9)" stroke="rgba(56,189,248,0.4)" />
+          <rect x="30" y="90" width="100" height="6" rx="3" fill="rgba(15,23,42,0.9)" stroke="rgba(148,163,184,0.3)" />
+          <rect x="30" y="90" width="70" height="6" rx="3" fill="rgba(59,130,246,0.35)" />
+          <line x1="80" y1="86" x2="80" y2="104" stroke="url(#timelineSweep)" stroke-width="4" stroke-linecap="round" />
+          <circle cx="108" cy="93" r="8" fill="rgba(244,114,182,0.85)" stroke="rgba(248,250,252,0.5)" />
+          <circle cx="52" cy="93" r="8" fill="rgba(56,189,248,0.85)" stroke="rgba(248,250,252,0.45)" />
+          <circle cx="80" cy="93" r="9" fill="rgba(250,204,21,0.88)" stroke="rgba(248,250,252,0.6)" />
+        </g>
+        <g>
+          <path d="M34 28 C46 20 68 18 80 24" fill="none" stroke="rgba(244,114,182,0.55)" stroke-width="3" stroke-linecap="round" />
+          <path d="M80 24 C92 18 114 22 126 30" fill="none" stroke="rgba(56,189,248,0.5)" stroke-width="3" stroke-linecap="round" />
+          <circle cx="44" cy="28" r="5" fill="#facc15" stroke="rgba(248,250,252,0.6)" stroke-width="1.2" />
+          <circle cx="80" cy="24" r="5" fill="#38bdf8" stroke="rgba(248,250,252,0.6)" stroke-width="1.2" />
+          <circle cx="118" cy="30" r="5" fill="#f472b6" stroke="rgba(248,250,252,0.6)" stroke-width="1.2" />
+        </g>
+      </svg>
+    `,
+  },
+  {
     id: "speed-zone",
     name: "Speed Zone",
     description: "Chart a cannonball sprint past sirens, tolls, and neon checkpoints.",

--- a/madia.new/public/secret/1989/diner-debate/diner-debate.css
+++ b/madia.new/public/secret/1989/diner-debate/diner-debate.css
@@ -1,0 +1,613 @@
+:root {
+  color-scheme: dark;
+}
+
+.diner-debate {
+  background: radial-gradient(circle at 20% 20%, rgba(251, 191, 36, 0.12), transparent 50%),
+    radial-gradient(circle at 80% 15%, rgba(59, 130, 246, 0.18), transparent 55%),
+    linear-gradient(135deg, rgba(15, 23, 42, 0.95) 0%, rgba(9, 12, 24, 0.94) 60%, rgba(34, 25, 45, 0.9) 100%);
+  min-height: 100vh;
+  color: #e2e8f0;
+}
+
+.page-layout {
+  display: grid;
+  grid-template-columns: minmax(320px, 380px) 1fr;
+  gap: 32px;
+  align-items: start;
+}
+
+.briefing {
+  background: rgba(12, 18, 36, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 18px;
+  padding: 24px;
+  box-shadow: 0 12px 24px rgba(2, 6, 23, 0.45);
+  backdrop-filter: blur(6px);
+}
+
+.briefing .callouts {
+  margin: 16px 0 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 12px;
+}
+
+.briefing .callouts li {
+  line-height: 1.5;
+}
+
+.key-guide {
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.legend-list {
+  display: grid;
+  gap: 16px;
+}
+
+.legend-list dt {
+  font-weight: 600;
+  color: #facc15;
+}
+
+.legend-list dd {
+  margin: 6px 0 0;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.stage {
+  background: rgba(10, 16, 32, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 22px;
+  padding: 24px;
+  box-shadow: 0 16px 32px rgba(2, 6, 23, 0.55);
+  backdrop-filter: blur(8px);
+  position: relative;
+  overflow: hidden;
+}
+
+.stage::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 50% 10%, rgba(251, 191, 36, 0.2), transparent 60%);
+  opacity: 0.6;
+}
+
+.stage.climax-active::after {
+  background: radial-gradient(circle at 50% 50%, rgba(244, 114, 182, 0.25), transparent 65%);
+  opacity: 1;
+}
+
+.stage-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  position: relative;
+  z-index: 1;
+}
+
+.stage-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.stage-subtitle {
+  margin-top: 6px;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.performance-shell {
+  margin-top: 24px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+  position: relative;
+  z-index: 1;
+}
+
+.score-tile {
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 14px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 120px;
+  justify-content: center;
+}
+
+.score-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.score-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #facc15;
+}
+
+.score-note {
+  font-size: 0.9rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.score-tile.climax {
+  gap: 14px;
+  align-items: center;
+}
+
+.climax-meter {
+  width: 100%;
+  height: 18px;
+  border-radius: 20px;
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(56, 189, 248, 0.45);
+  overflow: hidden;
+  position: relative;
+}
+
+.climax-fill {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  background: linear-gradient(90deg, #38bdf8, #f472b6, #facc15);
+  transition: width 140ms ease-out;
+}
+
+.climax-caption {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.climax-button {
+  width: 100%;
+  background: rgba(120, 255, 255, 0.18);
+  border: 1px solid rgba(56, 189, 248, 0.5);
+  color: #e2e8f0;
+  border-radius: 999px;
+  padding: 10px 16px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.climax-button:not(:disabled):hover,
+.climax-button:not(:disabled):focus {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 16px rgba(56, 189, 248, 0.35);
+}
+
+.climax-button:disabled {
+  opacity: 0.45;
+}
+
+.diner-floor {
+  margin-top: 28px;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.9) 0%, rgba(30, 41, 59, 0.85) 45%, rgba(79, 70, 229, 0.25) 100%);
+  padding: 24px;
+  position: relative;
+  overflow: hidden;
+  min-height: 220px;
+  backdrop-filter: blur(4px);
+  transition: filter 160ms ease;
+}
+
+.stage.climax-active .diner-floor {
+  filter: blur(2px) brightness(0.8);
+}
+
+.crowd {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  padding: 12px 18px;
+  pointer-events: none;
+}
+
+.patron {
+  width: 90px;
+  height: 140px;
+  border-radius: 45px 45px 16px 16px;
+  background: linear-gradient(180deg, rgba(148, 163, 184, 0.2), rgba(71, 85, 105, 0.7));
+  opacity: 0.55;
+  position: relative;
+}
+
+.patron::after {
+  content: "";
+  position: absolute;
+  inset: 18px 18px auto 18px;
+  height: 28px;
+  border-radius: 50%;
+  background: rgba(226, 232, 240, 0.6);
+  opacity: 0.65;
+}
+
+.camera-flash {
+  position: absolute;
+  top: 40px;
+  left: 50%;
+  width: 180px;
+  height: 180px;
+  transform: translateX(-50%);
+  background: radial-gradient(circle, rgba(250, 204, 21, 0.6), transparent 65%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.camera-flash.is-active {
+  animation: flash 520ms ease-out;
+}
+
+@keyframes flash {
+  0% {
+    opacity: 0;
+  }
+  20% {
+    opacity: 0.7;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.lead-performer {
+  width: 160px;
+  height: 200px;
+  margin: 0 auto;
+  background: radial-gradient(circle at 50% 25%, rgba(248, 250, 252, 0.95) 0%, rgba(148, 163, 184, 0.8) 40%, rgba(30, 41, 59, 0.95) 100%);
+  clip-path: polygon(50% 0%, 70% 20%, 74% 34%, 70% 60%, 62% 100%, 38% 100%, 30% 60%, 26% 34%, 30% 20%);
+  position: relative;
+  transition: transform 160ms ease;
+}
+
+.lead-performer::after {
+  content: "";
+  position: absolute;
+  inset: auto 18px 12px;
+  height: 12px;
+  background: radial-gradient(circle, rgba(15, 23, 42, 0.9), transparent 70%);
+  opacity: 0.65;
+  border-radius: 50%;
+}
+
+.lead-performer.is-pulsing {
+  animation: celebrate 320ms ease;
+}
+
+@keyframes celebrate {
+  0% {
+    transform: scale(1);
+  }
+  40% {
+    transform: scale(1.08);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.lead-performer.is-stumbling {
+  animation: stumble 420ms ease;
+}
+
+@keyframes stumble {
+  0% {
+    transform: translateX(0) rotate(0deg);
+  }
+  25% {
+    transform: translateX(-8px) rotate(-2deg);
+  }
+  50% {
+    transform: translateX(10px) rotate(3deg);
+  }
+  75% {
+    transform: translateX(-6px) rotate(-1.5deg);
+  }
+  100% {
+    transform: translateX(0) rotate(0deg);
+  }
+}
+
+.timeline-shell {
+  margin-top: 28px;
+  position: relative;
+  z-index: 1;
+}
+
+.timeline {
+  position: relative;
+  height: 120px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  overflow: hidden;
+}
+
+.timeline-background {
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(90deg, rgba(56, 189, 248, 0.1) 1px, transparent 1px),
+    linear-gradient(180deg, rgba(56, 189, 248, 0.1) 1px, transparent 1px);
+  background-size: 60px 60px;
+  opacity: 0.35;
+  z-index: 1;
+}
+
+.timeline .hit-marker {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 4px;
+  transform: translateX(-50%);
+  background: linear-gradient(180deg, rgba(120, 255, 255, 0), rgba(120, 255, 255, 0.9), rgba(120, 255, 255, 0));
+  box-shadow: 0 0 20px rgba(56, 189, 248, 0.6);
+  z-index: 3;
+}
+
+
+.timeline-note {
+  position: absolute;
+  top: 22px;
+  left: 50%;
+  width: 60px;
+  height: 60px;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: #0f172a;
+  --offset: 280px;
+  transform: translate(-50%, 0) translateX(var(--offset));
+  opacity: 0;
+  transition: transform 80ms linear, opacity 120ms ease-out;
+  z-index: 2;
+}
+
+.timeline-note.is-visible {
+  opacity: 1;
+}
+
+.timeline-note.gasp {
+  background: linear-gradient(135deg, #fbbf24, #f97316);
+}
+
+.timeline-note.pound {
+  background: linear-gradient(135deg, #38bdf8, #22d3ee);
+}
+
+.timeline-note.nod {
+  background: linear-gradient(135deg, #f472b6, #7c3aed);
+}
+
+.timeline-note.hold::after {
+  content: "";
+  position: absolute;
+  bottom: -18px;
+  left: 50%;
+  width: 4px;
+  height: 0;
+  border-radius: 999px;
+  background: rgba(226, 232, 240, 0.8);
+}
+
+.timeline-note.hold.is-visible::after {
+  height: calc(var(--hold-duration, 60px));
+}
+
+.timeline-note.is-hit {
+  box-shadow: 0 0 18px rgba(250, 204, 21, 0.85);
+}
+
+.timeline-note.is-missed {
+  filter: grayscale(0.8) brightness(0.5);
+  opacity: 0.4;
+}
+
+.timeline-note.is-active {
+  transform: translate(-50%, 0) translateX(var(--offset)) scale(1.05);
+}
+
+.timeline-legend {
+  display: flex;
+  gap: 16px;
+  margin-top: 12px;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.timeline-legend .legend-item::before {
+  content: "";
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  margin-right: 8px;
+}
+
+.legend-item.gasp::before {
+  background: linear-gradient(135deg, #fbbf24, #f97316);
+}
+
+.legend-item.pound::before {
+  background: linear-gradient(135deg, #38bdf8, #22d3ee);
+}
+
+.legend-item.nod::before {
+  background: linear-gradient(135deg, #f472b6, #7c3aed);
+}
+
+.legend-item.hold::before {
+  background: rgba(226, 232, 240, 0.75);
+}
+
+.log-panel {
+  margin-top: 24px;
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 16px;
+  padding: 18px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.log-panel ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.log-panel li {
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.log-panel li.success {
+  color: #38f6c4;
+}
+
+.log-panel li.warning {
+  color: #facc15;
+}
+
+.log-panel li.danger {
+  color: #fb7185;
+}
+
+.wrapup {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  background: rgba(15, 23, 42, 0.94);
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 18px;
+  padding: 24px;
+  width: min(360px, calc(100% - 32px));
+  box-shadow: 0 20px 40px rgba(2, 6, 23, 0.55);
+  z-index: 10;
+}
+
+.wrapup h2 {
+  font-size: 1.4rem;
+  color: #facc15;
+}
+
+.wrapup-text {
+  margin: 12px 0 18px;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.wrapup-stats {
+  display: grid;
+  gap: 12px;
+}
+
+.wrapup-stats dt {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.wrapup-stats dd {
+  font-size: 1.4rem;
+  margin: 4px 0 0;
+  color: #facc15;
+}
+
+.flash-banner {
+  position: fixed;
+  top: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.92), rgba(244, 114, 182, 0.92));
+  color: #0f172a;
+  padding: 18px 28px;
+  border-radius: 999px;
+  box-shadow: 0 12px 32px rgba(56, 189, 248, 0.35);
+  z-index: 15;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.combo-meter-shatter {
+  animation: shatter 400ms ease;
+}
+
+@keyframes shatter {
+  0% {
+    transform: scale(1);
+  }
+  20% {
+    transform: scale(1.1) rotate(-2deg);
+  }
+  40% {
+    transform: scale(0.9) rotate(2deg);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.timeline.is-climax {
+  box-shadow: 0 0 32px rgba(244, 114, 182, 0.55);
+  border-color: rgba(244, 114, 182, 0.7);
+}
+
+.stage.noise-medium .diner-floor {
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.92) 0%, rgba(30, 41, 59, 0.9) 35%, rgba(79, 70, 229, 0.3) 100%),
+    repeating-linear-gradient(45deg, rgba(148, 163, 184, 0.05), rgba(148, 163, 184, 0.05) 6px, transparent 6px, transparent 12px);
+}
+
+.stage.noise-high .diner-floor {
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.95) 0%, rgba(30, 41, 59, 0.88) 25%, rgba(236, 72, 153, 0.25) 100%),
+    repeating-linear-gradient(-45deg, rgba(148, 163, 184, 0.06), rgba(148, 163, 184, 0.06) 5px, transparent 5px, transparent 10px);
+}
+
+.stage.noise-high .crowd::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 40% 30%, rgba(236, 72, 153, 0.12), transparent 65%),
+    radial-gradient(circle at 70% 60%, rgba(56, 189, 248, 0.12), transparent 60%),
+    repeating-linear-gradient(0deg, rgba(226, 232, 240, 0.05), rgba(226, 232, 240, 0.05) 2px, transparent 2px, transparent 4px);
+  opacity: 0.22;
+  pointer-events: none;
+}
+
+@media (max-width: 1024px) {
+  .page-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .briefing {
+    order: 2;
+  }
+
+  .stage {
+    order: 1;
+  }
+}

--- a/madia.new/public/secret/1989/diner-debate/diner-debate.js
+++ b/madia.new/public/secret/1989/diner-debate/diner-debate.js
@@ -1,0 +1,763 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+import { mountParticleField } from "../particles.js";
+import { autoEnhanceFeedback } from "../feedback.js";
+
+const particleField = mountParticleField({
+  effects: {
+    palette: ["#facc15", "#38bdf8", "#f472b6", "#fb7185"],
+    ambientDensity: 0.45,
+  },
+});
+
+autoEnhanceFeedback();
+
+const scoreConfig = getScoreConfig("diner-debate");
+const highScore = initHighScoreBanner({
+  gameId: "diner-debate",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
+const APPROACH_WINDOW = 2200;
+const MISS_WINDOW = 260;
+const HOLD_START_WINDOW = 160;
+const HOLD_RELEASE_WINDOW = 200;
+const HOLD_PIXEL_SCALE = 0.12;
+
+const TIMING_WINDOWS = [
+  { rating: "Perfect", threshold: 70, score: 160, meter: 16 },
+  { rating: "Good", threshold: 140, score: 110, meter: 12 },
+  { rating: "OK", threshold: 220, score: 70, meter: 8 },
+];
+
+const ACTIONS = {
+  gasp: { key: "KeyJ", label: "Gasp", short: "G", tone: 860 },
+  pound: { key: "KeyK", label: "Pound", short: "P", tone: 520 },
+  nod: { key: "KeyL", label: "Nod", short: "N", tone: 640 },
+};
+
+const KEY_TO_ACTION = new Map(
+  Object.values(ACTIONS).map((action) => [action.key, action])
+);
+
+const sequences = [
+  {
+    id: "brunch-banter",
+    title: "Brunch Banter",
+    description: "Lean into the slow build and watch the lane cadence.",
+    noise: "low",
+    cues: [
+      note("gasp", 1200),
+      note("nod", 2200),
+      note("pound", 3200),
+      note("nod", 4200),
+      note("gasp", 5200),
+    ],
+  },
+  {
+    id: "counter-crossfire",
+    title: "Counter Crossfire",
+    description: "Kitchen clatter kicks in. Expect brisk doubles and a table hold.",
+    noise: "medium",
+    cues: [
+      note("pound", 900),
+      note("gasp", 1650),
+      note("nod", 2400),
+      note("pound", 3100, { hold: 520 }),
+      note("gasp", 4200),
+      note("nod", 4850),
+      note("pound", 5480),
+    ],
+  },
+  {
+    id: "press-gauntlet",
+    title: "Press Gauntlet",
+    description: "The crowd swells—rapid runs, camera flashes, and layered holds.",
+    noise: "high",
+    cues: [
+      note("gasp", 750),
+      note("nod", 1400),
+      note("pound", 2000),
+      note("nod", 2400),
+      note("gasp", 2800),
+      note("pound", 3400, { hold: 680 }),
+      note("nod", 4500),
+      note("gasp", 4900),
+      note("pound", 5300),
+      note("nod", 5700),
+    ],
+  },
+];
+
+const climaxSequence = {
+  id: "neon-finale",
+  title: "Neon Finale",
+  description: "Everything slows, then spikes—thread the entire crescendo without a stumble.",
+  noise: "climax",
+  cues: [
+    note("gasp", 600),
+    note("pound", 1350),
+    note("nod", 1900),
+    note("pound", 2400, { hold: 720 }),
+    note("gasp", 3600),
+    note("nod", 4100),
+    note("pound", 4500),
+    note("gasp", 4900),
+    note("nod", 5300),
+    note("pound", 5700, { hold: 780 }),
+  ],
+};
+
+const stageElement = document.querySelector(".stage");
+const timelineElement = document.getElementById("timeline");
+const performerElement = document.getElementById("lead-performer");
+const cameraFlashElement = document.getElementById("camera-flash");
+const stageStatusElement = document.getElementById("stage-status");
+const eventLogElement = document.getElementById("event-log");
+const startButton = document.getElementById("start-sequence");
+const nextButton = document.getElementById("next-sequence");
+const resetButton = document.getElementById("reset-sequence");
+const climaxButton = document.getElementById("climax-trigger");
+const convictionElement = document.getElementById("conviction-score");
+const comboElement = document.getElementById("combo-count");
+const comboBestElement = document.getElementById("combo-best");
+const accuracyElement = document.getElementById("accuracy-value");
+const hitReadoutElement = document.getElementById("hit-readout");
+const climaxMeterElement = document.getElementById("climax-meter");
+const climaxFillElement = document.getElementById("climax-fill");
+const wrapupElement = document.getElementById("wrapup");
+const wrapupSummaryElement = document.getElementById("wrapup-summary");
+const wrapupScoreElement = document.getElementById("wrapup-score");
+const wrapupAccuracyElement = document.getElementById("wrapup-accuracy");
+const wrapupComboElement = document.getElementById("wrapup-combo");
+const wrapupCloseButton = document.getElementById("wrapup-close");
+const flashBannerElement = document.getElementById("flash-banner");
+const flashTextElement = document.getElementById("flash-text");
+
+const comboTileElement = comboElement.closest(".score-tile");
+
+const state = {
+  sequenceIndex: 0,
+  playing: false,
+  notes: [],
+  frameId: null,
+  sequenceStart: 0,
+  sequenceDuration: 0,
+  stats: {
+    total: 0,
+    hits: 0,
+    perfects: 0,
+  },
+  conviction: 0,
+  combo: 0,
+  bestCombo: 0,
+  climaxMeter: 0,
+  climaxActivated: false,
+  climaxSequenceQueued: false,
+  climaxMultiplier: 1,
+  activeHolds: new Map(),
+  perfectInSequence: 0,
+  missesInSequence: 0,
+  pendingSequence: null,
+};
+
+prepareSequence(0);
+updateScoreboard();
+updateClimaxButton();
+
+startButton.addEventListener("click", () => {
+  if (state.playing) {
+    return;
+  }
+  beginSequence();
+});
+
+nextButton.addEventListener("click", () => {
+  if (state.playing) {
+    return;
+  }
+  if (state.sequenceIndex < sequences.length - 1) {
+    state.sequenceIndex += 1;
+    prepareSequence(state.sequenceIndex);
+  } else if (!state.climaxActivated && !state.climaxSequenceQueued) {
+    addLog("Meter primed. Trigger the climax whenever you're ready.", "warning");
+  }
+});
+
+resetButton.addEventListener("click", () => {
+  if (state.playing) {
+    stopSequence();
+  }
+  resetSession();
+});
+
+climaxButton.addEventListener("click", () => {
+  requestClimax();
+});
+
+wrapupCloseButton.addEventListener("click", () => {
+  wrapupElement.hidden = true;
+  resetSession();
+});
+
+window.addEventListener("keydown", (event) => {
+  if (event.defaultPrevented) {
+    return;
+  }
+
+  if (event.code === "Space") {
+    event.preventDefault();
+    requestClimax();
+    return;
+  }
+
+  if (event.repeat) {
+    return;
+  }
+
+  const action = KEY_TO_ACTION.get(event.code);
+  if (!action) {
+    return;
+  }
+
+  handleActionPress(action.key);
+});
+
+window.addEventListener("keyup", (event) => {
+  const action = KEY_TO_ACTION.get(event.code);
+  if (!action) {
+    return;
+  }
+  handleActionRelease(action.key);
+});
+
+function note(action, time, options = {}) {
+  return {
+    action,
+    time,
+    hold: options.hold ?? 0,
+    element: null,
+    hit: false,
+    missed: false,
+    active: false,
+    visible: false,
+    holdStart: null,
+    holdStartDelta: null,
+  };
+}
+
+function prepareSequence(index) {
+  const sequence = sequences[index];
+  state.sequenceIndex = index;
+  state.pendingSequence = sequence;
+  stageStatusElement.textContent = `${sequence.title} · ${sequence.description}`;
+  clearTimeline();
+  stageElement.classList.remove("noise-medium", "noise-high");
+  if (sequence.noise === "medium") {
+    stageElement.classList.add("noise-medium");
+  } else if (sequence.noise === "high") {
+    stageElement.classList.add("noise-high");
+  }
+  addLog(`Loaded ${sequence.title}. Study the cues, then launch when ready.`, "info");
+  startButton.disabled = false;
+  nextButton.disabled = index >= sequences.length - 1;
+}
+
+function beginSequence(sequenceOverride = null) {
+  const sequence = sequenceOverride ?? state.pendingSequence ?? sequences[state.sequenceIndex];
+  if (!sequence) {
+    return;
+  }
+  state.pendingSequence = sequence;
+  stageStatusElement.textContent = `${sequence.title} · Performance in progress…`;
+  clearTimeline();
+  state.playing = true;
+  state.notes = sequence.cues.map((cue) => ({ ...cue, element: createTimelineNote(cue) }));
+  state.perfectInSequence = 0;
+  state.missesInSequence = 0;
+  state.sequenceDuration = calculateSequenceDuration(state.notes);
+  state.sequenceStart = performance.now() + 600;
+  state.frameId = window.requestAnimationFrame(runFrame);
+  startButton.disabled = true;
+  nextButton.disabled = true;
+  addLog(`Rolling ${sequence.title}. Nail the beat line.`, "success");
+}
+
+function stopSequence() {
+  if (state.frameId !== null) {
+    window.cancelAnimationFrame(state.frameId);
+    state.frameId = null;
+  }
+  state.playing = false;
+  state.activeHolds.clear();
+}
+
+function calculateSequenceDuration(notes) {
+  if (notes.length === 0) {
+    return 0;
+  }
+  let last = 0;
+  for (const cue of notes) {
+    const end = cue.time + (cue.hold ?? 0);
+    if (end > last) {
+      last = end;
+    }
+  }
+  return last + 1200;
+}
+
+function runFrame(now) {
+  if (!state.playing) {
+    return;
+  }
+  const elapsed = now - state.sequenceStart;
+  const timelineWidth = timelineElement.clientWidth;
+  const halfWidth = Math.max(120, timelineWidth / 2 - 40);
+
+  for (const noteItem of state.notes) {
+    updateNotePosition(noteItem, elapsed, halfWidth);
+    if (!noteItem.hit && !noteItem.missed && !noteItem.active) {
+      const lateBy = elapsed - noteItem.time;
+      if (lateBy > MISS_WINDOW) {
+        registerMiss(noteItem, lateBy > 0 ? "Late" : "Early");
+      }
+    }
+  }
+
+  if (elapsed >= state.sequenceDuration && state.activeHolds.size === 0) {
+    completeSequence();
+    return;
+  }
+
+  state.frameId = window.requestAnimationFrame(runFrame);
+}
+
+function updateNotePosition(noteItem, elapsed, halfWidth) {
+  if (!noteItem.element) {
+    return;
+  }
+  const timeUntil = noteItem.time - elapsed;
+  const shouldBeVisible = timeUntil <= APPROACH_WINDOW + 300 && elapsed <= noteItem.time + (noteItem.hold ?? 0) + 600;
+  if (shouldBeVisible && !noteItem.visible) {
+    noteItem.visible = true;
+    noteItem.element.classList.add("is-visible");
+  }
+
+  if (noteItem.visible) {
+    const ratio = timeUntil / APPROACH_WINDOW;
+    const offset = Math.max(-halfWidth, Math.min(halfWidth, ratio * halfWidth));
+    noteItem.element.style.setProperty("--offset", `${offset}px`);
+  }
+}
+
+function handleActionPress(key) {
+  if (!state.playing) {
+    addLog("Wait for the cue—sequence hasn’t started.", "warning");
+    return;
+  }
+  const elapsed = performance.now() - state.sequenceStart;
+  const noteItem = findNextNoteForKey(key);
+  if (!noteItem) {
+    addLog("That cue isn’t ready yet.", "warning");
+    return;
+  }
+
+  if (noteItem.hold > 0) {
+    const delta = elapsed - noteItem.time;
+    if (Math.abs(delta) > HOLD_START_WINDOW) {
+      addLog("Hold too early—watch the marker.", "danger");
+      registerMiss(noteItem, delta < 0 ? "Too Early" : "Too Late");
+      return;
+    }
+    noteItem.active = true;
+    noteItem.holdStart = performance.now();
+    noteItem.holdStartDelta = delta;
+    state.activeHolds.set(key, noteItem);
+    noteItem.element.classList.add("is-active");
+    performerCelebrate();
+    playTone(ACTIONS[noteItem.action].tone * 0.85, 0.18, "triangle");
+    return;
+  }
+
+  evaluateNoteHit(noteItem, elapsed - noteItem.time);
+}
+
+function handleActionRelease(key) {
+  if (!state.playing) {
+    state.activeHolds.delete(key);
+    return;
+  }
+  const holdNote = state.activeHolds.get(key);
+  if (!holdNote) {
+    return;
+  }
+  state.activeHolds.delete(key);
+  const heldDuration = performance.now() - holdNote.holdStart;
+  const elapsed = performance.now() - state.sequenceStart;
+  const durationDelta = heldDuration - holdNote.hold;
+  const startDelta = holdNote.holdStartDelta ?? 0;
+  const worstDelta = Math.max(Math.abs(durationDelta), Math.abs(startDelta));
+
+  if (worstDelta > HOLD_RELEASE_WINDOW) {
+    registerMiss(holdNote, durationDelta < 0 ? "Hold dropped" : "Hold overshot");
+    return;
+  }
+
+  evaluateNoteHit(holdNote, elapsed - holdNote.time, { hold: true, durationDelta });
+}
+
+function evaluateNoteHit(noteItem, delta, options = {}) {
+  const ratingInfo = resolveRating(delta);
+  if (!ratingInfo) {
+    registerMiss(noteItem, delta < 0 ? "Too early" : "Too late");
+    return;
+  }
+  noteItem.hit = true;
+  noteItem.active = false;
+  if (noteItem.element) {
+    noteItem.element.classList.add("is-hit");
+    noteItem.element.classList.remove("is-active");
+  }
+
+  state.stats.total += 1;
+  state.stats.hits += 1;
+  if (ratingInfo.rating === "Perfect") {
+    state.stats.perfects += 1;
+    state.perfectInSequence += 1;
+  }
+
+  state.combo += 1;
+  if (state.combo > state.bestCombo) {
+    state.bestCombo = state.combo;
+  }
+
+  const multiplier = state.climaxActivated ? state.climaxMultiplier : 1;
+  state.conviction += Math.round(ratingInfo.score * multiplier);
+  state.climaxMeter = Math.min(100, state.climaxMeter + ratingInfo.meter);
+  addLog(`${ratingInfo.rating}! ${ACTIONS[noteItem.action].label} landed.`, "success");
+  performerCelebrate();
+  maybeFlashCamera(ratingInfo.rating);
+  updateScoreboard();
+  updateClimaxButton();
+  playTone(ACTIONS[noteItem.action].tone * multiplier, 0.18 + (options.hold ? 0.12 : 0), options.hold ? "sawtooth" : "sine");
+
+  checkSequencePerfect();
+}
+
+function registerMiss(noteItem, reason) {
+  if (noteItem.missed || noteItem.hit) {
+    return;
+  }
+  noteItem.missed = true;
+  noteItem.active = false;
+  if (noteItem.element) {
+    noteItem.element.classList.add("is-missed");
+    noteItem.element.classList.remove("is-active");
+  }
+  state.stats.total += 1;
+  state.missesInSequence += 1;
+  state.combo = 0;
+  state.climaxMeter = Math.max(0, state.climaxMeter - 18);
+  addLog(`Missed ${ACTIONS[noteItem.action].label}. ${reason}.`, "danger");
+  performerStumble();
+  shatterComboMeter();
+  playScratch();
+  updateScoreboard();
+  updateClimaxButton();
+}
+
+function checkSequencePerfect() {
+  if (!state.playing) {
+    return;
+  }
+  if (state.perfectInSequence === state.notes.length && state.notes.length > 0) {
+    showFlash("Flawless Performance!");
+  }
+}
+
+function resolveRating(delta) {
+  const offset = Math.abs(delta);
+  for (const windowInfo of TIMING_WINDOWS) {
+    if (offset <= windowInfo.threshold) {
+      return windowInfo;
+    }
+  }
+  return null;
+}
+
+function findNextNoteForKey(key) {
+  for (const noteItem of state.notes) {
+    if (noteItem.hit || noteItem.missed) {
+      continue;
+    }
+    if (ACTIONS[noteItem.action].key === key) {
+      return noteItem;
+    }
+  }
+  return null;
+}
+
+function completeSequence() {
+  stopSequence();
+  const sequence = state.pendingSequence ?? sequences[state.sequenceIndex];
+  state.pendingSequence = sequence;
+  if (sequence && !state.climaxActivated) {
+    if (sequence.noise === "climax") {
+      stageStatusElement.textContent = "Finale complete. Review the wrap below.";
+    } else {
+      stageStatusElement.textContent = `${sequence.title} complete. Take a breath or queue the next round.`;
+    }
+  }
+  startButton.disabled = false;
+  nextButton.disabled = state.sequenceIndex >= sequences.length - 1 || state.climaxActivated;
+
+  if (state.sequenceIndex < sequences.length - 1) {
+    addLog(`Sequence clear. ${sequences[state.sequenceIndex + 1].title} is ready.`, "success");
+  } else if (!state.climaxActivated) {
+    addLog("Debate conquered. Fill that meter and fire the finale.", "warning");
+  }
+
+  if (state.climaxSequenceQueued) {
+    state.climaxSequenceQueued = false;
+    window.setTimeout(() => {
+      stageElement.classList.add("climax-active");
+      timelineElement.classList.add("is-climax");
+      beginSequence(climaxSequence);
+    }, 320);
+    return;
+  }
+
+  if (!state.climaxActivated) {
+    return;
+  }
+
+  finalizeSession();
+}
+
+function finalizeSession() {
+  stageElement.classList.remove("climax-active");
+  timelineElement.classList.remove("is-climax");
+  clearTimeline();
+  startButton.disabled = true;
+  nextButton.disabled = true;
+  stageStatusElement.textContent = "Debate wrapped. Check the performance summary.";
+  const accuracy = state.stats.total > 0 ? Math.round((state.stats.hits / state.stats.total) * 100) : 0;
+  const summary = accuracy >= 90
+    ? "You owned the room—diners are telling this story for years."
+    : accuracy >= 70
+      ? "Solid delivery. One more pass and the gossip pages are yours."
+      : "The crowd’s skeptical, but the booth is ready for redemption.";
+  wrapupSummaryElement.textContent = summary;
+  wrapupScoreElement.textContent = String(state.conviction);
+  wrapupAccuracyElement.textContent = `${accuracy}%`;
+  wrapupComboElement.textContent = String(state.bestCombo);
+  wrapupElement.hidden = false;
+
+  highScore.submit(state.conviction, {
+    accuracy,
+    combo: state.bestCombo,
+  });
+}
+
+function requestClimax() {
+  if (state.climaxActivated) {
+    return;
+  }
+  if (state.climaxMeter < 30) {
+    addLog("Build more momentum before unleashing the finale.", "warning");
+    return;
+  }
+
+  const tier = state.climaxMeter >= 100 ? 3 : state.climaxMeter >= 70 ? 2.2 : 1.6;
+  state.climaxMultiplier = tier;
+  state.climaxActivated = true;
+  stageElement.classList.add("climax-active");
+  timelineElement.classList.add("is-climax");
+  addLog(`Climax engaged! Multiplier x${tier.toFixed(1)} active.`, "success");
+  if (typeof particleField.emitBurst === "function") {
+    particleField.emitBurst(tier + 0.6);
+  }
+  if (typeof particleField.emitSparkle === "function") {
+    particleField.emitSparkle(tier);
+  }
+  climaxButton.disabled = true;
+  if (state.playing) {
+    state.climaxSequenceQueued = true;
+  } else {
+    beginSequence(climaxSequence);
+  }
+}
+
+function updateScoreboard() {
+  convictionElement.textContent = String(state.conviction);
+  comboElement.textContent = String(state.combo);
+  comboBestElement.textContent = `Best ${state.bestCombo}`;
+  const accuracy = state.stats.total > 0 ? Math.round((state.stats.hits / state.stats.total) * 100) : 0;
+  accuracyElement.textContent = `${accuracy}%`;
+  hitReadoutElement.textContent = `${state.stats.hits} / ${state.stats.total}`;
+  climaxFillElement.style.width = `${state.climaxMeter}%`;
+  climaxMeterElement.setAttribute("aria-valuenow", String(state.climaxMeter));
+}
+
+function updateClimaxButton() {
+  const ready = state.climaxMeter >= 30 && !state.climaxActivated;
+  climaxButton.disabled = !ready;
+  climaxButton.textContent = ready ? "Cue the Finale" : "Hold for Applause";
+}
+
+function clearTimeline() {
+  while (timelineElement.firstChild) {
+    timelineElement.removeChild(timelineElement.firstChild);
+  }
+  const background = document.createElement("div");
+  background.className = "timeline-background";
+  background.setAttribute("aria-hidden", "true");
+  const marker = document.createElement("div");
+  marker.className = "hit-marker";
+  marker.setAttribute("aria-hidden", "true");
+  timelineElement.append(background, marker);
+}
+
+function createTimelineNote(noteItem) {
+  const element = document.createElement("div");
+  element.className = `timeline-note ${noteItem.action}`;
+  element.textContent = ACTIONS[noteItem.action].short;
+  const halfWidth = Math.max(120, timelineElement.clientWidth / 2 - 30);
+  element.style.setProperty("--offset", `${halfWidth}px`);
+  if (noteItem.hold > 0) {
+    element.classList.add("hold");
+    element.style.setProperty("--hold-duration", `${Math.max(60, noteItem.hold * HOLD_PIXEL_SCALE)}px`);
+  }
+  timelineElement.append(element);
+  return element;
+}
+
+function performerCelebrate() {
+  performerElement.classList.remove("is-stumbling");
+  performerElement.classList.add("is-pulsing");
+  window.setTimeout(() => {
+    performerElement.classList.remove("is-pulsing");
+  }, 300);
+}
+
+function performerStumble() {
+  performerElement.classList.remove("is-pulsing");
+  performerElement.classList.add("is-stumbling");
+  window.setTimeout(() => {
+    performerElement.classList.remove("is-stumbling");
+  }, 420);
+}
+
+function shatterComboMeter() {
+  if (!comboTileElement) {
+    return;
+  }
+  comboTileElement.classList.add("combo-meter-shatter");
+  window.setTimeout(() => {
+    comboTileElement.classList.remove("combo-meter-shatter");
+  }, 400);
+}
+
+function maybeFlashCamera(rating) {
+  if (rating !== "Perfect") {
+    return;
+  }
+  if (!cameraFlashElement) {
+    return;
+  }
+  cameraFlashElement.classList.remove("is-active");
+  void cameraFlashElement.offsetWidth;
+  cameraFlashElement.classList.add("is-active");
+}
+
+function addLog(message, variant = "info") {
+  const entry = document.createElement("li");
+  entry.textContent = message;
+  entry.classList.add(variant);
+  eventLogElement.prepend(entry);
+  while (eventLogElement.children.length > 9) {
+    eventLogElement.removeChild(eventLogElement.lastChild);
+  }
+}
+
+function showFlash(message) {
+  flashTextElement.textContent = message;
+  flashBannerElement.hidden = false;
+  window.setTimeout(() => {
+    flashBannerElement.hidden = true;
+  }, 1400);
+}
+
+function resetSession() {
+  stopSequence();
+  state.sequenceIndex = 0;
+  state.pendingSequence = sequences[0];
+  state.conviction = 0;
+  state.combo = 0;
+  state.bestCombo = 0;
+  state.climaxMeter = 0;
+  state.climaxActivated = false;
+  state.climaxMultiplier = 1;
+  state.climaxSequenceQueued = false;
+  state.stats = { total: 0, hits: 0, perfects: 0 };
+  stageElement.classList.remove("climax-active", "noise-medium", "noise-high");
+  timelineElement.classList.remove("is-climax");
+  performerElement.classList.remove("is-pulsing", "is-stumbling");
+  wrapupElement.hidden = true;
+  flashBannerElement.hidden = true;
+  addLog("Session reset. Line up the opening salvo.", "warning");
+  prepareSequence(0);
+  updateScoreboard();
+  updateClimaxButton();
+}
+
+function playTone(frequency, duration = 0.18, type = "sine") {
+  const ctx = getAudioContext();
+  if (!ctx) {
+    return;
+  }
+  const oscillator = ctx.createOscillator();
+  const gain = ctx.createGain();
+  oscillator.type = type;
+  oscillator.frequency.value = frequency;
+  gain.gain.value = 0.18;
+  oscillator.connect(gain).connect(ctx.destination);
+  oscillator.start();
+  gain.gain.setTargetAtTime(0, ctx.currentTime + duration, 0.12);
+  oscillator.stop(ctx.currentTime + duration + 0.25);
+}
+
+function playScratch() {
+  const ctx = getAudioContext();
+  if (!ctx) {
+    return;
+  }
+  const duration = 0.32;
+  const buffer = ctx.createBuffer(1, ctx.sampleRate * duration, ctx.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < data.length; i += 1) {
+    const progress = i / data.length;
+    const noise = (Math.random() * 2 - 1) * (1 - progress);
+    data[i] = noise * (1 - Math.pow(progress, 2));
+  }
+  const source = ctx.createBufferSource();
+  const gain = ctx.createGain();
+  gain.gain.value = 0.28;
+  source.buffer = buffer;
+  source.connect(gain).connect(ctx.destination);
+  source.start();
+}
+
+let audioContext = null;
+function getAudioContext() {
+  if (typeof window.AudioContext !== "function" && typeof window.webkitAudioContext !== "function") {
+    return null;
+  }
+  if (!audioContext) {
+    const Ctor = window.AudioContext || window.webkitAudioContext;
+    audioContext = new Ctor();
+  }
+  return audioContext;
+}

--- a/madia.new/public/secret/1989/diner-debate/index.html
+++ b/madia.new/public/secret/1989/diner-debate/index.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>The Diner Debate</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="diner-debate.css" />
+  </head>
+  <body class="secret-annex-snes diner-debate">
+    <a class="skip-link" href="#main-content">Skip to game</a>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 24 · 1989 Arcade</p>
+      <h1>The Diner Debate</h1>
+      <p class="subtitle">
+        Nail the comedic crescendo with laser-precise timing, outshine the gawking crowd, and choose the perfect
+        moment to unleash your finale.
+      </p>
+    </header>
+    <main id="main-content" class="page-layout">
+      <section class="briefing" aria-labelledby="briefing-title">
+        <h2 id="briefing-title">Stage Notes</h2>
+        <p>
+          New Yorkers love a scene, but this booth showdown is yours to command. Each debate beat drops into the lane below—
+          time your inputs as the cue crosses the marker, keep the combo alive, and decide when the climax should roll.
+        </p>
+        <ul class="callouts">
+          <li>
+            <strong>Comedic cadence:</strong> Hit each prompt when the beat line slices through the icon. Tight timing earns
+            <span class="rating perfect">Perfect</span> ratings and pours on the conviction.
+          </li>
+          <li>
+            <strong>Escalating distractions:</strong> Later rounds crank up the kitchen clatter and camera flashes. Stay focused
+            and watch for hold cues and rapid-fire triples.
+          </li>
+          <li>
+            <strong>Climax meter:</strong> Fill it with consecutive hits, then decide when to fire the finale. Launch it early for
+            a safe bump or max it out for a high-pressure score surge.
+          </li>
+          <li>
+            <strong>Performance wrap:</strong> Flawless runs shower the diner in neon confetti and stamp a leaderboard-ready
+            Conviction Score.
+          </li>
+        </ul>
+        <section class="key-guide" aria-labelledby="key-guide-title">
+          <h3 id="key-guide-title">Input Legend</h3>
+          <dl class="legend-list">
+            <div>
+              <dt><span class="key-label">J</span> · Gasp</dt>
+              <dd>Sharp intake with a mock scandalized shoulder shake.</dd>
+            </div>
+            <div>
+              <dt><span class="key-label">K</span> · Pound Table</dt>
+              <dd>Smack the Formica for emphasis. Hold when the icon stretches.</dd>
+            </div>
+            <div>
+              <dt><span class="key-label">L</span> · Nod</dt>
+              <dd>A knowing, confident nod to sell the verdict.</dd>
+            </div>
+            <div>
+              <dt><span class="key-label">Space</span> · Activate Climax</dt>
+              <dd>
+                Trigger the high-voltage finale once the meter is ready. The lane pulses to confirm the window is open.
+              </dd>
+            </div>
+          </dl>
+        </section>
+      </section>
+      <section class="stage" aria-labelledby="stage-title">
+        <header class="stage-header">
+          <div>
+            <h2 id="stage-title">Performance Console</h2>
+            <p class="stage-subtitle" id="stage-status">Select a sequence to rehearse.</p>
+          </div>
+          <div class="stage-actions">
+            <button type="button" class="action-button" id="start-sequence">Begin Sequence</button>
+            <button type="button" class="action-button" id="next-sequence" disabled>Next Round</button>
+            <button type="button" class="action-button" id="reset-sequence">Reset Session</button>
+          </div>
+        </header>
+        <div class="performance-shell" role="group" aria-label="Performance metrics">
+          <div class="score-tile">
+            <span class="score-label">Conviction Score</span>
+            <span class="score-value" id="conviction-score">0</span>
+          </div>
+          <div class="score-tile">
+            <span class="score-label">Combo</span>
+            <span class="score-value" id="combo-count">0</span>
+            <span class="score-note" id="combo-best">Best 0</span>
+          </div>
+          <div class="score-tile">
+            <span class="score-label">Accuracy</span>
+            <span class="score-value" id="accuracy-value">0%</span>
+            <span class="score-note" id="hit-readout">0 / 0</span>
+          </div>
+          <div class="score-tile climax">
+            <div class="climax-meter" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" id="climax-meter">
+              <div class="climax-fill" id="climax-fill"></div>
+            </div>
+            <div class="climax-caption">
+              <span class="score-label">Climax Meter</span>
+              <button type="button" class="climax-button" id="climax-trigger" disabled>
+                Hold for Applause
+              </button>
+            </div>
+          </div>
+        </div>
+        <div class="diner-floor" id="diner-floor">
+          <div class="crowd" aria-hidden="true">
+            <div class="patron patron-left"></div>
+            <div class="patron patron-right"></div>
+            <div class="camera-flash" id="camera-flash" aria-hidden="true"></div>
+          </div>
+          <div class="lead-performer" id="lead-performer" role="img" aria-label="Lead performer delivering the debate"></div>
+        </div>
+        <div class="timeline-shell" aria-label="Timing lane">
+          <div class="timeline" id="timeline">
+            <div class="timeline-background" aria-hidden="true"></div>
+            <div class="hit-marker" aria-hidden="true"></div>
+          </div>
+          <div class="timeline-legend">
+            <span class="legend-item gasp">Gasp</span>
+            <span class="legend-item pound">Pound</span>
+            <span class="legend-item nod">Nod</span>
+            <span class="legend-item hold">Hold</span>
+          </div>
+        </div>
+        <div class="log-panel" aria-live="polite" aria-atomic="false">
+          <h3>Event Log</h3>
+          <ul id="event-log"></ul>
+        </div>
+      </section>
+    </main>
+    <aside class="wrapup" id="wrapup" hidden>
+      <h2>Performance Wrap</h2>
+      <p class="wrapup-text" id="wrapup-summary"></p>
+      <dl class="wrapup-stats">
+        <div>
+          <dt>Conviction Score</dt>
+          <dd id="wrapup-score">0</dd>
+        </div>
+        <div>
+          <dt>Accuracy</dt>
+          <dd id="wrapup-accuracy">0%</dd>
+        </div>
+        <div>
+          <dt>Highest Combo</dt>
+          <dd id="wrapup-combo">0</dd>
+        </div>
+      </dl>
+      <button type="button" class="action-button" id="wrapup-close">Replay the Debate</button>
+    </aside>
+    <div class="flash-banner" id="flash-banner" role="status" aria-live="assertive" hidden>
+      <p id="flash-text"></p>
+    </div>
+    <script type="module" src="diner-debate.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/1989/score-config.js
+++ b/madia.new/public/secret/1989/score-config.js
@@ -43,6 +43,16 @@ export const scoreConfigs = {
       return `${value ?? 0} pts · ${contexts} ${contextLabel}`;
     },
   },
+  "diner-debate": {
+    label: "Conviction Score",
+    empty: "No performances recorded yet.",
+    format: ({ value, meta }) => {
+      const accuracy = Number.isFinite(meta?.accuracy) ? Math.round(meta.accuracy) : null;
+      const combo = Number(meta?.combo ?? 0);
+      const accuracyText = accuracy !== null ? `${accuracy}% accuracy` : "0% accuracy";
+      return `${value ?? 0} pts · ${accuracyText} · combo ${combo}`;
+    },
+  },
   "wardline-breakout": {
     label: "Final Sanity",
     empty: "No breakout simulated yet.",


### PR DESCRIPTION
## Summary
- add the new Level 24 "The Diner Debate" cabinet with a comedic timing control scheme and wrap-up panel
- wire the cabinet into the arcade catalog, score banner, and documentation for the 1989 coverage ladder
- style the diner experience with neon feedback, escalating noise states, and climax meter FX

## Testing
- python -m http.server 5000

------
https://chatgpt.com/codex/tasks/task_e_68e02aa071f88328894f74d4fd24288d