### PR TITLE
Add The Sugar Ray Hustle arcade cabinet

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -1287,6 +1287,54 @@ const games = [
       </svg>
     `,
   },
+  // Level 17
+  {
+    id: "sugar-ray-hustle",
+    name: "The Sugar Ray Hustle",
+    description: "Catch the shrinking ring in the Rose Room, double the pot, and cash swagger into slow-motion showdowns.",
+    url: "./sugar-ray-hustle/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="The Sugar Ray Hustle preview">
+        <defs>
+          <linearGradient id="hustleBg" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="rgba(6,11,26,0.95)" />
+            <stop offset="100%" stop-color="rgba(15,23,42,0.92)" />
+          </linearGradient>
+          <radialGradient id="ringGlow" cx="0.5" cy="0.4" r="0.6">
+            <stop offset="0%" stop-color="rgba(250,204,21,0.95)" />
+            <stop offset="45%" stop-color="rgba(250,204,21,0.45)" />
+            <stop offset="100%" stop-color="rgba(250,204,21,0.05)" />
+          </radialGradient>
+          <linearGradient id="felt" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(17,24,39,0.92)" />
+            <stop offset="100%" stop-color="rgba(8,11,24,0.92)" />
+          </linearGradient>
+        </defs>
+        <rect x="8" y="8" width="144" height="104" rx="18" fill="url(#hustleBg)" stroke="rgba(250,204,21,0.35)" />
+        <rect x="20" y="20" width="120" height="80" rx="16" fill="url(#felt)" stroke="rgba(148,163,184,0.3)" />
+        <g opacity="0.65">
+          <circle cx="80" cy="62" r="34" fill="none" stroke="rgba(250,204,21,0.28)" stroke-width="4" />
+          <circle cx="80" cy="62" r="24" fill="none" stroke="rgba(249,115,22,0.4)" stroke-width="4" />
+          <circle cx="80" cy="62" r="16" fill="none" stroke="rgba(250,204,21,0.65)" stroke-width="4" />
+        </g>
+        <circle cx="80" cy="62" r="18" fill="url(#ringGlow)" stroke="rgba(250,204,21,0.8)" stroke-width="2" />
+        <g transform="translate(48 36)">
+          <rect x="0" y="0" width="20" height="20" rx="5" fill="rgba(15,23,42,0.85)" stroke="rgba(250,204,21,0.55)" />
+          <circle cx="10" cy="10" r="4" fill="rgba(250,204,21,0.85)" />
+          <rect x="26" y="4" width="24" height="12" rx="6" fill="rgba(14,116,144,0.8)" stroke="rgba(56,189,248,0.6)" />
+          <rect x="26" y="20" width="24" height="12" rx="6" fill="rgba(244,114,182,0.78)" stroke="rgba(244,114,182,0.6)" />
+        </g>
+        <g transform="translate(50 76)">
+          <rect x="0" y="0" width="60" height="18" rx="9" fill="rgba(15,23,42,0.92)" stroke="rgba(250,204,21,0.5)" />
+          <text x="30" y="12" text-anchor="middle" font-size="10" fill="rgba(250,250,250,0.9)" font-family="'Press Start 2P', monospace">CHALLENGE</text>
+        </g>
+        <g opacity="0.7">
+          <text x="24" y="104" font-size="9" fill="rgba(250,204,21,0.75)" font-family="'Press Start 2P', monospace">×2 POT</text>
+          <text x="136" y="104" text-anchor="end" font-size="9" fill="rgba(148,163,184,0.75)" font-family="'Press Start 2P', monospace">SWAGGER</text>
+        </g>
+      </svg>
+    `,
+  }, // Level 17
   {
     id: "personal-ad-trap",
     name: "The Personal Ad Trap",

--- a/madia.new/public/secret/1989/score-config.js
+++ b/madia.new/public/secret/1989/score-config.js
@@ -195,6 +195,26 @@ export const scoreConfigs = {
     empty: "No checkpoints cleared yet.",
     format: ({ value }) => `${value ?? 0} / 4`,
   },
+  "sugar-ray-hustle": {
+    label: "Career Take",
+    empty: "No winnings recorded yet.",
+    format: ({ value, meta }) => {
+      const amount = Number(value ?? 0);
+      const formatter = new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        maximumFractionDigits: 0,
+      });
+      const take = formatter.format(amount);
+      const streak = Number(meta?.longestStreak ?? 0);
+      const foes = Number(meta?.opponents ?? 0);
+      const swagger = Number(meta?.swaggerActivations ?? 0);
+      const streakLabel = streak === 1 ? "1 perfect" : `${streak} perfects`;
+      const foeLabel = foes === 1 ? "1 foe" : `${foes} foes`;
+      const swaggerLabel = swagger === 1 ? "1 slow-mo" : `${swagger} slow-mo`;
+      return `${take} · ${streakLabel} · ${foeLabel} · ${swaggerLabel}`;
+    },
+  },
   "three-fugitives": {
     label: "Tempo Buffer",
     empty: "No rescues logged yet.",

--- a/madia.new/public/secret/1989/sugar-ray-hustle/index.html
+++ b/madia.new/public/secret/1989/sugar-ray-hustle/index.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>The Sugar Ray Hustle</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="sugar-ray-hustle.css" />
+  </head>
+  <body class="secret-annex-snes sugar-ray-theme">
+    <a class="skip-link" href="#main-content">Skip to game</a>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 17 · 1989 Arcade</p>
+      <h1>The Sugar Ray Hustle</h1>
+      <p class="subtitle">
+        Call every bluff in the Rose Room speakeasy. Timing the challenge, not the odds, wins the night.
+      </p>
+    </header>
+    <main id="main-content" class="page-layout sugar-layout">
+      <section class="briefing" aria-labelledby="briefing-title">
+        <h2 id="briefing-title">Speakeasy Briefing</h2>
+        <p>
+          The Rose Room is humming, the floor packed with night owls, and the house crew is rolling gilded dice for anyone
+          brave enough to challenge. Bankrupt the table one shark at a time by calling their moves at the exact moment the
+          glow hits. Rely on rhythm, not reason—the dice are just stage dressing.
+        </p>
+        <ul class="callouts">
+          <li><strong>Pot Pressure:</strong> Each round starts with a fresh pot. Hover too long and the window slams shut.</li>
+          <li>
+            <strong>Reaction Windows:</strong> Three concentric rings tighten around the Challenge button—Late is a push, Good
+            pays the pot, Perfect doubles the take.
+          </li>
+          <li>
+            <strong>Swagger Meter:</strong> Run consecutive Perfects to fill your swagger. When the meter blazes, spend it to slow
+            time for one critical round.
+          </li>
+          <li>
+            <strong>Opponents:</strong> The deeper you dance into the night, the faster the ring shrinks and the harsher the miss
+            penalty becomes.
+          </li>
+        </ul>
+        <section class="action-guide" aria-labelledby="action-guide-title">
+          <h3 id="action-guide-title">Actions</h3>
+          <dl>
+            <div>
+              <dt>Prime the Dice</dt>
+              <dd>Establish the next pot and watch your opponent flaunt their claim.</dd>
+            </div>
+            <div>
+              <dt>Challenge</dt>
+              <dd>Strike exactly when the inner ring flares. Wait too long and the house rakes the winnings.</dd>
+            </div>
+            <div>
+              <dt>Spend Swagger</dt>
+              <dd>
+                After stringing together Perfect hits, burn your swagger for a single slow-motion round. The gold ring lingers,
+                making perfection almost inevitable.
+              </dd>
+            </div>
+          </dl>
+        </section>
+      </section>
+      <section class="speakeasy" aria-labelledby="speakeasy-title">
+        <header class="speakeasy-header">
+          <div>
+            <h2 id="speakeasy-title">Rose Room Showdown</h2>
+            <p class="speakeasy-subtitle" id="opponent-progress">Opponent 1 of 4</p>
+          </div>
+          <div class="swagger-meter" id="swagger-meter" data-ready="false">
+            <p class="swagger-label">Swagger Meter</p>
+            <div class="swagger-track" role="presentation">
+              <div class="swagger-fill" id="swagger-fill" style="width: 0%"></div>
+            </div>
+            <p class="swagger-note" id="swagger-note">Perfect hits slow time. Keep the streak alive.</p>
+          </div>
+        </header>
+        <div class="hustle-hud" role="group" aria-label="Table status">
+          <article class="bank-card is-player">
+            <p class="bank-label">Your Winnings</p>
+            <p class="bank-value" id="player-bank">$0</p>
+          </article>
+          <article class="pot-card">
+            <p class="pot-label">Current Pot</p>
+            <p class="pot-value" id="pot-value">$0</p>
+            <p class="pot-note" id="pot-note">Press Prime the Dice to set the first stake.</p>
+          </article>
+          <article class="bank-card is-opponent">
+            <p class="bank-label" id="opponent-bank-label">House Bank</p>
+            <p class="bank-value" id="opponent-bank">$0</p>
+          </article>
+        </div>
+        <div class="streak-hud" role="group" aria-label="Streaks">
+          <article class="streak-card">
+            <p class="streak-label">Perfect Streak</p>
+            <p class="streak-value" id="streak-value">0</p>
+          </article>
+          <article class="streak-card">
+            <p class="streak-label">Night Best</p>
+            <p class="streak-value" id="best-streak-value">0</p>
+          </article>
+          <article class="streak-card">
+            <p class="streak-label">Round</p>
+            <p class="streak-value" id="round-counter">1</p>
+          </article>
+        </div>
+        <article class="opponent-card" id="opponent-card">
+          <p class="opponent-eyebrow" id="opponent-title">Velvet Verona · Floor Greeter</p>
+          <h3 class="opponent-name" id="opponent-name">Velvet Verona</h3>
+          <p class="opponent-intro" id="opponent-intro">
+            Velvet's glide is all smoke and smiles. She reads your pulse from the way you reach for the felt.
+          </p>
+          <dl class="opponent-stats">
+            <div>
+              <dt>Tempo</dt>
+              <dd id="opponent-tempo">Lounge glide</dd>
+            </div>
+            <div>
+              <dt>Perfect Window</dt>
+              <dd id="opponent-window">160&nbsp;ms</dd>
+            </div>
+            <div>
+              <dt>Miss Penalty</dt>
+              <dd id="opponent-penalty">×1.5 pot</dd>
+            </div>
+          </dl>
+        </article>
+        <div class="challenge-console">
+          <div class="console-actions">
+            <button type="button" class="action-button" id="deal-challenge">Prime the Dice</button>
+            <button type="button" class="action-button swagger-trigger" id="swagger-button" disabled>
+              Spend Swagger
+            </button>
+          </div>
+          <div class="challenge-area" id="challenge-area" data-zone="idle">
+            <div class="challenge-ring" id="timing-ring" aria-hidden="true"></div>
+            <button type="button" class="challenge-button" id="challenge-button" disabled>
+              <span class="challenge-label">Challenge</span>
+              <span class="challenge-window" id="window-label">Wait for the glow</span>
+            </button>
+          </div>
+          <p class="timing-caption" id="timing-caption">The ring collapses fast—perfect hits double the pot.</p>
+          <p class="result-banner" id="result-banner">Waiting on the next claim.</p>
+        </div>
+        <div class="status-row">
+          <div class="status-banner" id="status-bar">Welcome to the Rose Room. Prime the dice to start the hustle.</div>
+        </div>
+        <section class="event-ledger" aria-labelledby="ledger-title">
+          <div class="ledger-header">
+            <h3 id="ledger-title">Table Ledger</h3>
+          </div>
+          <ul class="event-log" id="event-log"></ul>
+        </section>
+      </section>
+      <section class="wrap-up" id="wrap-up" hidden aria-live="polite">
+        <div class="wrap-up-card">
+          <p class="wrap-up-eyebrow">Nightfall Recap</p>
+          <h2 class="wrap-up-title" id="wrap-up-title">House Rules the Night</h2>
+          <p class="wrap-up-total">Final Take: <strong id="wrap-up-money">$0</strong></p>
+          <p class="wrap-up-streak">Longest Perfect Streak: <strong id="wrap-up-streak">0</strong></p>
+          <p class="wrap-up-foes">
+            Opponents Dusted: <strong id="wrap-up-opponents">0</strong> /
+            <span id="wrap-up-total-opponents">4</span>
+          </p>
+          <p class="wrap-up-note" id="wrap-up-note">Keep grinding for that marquee slot.</p>
+          <button type="button" class="action-button wrap-up-button" id="wrap-up-replay">Run It Back</button>
+        </div>
+      </section>
+    </main>
+    <footer class="page-footer">
+      <p>
+        Tip: Watch the rhythm of each hustler. Banking a swagger slow-down right before a ruthless opponent can turn an
+        impossible perfect into an effortless slam.
+      </p>
+    </footer>
+    <script type="module" src="sugar-ray-hustle.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/1989/sugar-ray-hustle/sugar-ray-hustle.css
+++ b/madia.new/public/secret/1989/sugar-ray-hustle/sugar-ray-hustle.css
@@ -1,0 +1,714 @@
+:root {
+  --sugar-gold: #fbbf24;
+  --sugar-amber: #f59e0b;
+  --sugar-rose: #f472b6;
+  --sugar-ink: #020617;
+  --sugar-deep: #0f172a;
+  --sugar-accent: #facc15;
+  --sugar-muted: rgba(203, 213, 225, 0.7);
+}
+
+body.sugar-ray-theme {
+  background: radial-gradient(circle at 20% 20%, rgba(250, 191, 36, 0.08), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(244, 114, 182, 0.07), transparent 52%),
+    radial-gradient(circle at 50% 80%, rgba(59, 130, 246, 0.1), transparent 60%),
+    linear-gradient(135deg, rgba(6, 11, 26, 0.95), rgba(3, 6, 18, 0.92));
+  color: #f8fafc;
+  --focus-ring: rgba(250, 204, 21, 0.82);
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.page-header .eyebrow {
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(250, 204, 21, 0.8);
+}
+
+.page-header h1 {
+  font-size: clamp(2.25rem, 4vw, 3rem);
+  letter-spacing: 0.08em;
+  margin-bottom: 0.75rem;
+}
+
+.page-header .subtitle {
+  max-width: 48rem;
+  margin: 0 auto;
+  color: var(--sugar-muted);
+}
+
+.sugar-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 24rem) minmax(0, 1fr) minmax(0, 20rem);
+  gap: 2.75rem;
+  align-items: start;
+}
+
+.briefing {
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.9), rgba(8, 11, 24, 0.92));
+  border: 1px solid rgba(248, 250, 252, 0.08);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  box-shadow: 0 28px 70px rgba(2, 6, 23, 0.65);
+  position: sticky;
+  top: 1.5rem;
+}
+
+.briefing h2 {
+  margin-top: 0;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(250, 204, 21, 0.85);
+}
+
+.callouts {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0 2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.callouts li {
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.08), rgba(15, 23, 42, 0.4));
+  border-radius: 1.2rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 1px 0 rgba(248, 250, 252, 0.06);
+}
+
+.action-guide dl {
+  display: grid;
+  gap: 1.2rem;
+  margin: 1.5rem 0 0;
+}
+
+.action-guide dt {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(250, 204, 21, 0.85);
+}
+
+.action-guide dd {
+  margin: 0.35rem 0 0;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.speakeasy {
+  background: linear-gradient(160deg, rgba(8, 11, 24, 0.94), rgba(2, 6, 17, 0.92));
+  border-radius: 1.75rem;
+  padding: 2.25rem;
+  border: 1px solid rgba(250, 204, 21, 0.16);
+  box-shadow: 0 32px 90px rgba(2, 6, 23, 0.7);
+  backdrop-filter: blur(12px);
+  position: relative;
+  overflow: hidden;
+}
+
+.speakeasy::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 20% 10%, rgba(250, 204, 21, 0.16), transparent 60%),
+    radial-gradient(circle at 80% 0%, rgba(244, 114, 182, 0.12), transparent 62%);
+  opacity: 0.8;
+}
+
+.speakeasy > * {
+  position: relative;
+  z-index: 1;
+}
+
+.speakeasy-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.speakeasy-header h2 {
+  margin: 0;
+  font-size: 1.8rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.speakeasy-subtitle {
+  margin: 0.4rem 0 0;
+  color: rgba(226, 232, 240, 0.75);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+.swagger-meter {
+  width: min(20rem, 100%);
+  background: linear-gradient(135deg, rgba(250, 204, 21, 0.08), rgba(15, 23, 42, 0.6));
+  border: 1px solid rgba(250, 204, 21, 0.32);
+  border-radius: 1.25rem;
+  padding: 1rem 1.25rem;
+  box-shadow: inset 0 1px 0 rgba(248, 250, 252, 0.08);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.swagger-meter[data-ready="true"] {
+  border-color: rgba(250, 204, 21, 0.75);
+  box-shadow: 0 0 0 1px rgba(250, 204, 21, 0.35), 0 22px 40px rgba(250, 204, 21, 0.2);
+}
+
+.swagger-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.75rem;
+  color: rgba(250, 204, 21, 0.75);
+}
+
+.swagger-track {
+  margin: 0.75rem 0 0.5rem;
+  height: 0.65rem;
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 999px;
+  overflow: hidden;
+  border: 1px solid rgba(250, 204, 21, 0.35);
+}
+
+.swagger-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #facc15, #f97316);
+  transition: width 0.35s cubic-bezier(0.36, 0, 0.21, 1), filter 0.3s ease;
+  box-shadow: 0 0 12px rgba(250, 204, 21, 0.4);
+}
+
+.swagger-meter[data-ready="true"] .swagger-fill {
+  filter: drop-shadow(0 0 14px rgba(250, 204, 21, 0.7));
+}
+
+.swagger-note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.hustle-hud,
+.streak-hud {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 1.75rem;
+}
+
+.bank-card,
+.pot-card,
+.streak-card {
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.86), rgba(2, 6, 17, 0.9));
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 1px 0 rgba(248, 250, 252, 0.06);
+}
+
+.bank-card.is-player {
+  border-color: rgba(250, 204, 21, 0.4);
+}
+
+.bank-card.is-opponent {
+  border-color: rgba(244, 114, 182, 0.35);
+}
+
+.bank-label,
+.pot-label,
+.streak-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.bank-value,
+.pot-value,
+.streak-value {
+  margin: 0.75rem 0 0;
+  font-size: clamp(1.65rem, 2vw, 2rem);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.pot-note {
+  margin: 0.6rem 0 0;
+  color: rgba(226, 232, 240, 0.7);
+  min-height: 2.4rem;
+}
+
+.opponent-card {
+  border-radius: 1.5rem;
+  padding: 1.75rem;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.92), rgba(2, 6, 17, 0.9));
+  border: 1px solid rgba(250, 204, 21, 0.25);
+  box-shadow: 0 25px 60px rgba(2, 6, 23, 0.6);
+  position: relative;
+  overflow: hidden;
+  margin-bottom: 2rem;
+  transition: transform 0.35s ease;
+}
+
+.opponent-card::before {
+  content: "";
+  position: absolute;
+  inset: -20% -40% auto;
+  height: 60%;
+  background: radial-gradient(circle, rgba(250, 204, 21, 0.25), transparent 60%);
+  opacity: 0.6;
+  transform: rotate(-6deg);
+}
+
+.opponent-card.is-rolling {
+  animation: card-sway 0.8s ease both;
+}
+
+.opponent-card.is-taunting {
+  animation: taunt-pop 0.55s ease-in-out both;
+}
+
+@keyframes card-sway {
+  0% {
+    transform: rotate(0deg);
+  }
+  40% {
+    transform: rotate(-1.6deg) translateY(-4px);
+  }
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+@keyframes taunt-pop {
+  0% {
+    transform: scale(1) translateX(0);
+  }
+  30% {
+    transform: scale(1.04) translateX(-6px);
+  }
+  60% {
+    transform: scale(1.04) translateX(6px);
+  }
+  100% {
+    transform: scale(1) translateX(0);
+  }
+}
+
+.opponent-eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.75rem;
+  color: rgba(250, 204, 21, 0.75);
+}
+
+.opponent-name {
+  margin: 0.5rem 0 0.75rem;
+  font-size: 1.85rem;
+  letter-spacing: 0.04em;
+}
+
+.opponent-intro {
+  margin: 0 0 1.25rem;
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.opponent-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.opponent-stats div {
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.9rem;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.75), rgba(2, 6, 23, 0.6));
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.opponent-stats dt {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.7rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.opponent-stats dd {
+  margin: 0.4rem 0 0;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.challenge-console {
+  border-radius: 1.5rem;
+  padding: 1.75rem;
+  background: linear-gradient(140deg, rgba(15, 23, 42, 0.88), rgba(2, 6, 17, 0.92));
+  border: 1px solid rgba(250, 204, 21, 0.2);
+  box-shadow: inset 0 1px 0 rgba(248, 250, 252, 0.04);
+}
+
+.console-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+}
+
+.action-button {
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(250, 204, 21, 0.4);
+  background: linear-gradient(135deg, rgba(250, 204, 21, 0.22), rgba(249, 115, 22, 0.22));
+  color: #fdf9e6;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  box-shadow: 0 16px 32px rgba(2, 6, 23, 0.5);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.action-button:hover:not(:disabled),
+.action-button:focus-visible:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 40px rgba(250, 204, 21, 0.25);
+  border-color: rgba(250, 204, 21, 0.8);
+}
+
+.action-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  box-shadow: none;
+}
+
+.swagger-trigger {
+  background: linear-gradient(135deg, rgba(244, 114, 182, 0.25), rgba(59, 130, 246, 0.2));
+  border-color: rgba(244, 114, 182, 0.35);
+}
+
+.swagger-meter[data-ready="true"] + .console-actions .swagger-trigger,
+.swagger-trigger[data-ready="true"] {
+  border-color: rgba(250, 204, 21, 0.9);
+  background: linear-gradient(135deg, rgba(250, 204, 21, 0.45), rgba(249, 115, 22, 0.35));
+}
+
+.challenge-area {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 3rem 0;
+  overflow: hidden;
+}
+
+.challenge-area::before {
+  content: "";
+  position: absolute;
+  inset: auto;
+  width: 14rem;
+  height: 14rem;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(250, 204, 21, 0.16), transparent 65%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.challenge-area.is-flash::before {
+  opacity: 1;
+  animation: flash-pop 0.6s ease-out forwards;
+}
+
+@keyframes flash-pop {
+  0% {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  40% {
+    opacity: 1;
+    transform: scale(1.05);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.2);
+  }
+}
+
+.challenge-ring {
+  --ring-scale: 1;
+  position: absolute;
+  width: 14rem;
+  height: 14rem;
+  border-radius: 50%;
+  border: 2px solid rgba(250, 204, 21, 0.28);
+  box-shadow: 0 0 22px rgba(250, 204, 21, 0.15);
+  transform: translateZ(0) scale(var(--ring-scale));
+  opacity: 0;
+  transition: opacity 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.challenge-area[data-zone="late"] .challenge-ring {
+  opacity: 0.55;
+  border-color: rgba(250, 204, 21, 0.4);
+  box-shadow: 0 0 24px rgba(250, 204, 21, 0.28);
+}
+
+.challenge-area[data-zone="good"] .challenge-ring {
+  opacity: 0.75;
+  border-color: rgba(249, 115, 22, 0.6);
+  box-shadow: 0 0 30px rgba(249, 115, 22, 0.4);
+}
+
+.challenge-area[data-zone="perfect"] .challenge-ring {
+  opacity: 1;
+  border-color: rgba(250, 204, 21, 0.95);
+  box-shadow: 0 0 45px rgba(250, 204, 21, 0.7);
+}
+
+.challenge-button {
+  position: relative;
+  width: 11rem;
+  height: 11rem;
+  border-radius: 50%;
+  border: 3px solid rgba(148, 163, 184, 0.2);
+  background: radial-gradient(circle, rgba(15, 23, 42, 0.92), rgba(2, 6, 17, 0.95));
+  color: #f8fafc;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  cursor: pointer;
+}
+
+.challenge-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.challenge-area[data-zone="good"] .challenge-button,
+.challenge-area[data-zone="perfect"] .challenge-button {
+  border-color: rgba(250, 204, 21, 0.65);
+  box-shadow: 0 16px 36px rgba(250, 204, 21, 0.28);
+}
+
+.challenge-area[data-zone="perfect"] .challenge-button {
+  transform: scale(1.02);
+  box-shadow: 0 18px 48px rgba(250, 204, 21, 0.35);
+}
+
+.challenge-label {
+  display: block;
+  font-size: 0.85rem;
+}
+
+.challenge-window {
+  display: block;
+  margin-top: 0.75rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.timing-caption {
+  margin: 1.5rem 0 0.75rem;
+  text-align: center;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.result-banner {
+  margin: 0;
+  text-align: center;
+  color: rgba(250, 204, 21, 0.75);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  min-height: 1.5rem;
+}
+
+.status-row {
+  margin-top: 2rem;
+}
+
+.status-banner {
+  padding: 1rem 1.35rem;
+  border-radius: 1.15rem;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(2, 6, 17, 0.9));
+  border: 1px solid rgba(250, 204, 21, 0.25);
+  box-shadow: 0 24px 50px rgba(2, 6, 23, 0.6);
+  color: rgba(248, 250, 252, 0.9);
+}
+
+.event-ledger {
+  margin-top: 2rem;
+  background: linear-gradient(150deg, rgba(15, 23, 42, 0.88), rgba(2, 6, 17, 0.9));
+  border-radius: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 1.5rem;
+}
+
+.ledger-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.ledger-header h3 {
+  margin: 0;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.event-log {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+  max-height: 14rem;
+  overflow-y: auto;
+}
+
+.event-log li {
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.85rem;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+}
+
+.wrap-up {
+  position: sticky;
+  top: 1.5rem;
+}
+
+.wrap-up-card {
+  background: linear-gradient(155deg, rgba(15, 23, 42, 0.9), rgba(2, 6, 17, 0.94));
+  border-radius: 1.5rem;
+  padding: 2rem;
+  border: 1px solid rgba(250, 204, 21, 0.3);
+  box-shadow: 0 32px 80px rgba(2, 6, 23, 0.65);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.wrap-up[hidden] {
+  display: none;
+}
+
+.wrap-up-eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(250, 204, 21, 0.8);
+}
+
+.wrap-up-title {
+  margin: 0;
+  font-size: 1.85rem;
+  letter-spacing: 0.05em;
+}
+
+.wrap-up-total,
+.wrap-up-streak,
+.wrap-up-foes,
+.wrap-up-note {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.78);
+}
+
+.wrap-up-button {
+  align-self: center;
+}
+
+.page-footer {
+  margin: 3rem auto 4rem;
+  max-width: 70ch;
+  text-align: center;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+body.is-slowmo .challenge-ring {
+  animation: slowmo-glow 1.4s ease-in-out infinite;
+}
+
+@keyframes slowmo-glow {
+  0%,
+  100% {
+    box-shadow: 0 0 24px rgba(94, 234, 212, 0.45);
+  }
+  50% {
+    box-shadow: 0 0 36px rgba(94, 234, 212, 0.65);
+  }
+}
+
+@media (max-width: 1200px) {
+  .sugar-layout {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+
+  .wrap-up {
+    order: 3;
+  }
+}
+
+@media (max-width: 900px) {
+  .sugar-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .briefing,
+  .speakeasy,
+  .wrap-up-card {
+    position: static;
+  }
+
+  .hustle-hud,
+  .streak-hud {
+    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  }
+
+  .challenge-button {
+    width: 9.5rem;
+    height: 9.5rem;
+  }
+
+  .challenge-ring {
+    width: 12rem;
+    height: 12rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .console-actions {
+    flex-direction: column;
+  }
+
+  .challenge-area {
+    padding: 2.5rem 0;
+  }
+
+  .event-log {
+    max-height: 18rem;
+  }
+}

--- a/madia.new/public/secret/1989/sugar-ray-hustle/sugar-ray-hustle.js
+++ b/madia.new/public/secret/1989/sugar-ray-hustle/sugar-ray-hustle.js
@@ -1,0 +1,777 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+import { mountParticleField } from "../particles.js";
+import { createStatusChannel, createLogChannel } from "../feedback.js";
+
+const particleField = mountParticleField({
+  effects: {
+    palette: ["#fde68a", "#fbbf24", "#f59e0b", "#f97316", "#f472b6"],
+    ambientDensity: 0.32,
+  },
+});
+
+const scoreConfig = getScoreConfig("sugar-ray-hustle");
+const highScore = initHighScoreBanner({
+  gameId: "sugar-ray-hustle",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
+const statusBar = document.getElementById("status-bar");
+const eventLog = document.getElementById("event-log");
+const swaggerMeter = document.getElementById("swagger-meter");
+const swaggerFill = document.getElementById("swagger-fill");
+const swaggerNote = document.getElementById("swagger-note");
+const swaggerButton = document.getElementById("swagger-button");
+const dealButton = document.getElementById("deal-challenge");
+const challengeButton = document.getElementById("challenge-button");
+const challengeArea = document.getElementById("challenge-area");
+const timingRing = document.getElementById("timing-ring");
+const windowLabel = document.getElementById("window-label");
+const timingCaption = document.getElementById("timing-caption");
+const resultBanner = document.getElementById("result-banner");
+const playerBankValue = document.getElementById("player-bank");
+const opponentBankValue = document.getElementById("opponent-bank");
+const opponentBankLabel = document.getElementById("opponent-bank-label");
+const potValue = document.getElementById("pot-value");
+const potNote = document.getElementById("pot-note");
+const streakValue = document.getElementById("streak-value");
+const bestStreakValue = document.getElementById("best-streak-value");
+const roundCounter = document.getElementById("round-counter");
+const opponentCard = document.getElementById("opponent-card");
+const opponentTitle = document.getElementById("opponent-title");
+const opponentName = document.getElementById("opponent-name");
+const opponentIntro = document.getElementById("opponent-intro");
+const opponentTempo = document.getElementById("opponent-tempo");
+const opponentWindow = document.getElementById("opponent-window");
+const opponentPenalty = document.getElementById("opponent-penalty");
+const opponentProgress = document.getElementById("opponent-progress");
+const wrapUp = document.getElementById("wrap-up");
+const wrapUpTitle = document.getElementById("wrap-up-title");
+const wrapUpMoney = document.getElementById("wrap-up-money");
+const wrapUpStreak = document.getElementById("wrap-up-streak");
+const wrapUpOpponents = document.getElementById("wrap-up-opponents");
+const wrapUpTotalOpponents = document.getElementById("wrap-up-total-opponents");
+const wrapUpNote = document.getElementById("wrap-up-note");
+const wrapUpReplay = document.getElementById("wrap-up-replay");
+
+const setStatus = createStatusChannel(statusBar);
+const logChannel = createLogChannel(eventLog, { limit: 12 });
+
+const opponents = [
+  {
+    id: "velvet-verona",
+    name: "Velvet Verona",
+    title: "Floor Greeter",
+    intro:
+      "Velvet's glide is all satin and smoke. She tracks your pulse from the way you reach for the felt.",
+    tempoLabel: "Lounge glide",
+    accent: "#facc15",
+    baseDuration: 2200,
+    windows: { late: 420, good: 300, perfect: 160 },
+    missMultiplier: 1.5,
+    basePot: 160,
+    potSwing: 90,
+    bank: 900,
+    swaggerBonus: 32,
+    entrance: "Velvet Verona fans a velvet fan and beckons you to the rail.",
+    exit: "Velvet tips the dealer and fades into the crowd—tapped out.",
+    claims: [
+      "fans the bones and calls velvet sevens",
+      "lets the dice dance and hums for boxcars",
+      "palms a die and whispers midnight doubles",
+      "spins the cup and promises a satin eleven",
+    ],
+    taunts: [
+      "\"Blink again and I'll rent those chips, sugar.\"",
+      "\"Too slow. The glow waits for no one.\"",
+      "\"Hands like that won't buy the next round.\"",
+    ],
+  },
+  {
+    id: "quickhand-quincy",
+    name: "Quickhand Quincy",
+    title: "Backroom Mechanic",
+    intro: "Quincy rattles the dice like a snare drum, carving windows so tight you can feel the draft.",
+    tempoLabel: "Switchback shuffle",
+    accent: "#38bdf8",
+    baseDuration: 1900,
+    windows: { late: 360, good: 240, perfect: 120 },
+    missMultiplier: 1.55,
+    basePot: 210,
+    potSwing: 110,
+    bank: 1100,
+    swaggerBonus: 34,
+    entrance: "Quickhand Quincy snaps his suspenders and smirks at the pit boss.",
+    exit: "Quincy flicks his hat brim and mutters about bad rhythm as he bows out.",
+    claims: [
+      "taps the cup twice and swears it's a midnight jump",
+      "slides the bones down the rail and calls razored eights",
+      "cackles about a hustle pair and snaps for double nickels",
+      "palms the felt and whispers for angel wings",
+    ],
+    taunts: [
+      "\"Thought you had the tempo? Try again, rookie.\"",
+      "\"You just paid the house to practice.\"",
+      "\"I heard the hesitation from the bar.\"",
+    ],
+  },
+  {
+    id: "lady-domino-della",
+    name: "Lady Domino Della",
+    title: "Pit Boss",
+    intro: "Della drapes the table in gold filigree, collapsing the window to a razor's edge.",
+    tempoLabel: "Metronome snap",
+    accent: "#f472b6",
+    baseDuration: 1650,
+    windows: { late: 300, good: 200, perfect: 100 },
+    missMultiplier: 1.65,
+    basePot: 260,
+    potSwing: 130,
+    bank: 1300,
+    swaggerBonus: 36,
+    entrance: "Lady Della clicks her locket shut and orders the band to drop the beat.",
+    exit: "Della laughs, promising a rematch when the lights cool down.",
+    claims: [
+      "rolls blindfolded and guarantees royal crowns",
+      "tosses high and nods for a midnight ladder",
+      "cuts the air and swears on triple moons",
+      "beckons the dealer and calls a silk straight",
+    ],
+    taunts: [
+      "\"Come back when you can hold a pulse.\"",
+      "\"I saw you counting heartbeats instead of bars.\"",
+      "\"That hesitation cost you the champagne.\"",
+    ],
+  },
+  {
+    id: "sugar-ray-caldwell",
+    name: "Sugar Ray Caldwell",
+    title: "Club Owner",
+    intro:
+      "The man himself steps in, cane sparkling. His ring shrinks faster than the spotlight on closing time.",
+    tempoLabel: "Strobe blitz",
+    accent: "#fde047",
+    baseDuration: 1450,
+    windows: { late: 260, good: 180, perfect: 80 },
+    missMultiplier: 1.75,
+    basePot: 320,
+    potSwing: 160,
+    bank: 1500,
+    swaggerBonus: 40,
+    entrance: "Sugar Ray twirls his cane and lets the room hush before the next throw.",
+    exit: "Sugar Ray tips his hat—tonight, the floor is yours.",
+    claims: [
+      "tosses a blur and calls the dawn double",
+      "cracks the dice like lightning and swears on midnight gold",
+      "smiles thin and predicts a hustler's halo",
+      "lets them ricochet and promises the house a silent twelve",
+    ],
+    taunts: [
+      "\"You want the marquee? Catch the glint, not the rumor.\"",
+      "\"Close isn't a currency in my club.\"",
+      "\"The ring vanished and so did your bankroll.\"",
+    ],
+  },
+];
+
+const audioState = { context: null };
+
+const state = {
+  opponentIndex: 0,
+  currentOpponent: opponents[0],
+  playerMoney: 1200,
+  opponentMoney: opponents[0].bank,
+  pot: 0,
+  round: 0,
+  roundsAgainstCurrent: 0,
+  perfectStreak: 0,
+  bestPerfectStreak: 0,
+  swagger: 0,
+  swaggerReady: false,
+  slowTimeCharges: 0,
+  swaggerActivations: 0,
+  challengeActive: false,
+  challengeStart: null,
+  challengeDuration: 0,
+  challengeWindows: { late: 0, good: 0, perfect: 0 },
+  animationId: null,
+  zone: "idle",
+  sessionActive: true,
+  opponentsCleared: 0,
+  lastClaim: "",
+};
+
+initialize();
+
+function initialize() {
+  wrapUpTotalOpponents.textContent = opponents.length.toString();
+  setStatus("Welcome to the Rose Room. Prime the dice to start the hustle.", "info");
+  updateOpponentCard();
+  updateBanks();
+  updateSwagger();
+  updateRoundCounter();
+  updateResultBanner("Waiting on the next claim.");
+  updateDealButtonLabel();
+  logChannel.push(state.currentOpponent.entrance, "info");
+  dealButton.addEventListener("click", () => {
+    if (!state.sessionActive || state.challengeActive) {
+      return;
+    }
+    primeRound();
+  });
+
+  challengeButton.addEventListener("click", () => {
+    if (!state.challengeActive) {
+      return;
+    }
+    const context = ensureAudioContext();
+    if (context?.state === "suspended") {
+      context.resume().catch(() => {});
+    }
+    resolveChallenge(performance.now());
+  });
+
+  swaggerButton.addEventListener("click", () => {
+    if (!state.sessionActive || state.challengeActive || !state.swaggerReady) {
+      return;
+    }
+    const context = ensureAudioContext();
+    if (context?.state === "suspended") {
+      context.resume().catch(() => {});
+    }
+    activateSwagger();
+  });
+
+  wrapUpReplay.addEventListener("click", () => {
+    resetSession();
+  });
+}
+
+function primeRound() {
+  const opponent = state.currentOpponent;
+  state.round += 1;
+  state.roundsAgainstCurrent += 1;
+  state.pot = computePot(opponent);
+  state.lastClaim = pick(opponent.claims);
+  updateRoundCounter();
+  updateBanks();
+  updatePotNote();
+  setStatus(
+    `${opponent.name} ${state.lastClaim} for ${formatCurrency(state.pot)}. Wait for the glow.`,
+    "info",
+  );
+  logChannel.push(
+    `Round ${state.round}: ${opponent.name} ${state.lastClaim} for ${formatCurrency(state.pot)}.`,
+  );
+  opponentCard.classList.remove("is-taunting");
+  opponentCard.classList.add("is-rolling");
+  window.clearTimeout(primeRound.rollTimeout);
+  primeRound.rollTimeout = window.setTimeout(() => {
+    opponentCard.classList.remove("is-rolling");
+    armChallenge(opponent);
+  }, 520);
+  dealButton.disabled = true;
+}
+
+function armChallenge(opponent) {
+  const slowFactor = state.slowTimeCharges > 0 ? 1.65 : 1;
+  const duration = opponent.baseDuration * slowFactor;
+  const perfectWindow = opponent.windows.perfect * slowFactor;
+  const goodWindow = opponent.windows.good * slowFactor;
+  const lateWindow = opponent.windows.late * slowFactor;
+  state.challengeDuration = duration;
+  state.challengeWindows = {
+    perfect: Math.max(0, duration - perfectWindow),
+    good: Math.max(0, duration - perfectWindow - goodWindow),
+    late: Math.max(0, duration - perfectWindow - goodWindow - lateWindow),
+  };
+  state.challengeActive = true;
+  state.challengeStart = null;
+  setChallengeZone("pre");
+  challengeButton.disabled = false;
+  if (state.slowTimeCharges > 0) {
+    document.body.classList.add("is-slowmo");
+    state.slowTimeCharges -= 1;
+    state.swaggerReady = false;
+    updateSwagger();
+  }
+  cancelAnimationFrame(state.animationId);
+  state.animationId = requestAnimationFrame(stepChallenge);
+}
+
+function stepChallenge(timestamp) {
+  if (!state.challengeActive) {
+    return;
+  }
+  if (state.challengeStart === null) {
+    state.challengeStart = timestamp;
+  }
+  const elapsed = timestamp - state.challengeStart;
+  const progress = Math.min(elapsed / state.challengeDuration, 1);
+  const scale = Math.max(0.1, 1 - progress);
+  timingRing.style.setProperty("--ring-scale", scale.toFixed(3));
+  updateZoneForElapsed(elapsed);
+  if (elapsed >= state.challengeDuration) {
+    resolveChallenge(timestamp);
+    return;
+  }
+  state.animationId = requestAnimationFrame(stepChallenge);
+}
+
+function resolveChallenge(timestamp) {
+  if (!state.challengeActive) {
+    return;
+  }
+  const elapsed = timestamp - (state.challengeStart ?? timestamp);
+  finishChallenge();
+  const { perfect, good, late } = state.challengeWindows;
+  if (elapsed < late) {
+    handleMiss("Jumped before the rings aligned.");
+    return;
+  }
+  if (elapsed >= state.challengeDuration) {
+    handleMiss("Too late—the glow vanished.");
+    return;
+  }
+  if (elapsed >= perfect) {
+    handlePerfect(elapsed);
+    return;
+  }
+  if (elapsed >= good) {
+    handleGood();
+    return;
+  }
+  handleLate();
+}
+
+function finishChallenge() {
+  state.challengeActive = false;
+  cancelAnimationFrame(state.animationId);
+  state.animationId = null;
+  challengeButton.disabled = true;
+  challengeArea.classList.remove("is-flash");
+  document.body.classList.remove("is-slowmo");
+  state.zone = "idle";
+  challengeArea.dataset.zone = "idle";
+  windowLabel.textContent = "Wait for the glow";
+  timingCaption.textContent = "The ring collapses fast—perfect hits double the pot.";
+  timingRing.style.setProperty("--ring-scale", "1");
+  window.setTimeout(() => {
+    if (state.sessionActive) {
+      dealButton.disabled = false;
+      updateDealButtonLabel();
+    }
+  }, 420);
+}
+
+function handlePerfect(elapsed) {
+  const opponent = state.currentOpponent;
+  const haul = state.pot * 2;
+  state.playerMoney += haul;
+  state.opponentMoney -= haul;
+  state.perfectStreak += 1;
+  state.bestPerfectStreak = Math.max(state.bestPerfectStreak, state.perfectStreak);
+  state.swagger = Math.min(100, state.swagger + opponent.swaggerBonus);
+  state.swaggerReady = state.swagger >= 100;
+  const intensity = Math.min(1.2, 0.85 + state.perfectStreak * 0.05);
+  playKaChing(intensity);
+  particleField.emitBurst(1.25 * intensity);
+  particleField.emitSparkle(0.9 * intensity);
+  challengeArea.classList.add("is-flash");
+  window.setTimeout(() => {
+    challengeArea.classList.remove("is-flash");
+  }, 420);
+  const windowMs = Math.max(0, state.challengeDuration - elapsed);
+  const windowText = windowMs > 0 ? `${Math.round(windowMs)}ms spare` : "edge tight";
+  setStatus(
+    `Perfect! ${opponent.name}'s hustle collapses. ${formatCurrency(haul)} banked with ${windowText}.`,
+    "success",
+  );
+  logChannel.push(
+    `Perfect timing! ${formatCurrency(haul)} haul. Swagger rises to ${Math.round(state.swagger)}%.`,
+    "success",
+  );
+  updateResultBanner("Perfect Challenge · Massive Win");
+  updateBanks();
+  updateSwagger();
+  updateStreaks();
+  evaluateOpponentState();
+}
+
+function handleGood() {
+  const opponent = state.currentOpponent;
+  const haul = state.pot;
+  state.playerMoney += haul;
+  state.opponentMoney -= haul;
+  state.perfectStreak = 0;
+  playKaChing(0.55);
+  setStatus(`Good hit. ${formatCurrency(haul)} slides your way.`, "success");
+  logChannel.push(`Good read. ${formatCurrency(haul)} secured.`, "success");
+  updateResultBanner("Good Challenge · Solid Win");
+  updateBanks();
+  updateSwagger();
+  updateStreaks();
+  evaluateOpponentState();
+}
+
+function handleLate() {
+  state.perfectStreak = 0;
+  playThud();
+  setStatus("Late window—chips stay put.", "warning");
+  logChannel.push("Late window. Pot pushes.", "warning");
+  triggerTaunt();
+  updateResultBanner("Late Challenge · Push");
+  updateSwagger(-12);
+  updateStreaks();
+}
+
+function handleMiss(reason) {
+  const opponent = state.currentOpponent;
+  const penalty = Math.round(state.pot * opponent.missMultiplier);
+  state.playerMoney -= penalty;
+  state.opponentMoney += penalty;
+  state.perfectStreak = 0;
+  playThud();
+  setStatus(`Miss! ${reason} Lose ${formatCurrency(penalty)}.`, "danger");
+  logChannel.push(`Missed window. ${reason} (${formatCurrency(-penalty)}).`, "danger");
+  triggerTaunt();
+  updateResultBanner("Miss · House Takes the Pot");
+  updateBanks();
+  updateSwagger(-18);
+  updateStreaks();
+  evaluateDefeat();
+}
+
+function updateZoneForElapsed(elapsed) {
+  const { perfect, good, late } = state.challengeWindows;
+  if (elapsed >= perfect) {
+    setChallengeZone("perfect");
+    return;
+  }
+  if (elapsed >= good) {
+    setChallengeZone("good");
+    return;
+  }
+  if (elapsed >= late) {
+    setChallengeZone("late");
+    return;
+  }
+  setChallengeZone("pre");
+}
+
+function setChallengeZone(zone) {
+  if (state.zone === zone) {
+    return;
+  }
+  state.zone = zone;
+  challengeArea.dataset.zone = zone;
+  switch (zone) {
+    case "perfect":
+      windowLabel.textContent = "Perfect · Massive Win";
+      timingCaption.textContent = "Now! Slam it while the inner ring burns gold.";
+      break;
+    case "good":
+      windowLabel.textContent = "Good · Modest Win";
+      timingCaption.textContent = "Hold your nerve a heartbeat longer for the big flash.";
+      break;
+    case "late":
+      windowLabel.textContent = "Late · Push";
+      timingCaption.textContent = "Play it safe or wait for the gold.";
+      break;
+    case "pre":
+      windowLabel.textContent = "Hold for the tighten";
+      timingCaption.textContent = "The ring is still wide—wait for the heat.";
+      break;
+    default:
+      windowLabel.textContent = "Wait for the glow";
+      timingCaption.textContent = "The ring collapses fast—perfect hits double the pot.";
+      break;
+  }
+}
+
+function triggerTaunt() {
+  const opponent = state.currentOpponent;
+  opponentCard.classList.remove("is-rolling");
+  opponentCard.classList.remove("is-taunting");
+  void opponentCard.offsetWidth;
+  opponentCard.classList.add("is-taunting");
+  const taunt = pick(opponent.taunts);
+  if (taunt) {
+    logChannel.push(`${opponent.name} sneers: ${taunt}`, "warning");
+  }
+}
+
+function evaluateOpponentState() {
+  if (state.opponentMoney <= 0) {
+    const opponent = state.currentOpponent;
+    state.opponentsCleared += 1;
+    setStatus(`${opponent.name} is tapped out. ${opponent.exit}`, "success");
+    logChannel.push(`${opponent.name} folds. On to the next shark.`, "success");
+    advanceOpponent();
+  }
+}
+
+function evaluateDefeat() {
+  if (state.playerMoney <= 0) {
+    state.playerMoney = Math.max(state.playerMoney, 0);
+    endSession(false);
+  }
+}
+
+function advanceOpponent() {
+  state.opponentIndex += 1;
+  if (state.opponentIndex >= opponents.length) {
+    endSession(true);
+    return;
+  }
+  state.currentOpponent = opponents[state.opponentIndex];
+  state.opponentMoney = state.currentOpponent.bank;
+  state.roundsAgainstCurrent = 0;
+  updateOpponentCard();
+  updateBanks();
+  updateRoundCounter();
+  state.pot = 0;
+  updatePotNote();
+  setStatus(state.currentOpponent.entrance, "info");
+  logChannel.push(state.currentOpponent.entrance, "info");
+}
+
+function endSession(victory) {
+  state.sessionActive = false;
+  finishChallenge();
+  dealButton.disabled = true;
+  swaggerButton.disabled = true;
+  state.challengeActive = false;
+  updateBanks();
+  const summary = victory
+    ? "You own the Rose Room."
+    : "The house sweeps the night.";
+  wrapUpTitle.textContent = summary;
+  wrapUpMoney.textContent = formatCurrency(state.playerMoney);
+  wrapUpStreak.textContent = state.bestPerfectStreak.toString();
+  if (victory) {
+    state.opponentsCleared = opponents.length;
+  }
+  wrapUpOpponents.textContent = state.opponentsCleared.toString();
+  wrapUpTotalOpponents.textContent = opponents.length.toString();
+  wrapUpNote.textContent = victory
+    ? "Hit the marquee and log the score upstairs."
+    : "Keep grinding for that marquee slot.";
+  wrapUp.hidden = false;
+  const meta = {
+    longestStreak: state.bestPerfectStreak,
+    opponents: state.opponentsCleared,
+    swaggerActivations: state.swaggerActivations,
+  };
+  const result = highScore.submit(state.playerMoney, meta);
+  if (result.updated) {
+    wrapUpNote.textContent = "New high score! The Rose Room lights spell your name.";
+  }
+}
+
+function resetSession() {
+  state.opponentIndex = 0;
+  state.currentOpponent = opponents[0];
+  state.playerMoney = 1200;
+  state.opponentMoney = state.currentOpponent.bank;
+  state.pot = 0;
+  state.round = 0;
+  state.roundsAgainstCurrent = 0;
+  state.perfectStreak = 0;
+  state.bestPerfectStreak = 0;
+  state.swagger = 0;
+  state.swaggerReady = false;
+  state.slowTimeCharges = 0;
+  state.swaggerActivations = 0;
+  state.challengeActive = false;
+  state.sessionActive = true;
+  state.opponentsCleared = 0;
+  state.lastClaim = "";
+  wrapUp.hidden = true;
+  wrapUpTotalOpponents.textContent = opponents.length.toString();
+  wrapUpOpponents.textContent = "0";
+  wrapUpStreak.textContent = "0";
+  wrapUpMoney.textContent = formatCurrency(state.playerMoney);
+  eventLog.innerHTML = "";
+  updateOpponentCard();
+  logChannel.push(state.currentOpponent.entrance, "info");
+  updateBanks();
+  updateRoundCounter();
+  updateSwagger();
+  updatePotNote();
+  updateStreaks();
+  updateResultBanner("Waiting on the next claim.");
+  setStatus("Fresh bankroll. Prime the dice when you're ready.", "info");
+  dealButton.disabled = false;
+  updateDealButtonLabel();
+}
+
+function updateOpponentCard() {
+  const opponent = opponents[state.opponentIndex];
+  state.currentOpponent = opponent;
+  opponentTitle.textContent = `${opponent.name} · ${opponent.title}`;
+  opponentName.textContent = opponent.name;
+  opponentIntro.textContent = opponent.intro;
+  opponentTempo.textContent = opponent.tempoLabel;
+  opponentWindow.innerHTML = `${Math.round(opponent.windows.perfect)}&nbsp;ms`;
+  opponentPenalty.textContent = `×${formatMultiplier(opponent.missMultiplier)} pot`;
+  opponentProgress.textContent = `Opponent ${state.opponentIndex + 1} of ${opponents.length}`;
+  document.body.style.setProperty("--sugar-accent", opponent.accent ?? "#facc15");
+  opponentBankLabel.textContent = `${opponent.name}'s Bank`;
+}
+
+function updateBanks() {
+  playerBankValue.textContent = formatCurrency(state.playerMoney);
+  opponentBankValue.textContent = formatCurrency(Math.max(state.opponentMoney, 0));
+}
+
+function updatePotNote() {
+  if (state.pot <= 0) {
+    potValue.textContent = "$0";
+    potNote.textContent = "Press Prime the Dice to set the next stake.";
+    return;
+  }
+  potValue.textContent = formatCurrency(state.pot);
+  potNote.textContent = `${state.currentOpponent.name} ${state.lastClaim}.`;
+}
+
+function updateStreaks() {
+  streakValue.textContent = state.perfectStreak.toString();
+  bestStreakValue.textContent = state.bestPerfectStreak.toString();
+}
+
+function updateSwagger(change = 0) {
+  if (change !== 0) {
+    state.swagger = Math.max(0, Math.min(100, state.swagger + change));
+    state.swaggerReady = state.swagger >= 100;
+  }
+  swaggerFill.style.width = `${state.swagger}%`;
+  swaggerMeter.dataset.ready = state.swaggerReady ? "true" : "false";
+  swaggerButton.disabled = !state.swaggerReady || !state.sessionActive || state.challengeActive;
+  swaggerButton.dataset.ready = state.swaggerReady ? "true" : "false";
+  swaggerNote.textContent = state.swaggerReady
+    ? "Swagger primed. Spend it to slow time for one round."
+    : "Perfect hits slow time. Keep the streak alive.";
+}
+
+function activateSwagger() {
+  state.slowTimeCharges = 1;
+  state.swagger = 0;
+  state.swaggerReady = false;
+  state.swaggerActivations += 1;
+  updateSwagger();
+  setStatus("Swagger spent. Time drags for the next claim.", "success");
+  logChannel.push("Swagger activated—next ring slows to a crawl.", "success");
+}
+
+function updateRoundCounter() {
+  const display = state.roundsAgainstCurrent > 0 ? state.roundsAgainstCurrent : 1;
+  roundCounter.textContent = display.toString();
+}
+
+function updateResultBanner(text) {
+  resultBanner.textContent = text;
+}
+
+function updateDealButtonLabel() {
+  dealButton.textContent = state.round > 0 ? "Raise Another Pot" : "Prime the Dice";
+}
+
+function computePot(opponent) {
+  const variance = Math.round(Math.random() * opponent.potSwing);
+  return opponent.basePot + variance;
+}
+
+function formatCurrency(value) {
+  const formatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
+  return formatter.format(value);
+}
+
+function formatMultiplier(multiplier) {
+  const text = multiplier.toFixed(2);
+  return text.replace(/\.00$/, "");
+}
+
+function pick(list) {
+  return list[Math.floor(Math.random() * list.length)];
+}
+
+function ensureAudioContext() {
+  if (audioState.context) {
+    return audioState.context;
+  }
+  try {
+    audioState.context = new AudioContext();
+  } catch (error) {
+    console.warn("Audio context unavailable", error);
+  }
+  return audioState.context;
+}
+
+function playKaChing(strength = 1) {
+  const context = ensureAudioContext();
+  if (!context) {
+    return;
+  }
+  const now = context.currentTime;
+  const master = context.createGain();
+  master.gain.setValueAtTime(0.0001, now);
+  master.gain.linearRampToValueAtTime(0.5 * strength, now + 0.02);
+  master.gain.exponentialRampToValueAtTime(0.001, now + 0.6);
+  master.connect(context.destination);
+
+  const freqs = [880, 1320, 1760];
+  freqs.forEach((frequency, index) => {
+    const osc = context.createOscillator();
+    const gain = context.createGain();
+    osc.type = "triangle";
+    osc.frequency.setValueAtTime(frequency, now);
+    osc.frequency.exponentialRampToValueAtTime(frequency * 1.05, now + 0.08);
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.linearRampToValueAtTime(0.2 * strength, now + 0.015 + index * 0.01);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.45 + index * 0.05);
+    osc.connect(gain).connect(master);
+    osc.start(now + index * 0.01);
+    osc.stop(now + 0.6 + index * 0.05);
+  });
+
+  const noise = context.createBufferSource();
+  const buffer = context.createBuffer(1, context.sampleRate * 0.3, context.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < data.length; i += 1) {
+    data[i] = (Math.random() * 2 - 1) * Math.exp(-i / (data.length * 0.6));
+  }
+  noise.buffer = buffer;
+  const noiseGain = context.createGain();
+  noiseGain.gain.setValueAtTime(0.0001, now);
+  noiseGain.gain.linearRampToValueAtTime(0.3 * strength, now + 0.02);
+  noiseGain.gain.exponentialRampToValueAtTime(0.0001, now + 0.35);
+  noise.connect(noiseGain).connect(master);
+  noise.start(now);
+  noise.stop(now + 0.35);
+}
+
+function playThud() {
+  const context = ensureAudioContext();
+  if (!context) {
+    return;
+  }
+  const now = context.currentTime;
+  const osc = context.createOscillator();
+  const gain = context.createGain();
+  osc.type = "sine";
+  osc.frequency.setValueAtTime(120, now);
+  osc.frequency.exponentialRampToValueAtTime(60, now + 0.35);
+  gain.gain.setValueAtTime(0.0001, now);
+  gain.gain.linearRampToValueAtTime(0.35, now + 0.02);
+  gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.45);
+  osc.connect(gain).connect(context.destination);
+  osc.start(now);
+  osc.stop(now + 0.5);
+}


### PR DESCRIPTION
## Summary
- add the Level 17 Sugar Ray Hustle cabinet with briefing, status HUD, swagger meter, and wrap-up panel
- implement timing-based challenge flow with escalating opponents, swagger slow time, audio cues, and celebratory particles
- register the cabinet in the 1989 arcade catalog and expose a currency-based high score formatter

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e036ab5c288328a51bcb67c3a2b445