### PR TITLE
Document level comment guidelines for 1989

### DIFF
--- a/madia.new/public/secret/1989/AGENTS.md
+++ b/madia.new/public/secret/1989/AGENTS.md
@@ -9,6 +9,10 @@ games should be added to the 1989 arcade so that they can be played/replayed in 
 Shared animation/particle conventions:
 - Use `particles.js` via `mountParticleField` for ambient cabinet effects when you need celebratory bursts (see `augmentum` and other neon-heavy stages).
 - Keep palettes within the synthwave/neon spectrum defined in `particles.js` unless a level demands a bespoke theme; prefer extending the palette rather than writing new particle systems.
+
+## Code comments for level registries
+
+- When adding items to the shared arrays that register levels (e.g., the arrays of `scoreConfigs` and `const games`), place a `// Level ##` comment on the first line where the element is added and repeat the same comment on the closing `},` line of that element. This symmetry prevents merge conflicts when multiple levels land simultaneously.
 ## 1989 Arcade Polish Rules
 
 Study the strongest cabinet builds (e.g., "Speed Zone", "Second Star Flight", "Velvet Syncopation") and apply these shared rules to every new level so it instantly feels at home in the arcade:


### PR DESCRIPTION
## Summary
- add guidance in the 1989 agent file to require `// Level ##` comments around new score and game entries
- explain the goal of preventing merge conflicts when multiple levels are added

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e035313bd88328b724c20dca3e881f