### PR TITLE
Add Under the Sea Scramble cabinet

### DIFF
--- a/docs/1989/movie-coverage.md
+++ b/docs/1989/movie-coverage.md
@@ -2,6 +2,8 @@
 
 This reference tracks how the 1989 arcade cabinets map to their source films and how far the ladder has progressed up the 1989 domestic box office chart.
 
+Under the Sea Scramble now glitters at Level 13, turning Ariel's curiosity into a timed hidden-object sprint that punishes sloppy clicks while rewarding precise treasure hunts.
+
 River of Slime Escape now shocks Level 27 with Ghostbusters II’s river chase while Three Fugitives continues anchoring Level 32, and the ladder keeps backfilling the remaining Top 50 slots.
 Three Fugitives now anchors Level 32 while Hoverboard Pursuit secures Level 26, covering another Top 10 release as the ladder continues to backfill the remaining hits.
 Rollercoaster of Life now anchors Level 25, pushing the ladder deeper into the top 25 while earlier levels keep filling in the remaining Top 50 slots.
@@ -48,6 +50,7 @@ Three Fugitives now anchors Level 32, covering the next-highest new release stil
 | 28 | Voice Box Swap | *Look Who's Talking* | #6 |
 | 24 | The Diner Debate | *When Harry Met Sally...* | #11 |
 | 29 | Flapjack Flip-Out | *Uncle Buck* | #13 |
+| 13 | Under the Sea Scramble | *The Little Mermaid* | #22 |
 
 Remaining:
 ## Remaining Targets to Reach #1
@@ -90,7 +93,6 @@ Remaining:
 | **16** | Beaches | #19 | Wind Beneath My Wings | A musical rhythm or karaoke-style game hitting the notes of a powerful Bette Midler song. |
 | **15** | The Abyss | #20 | Deepcore Descent | A pressure/balance management game, keeping a deep-sea submersible stable and intact under crushing pressure. |
 | **14** | Star Trek V: The Final Frontier | #21 | The Final Barrier | A flying/shooting level piloting the Enterprise through a chaotic and disorienting energy field to reach a mythical planet. |
-| **13** | The Little Mermaid | #22 | Under the Sea Scramble | A hidden object or collection game in a colorful undersea environment, gathering "human gadgets." |
 | **12** | Steel Magnolias | #23 | Truvy's Salon Style | A rapid-fire styling/makeover game where you have to meet multiple clients' specific, complex hairstyle and makeup requests. |
 | **11** | Major League | #24 | Wild Thing Wind-Up | A timing/precision baseball pitching game focusing on a dramatically out-of-control, but fast, fastball. |
 | **10** | See No Evil, Hear No Evil | #25 | The Disorient Express | A cooperative or split-screen minigame where one player uses only visual cues and the other only audio cues to solve a simple puzzle. |

--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -1432,6 +1432,74 @@ const games = [
       </svg>
     `,
   },
+  { // Level 13
+    id: "under-the-sea-scramble",
+    name: "Under the Sea Scramble",
+    description: "Scan Ariel's hideouts for human gadgets before the sandglass empties and Flounder clouds the view.",
+    url: "./under-the-sea-scramble/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Under the Sea Scramble preview">
+        <defs>
+          <linearGradient id="utsBackdrop" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(59,130,246,0.85)" />
+            <stop offset="100%" stop-color="rgba(15,23,42,0.95)" />
+          </linearGradient>
+          <linearGradient id="utsReef" x1="0" y1="1" x2="1" y2="0">
+            <stop offset="0%" stop-color="rgba(34,197,94,0.65)" />
+            <stop offset="100%" stop-color="rgba(56,189,248,0.5)" />
+          </linearGradient>
+          <linearGradient id="utsParchment" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="rgba(254,240,138,0.95)" />
+            <stop offset="100%" stop-color="rgba(250,204,21,0.7)" />
+          </linearGradient>
+          <radialGradient id="utsGlow" cx="0.5" cy="0.3" r="0.6">
+            <stop offset="0%" stop-color="rgba(252,211,77,0.85)" />
+            <stop offset="100%" stop-color="rgba(252,211,77,0)" />
+          </radialGradient>
+        </defs>
+        <rect x="8" y="8" width="144" height="104" rx="18" fill="rgba(6,12,26,0.92)" stroke="rgba(148,163,184,0.35)" />
+        <rect x="18" y="18" width="124" height="88" rx="16" fill="url(#utsBackdrop)" stroke="rgba(56,189,248,0.35)" />
+        <g opacity="0.75">
+          <path d="M24 96 C30 74 44 56 58 44 C72 32 88 24 104 20" fill="none" stroke="rgba(16,185,129,0.5)" stroke-width="6" stroke-linecap="round" />
+          <path d="M40 96 C46 76 60 60 78 50" fill="none" stroke="rgba(45,212,191,0.45)" stroke-width="5" stroke-linecap="round" />
+          <path d="M120 96 C112 78 100 60 86 50" fill="none" stroke="rgba(56,189,248,0.4)" stroke-width="5" stroke-linecap="round" />
+        </g>
+        <g opacity="0.65">
+          ${Array.from({ length: 4 }, (_, i) => `<circle cx="${32 + i * 26}" cy="${34 + (i % 2) * 12}" r="${2 + (i % 3)}" fill="rgba(224,242,254,0.5)" />`).join("")}
+        </g>
+        <g transform="translate(24 48)">
+          <path d="M0 40 C10 22 22 10 40 0" fill="none" stroke="rgba(34,197,94,0.6)" stroke-width="4" stroke-linecap="round" />
+          <path d="M12 40 C22 26 34 14 52 6" fill="none" stroke="rgba(6,182,212,0.55)" stroke-width="4" stroke-linecap="round" />
+        </g>
+        <rect x="92" y="26" width="44" height="32" rx="9" fill="url(#utsParchment)" stroke="rgba(120,53,15,0.4)" />
+        <g font-family="'Press Start 2P', monospace" font-size="6" fill="#7f1d1d" transform="translate(98 34)">
+          <text x="0" y="6">LIST</text>
+          <text x="0" y="16">🍴</text>
+          <text x="14" y="16">🪈</text>
+          <text x="28" y="16">🎩</text>
+        </g>
+        <g>
+          <circle cx="58" cy="62" r="20" fill="rgba(14,165,233,0.3)" stroke="rgba(14,165,233,0.6)" stroke-width="2" />
+          <circle cx="58" cy="62" r="12" fill="url(#utsGlow)" />
+          <text x="58" y="66" text-anchor="middle" font-size="14" aria-hidden="true">⌛</text>
+        </g>
+        <g font-size="14" text-anchor="middle">
+          <text x="52" y="86">🍴</text>
+          <text x="78" y="90">🪈</text>
+          <text x="104" y="88">🌐</text>
+        </g>
+        <g stroke="url(#utsReef)" stroke-width="4" stroke-linecap="round" opacity="0.7">
+          <path d="M28 86 L52 76" />
+          <path d="M118 86 L94 74" />
+        </g>
+        <g transform="translate(32 92)">
+          <rect x="0" y="0" width="96" height="14" rx="7" fill="rgba(15,23,42,0.8)" stroke="rgba(56,189,248,0.45)" />
+          <rect x="6" y="4" width="56" height="6" rx="3" fill="rgba(56,189,248,0.65)" />
+          <rect x="64" y="4" width="24" height="6" rx="3" fill="rgba(234,179,8,0.7)" />
+        </g>
+      </svg>
+    `,
+  }, // Level 13
   {
     id: "prototype",
     name: "Prototype Cabinet",

--- a/madia.new/public/secret/1989/score-config.js
+++ b/madia.new/public/secret/1989/score-config.js
@@ -238,6 +238,23 @@ export const scoreConfigs = {
       return `${value ?? 0} pts · ${comboLabel}${riskyLabel}`;
     },
   },
+  // Level 13
+  "under-the-sea-scramble": {
+    label: "Treasure Trove Score",
+    empty: "No treasures cataloged yet.",
+    format: ({ value, meta }) => {
+      const accuracy = Number.isFinite(meta?.accuracy) ? Math.round(meta.accuracy) : null;
+      const accuracyText = accuracy !== null ? `${accuracy}% accuracy` : "accuracy unknown";
+      const helpCalls = Number(meta?.helpCalls ?? 0);
+      const helpLabel =
+        helpCalls === 0
+          ? "no Scuttle calls"
+          : `${helpCalls} Scuttle ${helpCalls === 1 ? "call" : "calls"}`;
+      const timeBonus = Number(meta?.timeBonus ?? 0);
+      const bonusLabel = timeBonus > 0 ? `+${timeBonus} bonus` : "no bonus";
+      return `${value ?? 0} pts · ${accuracyText} · ${helpLabel} · ${bonusLabel}`;
+    },
+  }, // Level 13
   "whispers-garden": {
     label: "Field Completion",
     empty: "No whispers answered yet.",

--- a/madia.new/public/secret/1989/under-the-sea-scramble/index.html
+++ b/madia.new/public/secret/1989/under-the-sea-scramble/index.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Under the Sea Scramble</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="under-the-sea-scramble.css" />
+  </head>
+  <body class="secret-annex-snes undersea-cabinet">
+    <a class="skip-link" href="#main-content">Skip to game</a>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 13 · 1989 Arcade</p>
+      <h1>Under the Sea Scramble</h1>
+      <p class="subtitle">
+        Ariel's collection is in disarray and Prince Eric arrives any minute.
+        Spot the human treasures hiding in each bustling reef before the sand-glass runs dry.
+      </p>
+    </header>
+    <main id="main-content" class="page-layout undersea-layout">
+      <section class="briefing" aria-labelledby="briefing-title">
+        <h2 id="briefing-title">Treasure Briefing</h2>
+        <p>
+          Ariel keeps expanding her grotto faster than Scuttle can explain what anything does.
+          Each scene lists the must-grab curiosities on her parchment—find them quickly, or Flotsam and Jetsam will clutter the path with distractions.
+        </p>
+        <ul class="callouts">
+          <li>
+            <strong>Treasure Trove Score:</strong>
+            Earn points for every item you secure, plus a sparkling time bonus when you finish a list without calling Scuttle.
+          </li>
+          <li>
+            <strong>Accuracy Matters:</strong>
+            Miss-clicks summon Flounder in a panic, blotting out the view and docking points.
+            Scan carefully before you tap that snarfblat.
+          </li>
+          <li>
+            <strong>Risk and Reward:</strong>
+            Scuttle can swoop in once per round to highlight a hard-to-spot treasure, but his help forfeits that juicy time bonus.
+          </li>
+        </ul>
+        <p>
+          Clear all three locations—from Ariel's grotto to the husk of a sunken ship—while keeping your Treasure Trove Score climbing.
+          Wrap up strong and Scuttle will catalog every gadget with his... unique expertise.
+        </p>
+      </section>
+      <section class="simulator" aria-labelledby="simulator-title">
+        <div class="simulator-header">
+          <h2 id="simulator-title">Salvage Console</h2>
+          <div class="simulator-controls">
+            <button type="button" class="action-button" id="start-button">Press Start</button>
+            <button type="button" class="action-button" id="reset-button">Reset</button>
+          </div>
+        </div>
+        <div class="hud" aria-label="Treasure tracking heads-up display">
+          <div class="hud-card">
+            <p class="hud-label">Current Locale</p>
+            <p class="hud-value" id="scene-name">Grotto Warm-Up</p>
+          </div>
+          <div class="hud-card">
+            <p class="hud-label">Time Remaining</p>
+            <div class="timer-bar" aria-hidden="true">
+              <div class="timer-fill" id="timer-fill"></div>
+            </div>
+            <p class="hud-value" id="timer-value">00:00</p>
+          </div>
+          <div class="hud-card">
+            <p class="hud-label">Treasure Trove Score</p>
+            <p class="hud-value" id="score-value">0</p>
+          </div>
+          <div class="hud-card">
+            <p class="hud-label">Scuttle's Help</p>
+            <button type="button" class="action-button" id="help-button">Available</button>
+          </div>
+        </div>
+        <div class="parchment" aria-labelledby="parchment-title">
+          <h3 id="parchment-title">Ariel's Parchment</h3>
+          <p class="parchment-note">Click the treasures to add them to the trove.</p>
+          <ul id="target-list" class="target-list"></ul>
+        </div>
+        <div class="scene-wrapper">
+          <div class="ambient-swim" aria-hidden="true">
+            <div class="fish-layer fish-one"></div>
+            <div class="fish-layer fish-two"></div>
+            <div class="seaweed seaweed-left"></div>
+            <div class="seaweed seaweed-right"></div>
+          </div>
+          <div
+            class="search-scene"
+            id="search-scene"
+            role="application"
+            aria-label="Hidden object field"
+            data-status="idle"
+          ></div>
+          <div class="flounder-overlay" id="flounder-overlay" aria-hidden="true">
+            <div class="flounder"></div>
+          </div>
+        </div>
+        <section class="status-panel" aria-live="assertive" id="status-banner">
+          Press Start to begin the scramble.
+        </section>
+        <section class="log-panel" aria-labelledby="log-title">
+          <div class="log-header">
+            <h3 id="log-title">Dive Log</h3>
+            <button type="button" class="action-button" id="clear-log">Clear</button>
+          </div>
+          <ol class="log-entries" id="log-feed"></ol>
+        </section>
+      </section>
+    </main>
+    <aside
+      class="wrapup"
+      id="wrapup-screen"
+      hidden
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="wrapup-title"
+    >
+      <div class="wrapup-card">
+        <h2 id="wrapup-title">Treasure Trove Tally</h2>
+        <p class="wrapup-score">Final Score: <span id="wrapup-score">0</span></p>
+        <p class="wrapup-subscore" id="wrapup-accuracy"></p>
+        <section class="wrapup-treasures" aria-labelledby="wrapup-treasures-title">
+          <h3 id="wrapup-treasures-title">Scuttle's Field Guide</h3>
+          <ul id="wrapup-treasure-list"></ul>
+        </section>
+        <div class="wrapup-actions">
+          <button type="button" class="action-button" id="play-again">Dive Again</button>
+          <button type="button" class="action-button" id="wrapup-close">Close</button>
+        </div>
+      </div>
+    </aside>
+    <script type="module" src="under-the-sea-scramble.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/1989/under-the-sea-scramble/under-the-sea-scramble.css
+++ b/madia.new/public/secret/1989/under-the-sea-scramble/under-the-sea-scramble.css
@@ -1,0 +1,555 @@
+:root {
+  color-scheme: light;
+}
+
+.undersea-cabinet {
+  background: radial-gradient(circle at 50% 20%, rgba(56, 189, 248, 0.35), rgba(8, 18, 46, 0.95));
+  min-height: 100vh;
+  color: #f0f9ff;
+}
+
+.page-header {
+  background: linear-gradient(135deg, rgba(15, 118, 110, 0.85), rgba(14, 116, 144, 0.7));
+  border-bottom: 4px solid rgba(125, 211, 252, 0.6);
+  box-shadow: 0 12px 32px rgba(6, 182, 212, 0.35);
+}
+
+.page-header .subtitle {
+  max-width: 56rem;
+}
+
+.undersea-layout {
+  display: grid;
+  grid-template-columns: minmax(22rem, 32rem) minmax(28rem, 1fr);
+  gap: 2.5rem;
+}
+
+.briefing {
+  background: linear-gradient(160deg, rgba(14, 165, 233, 0.15), rgba(14, 116, 144, 0.05));
+  border: 2px solid rgba(125, 211, 252, 0.3);
+  border-radius: 24px;
+  padding: 1.75rem;
+  box-shadow: 0 20px 30px rgba(5, 94, 133, 0.25);
+}
+
+.briefing .callouts {
+  margin: 1.5rem 0;
+  padding-left: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.simulator {
+  background: linear-gradient(180deg, rgba(2, 132, 199, 0.5), rgba(8, 47, 73, 0.85));
+  border: 2px solid rgba(125, 211, 252, 0.45);
+  border-radius: 28px;
+  padding: 1.5rem;
+  box-shadow: 0 24px 38px rgba(8, 47, 73, 0.5);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.simulator-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.simulator-controls {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.hud {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 1rem;
+}
+
+.hud-card {
+  background: linear-gradient(145deg, rgba(14, 165, 233, 0.35), rgba(7, 89, 133, 0.55));
+  border: 1px solid rgba(125, 211, 252, 0.4);
+  border-radius: 20px;
+  padding: 1rem;
+  box-shadow: inset 0 0 18px rgba(56, 189, 248, 0.3);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.hud-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(224, 242, 254, 0.75);
+}
+
+.hud-value {
+  font-family: "Press Start 2P", system-ui, sans-serif;
+  font-size: 1rem;
+  line-height: 1.4;
+}
+
+.timer-bar {
+  height: 0.6rem;
+  border-radius: 999px;
+  background: rgba(3, 105, 161, 0.6);
+  overflow: hidden;
+  border: 1px solid rgba(125, 211, 252, 0.45);
+}
+
+.timer-fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, #22d3ee, #38bdf8, #c084fc);
+  transition: width 0.25s ease;
+}
+
+#help-button {
+  width: 100%;
+  min-height: 2.5rem;
+}
+
+#help-button[disabled] {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.parchment {
+  background: radial-gradient(circle at 20% 20%, rgba(254, 243, 199, 0.95), rgba(252, 211, 77, 0.8));
+  color: #2f1b0c;
+  border-radius: 26px;
+  padding: 1.5rem;
+  border: 3px solid rgba(120, 53, 15, 0.35);
+  box-shadow: 0 18px 28px rgba(2, 6, 23, 0.45);
+}
+
+.parchment-note {
+  font-style: italic;
+  margin-bottom: 1rem;
+}
+
+.target-list {
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+  padding: 0;
+}
+
+.target-item {
+  background: rgba(250, 204, 21, 0.16);
+  border: 1px solid rgba(120, 53, 15, 0.35);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+  transition: transform 0.3s ease, background 0.3s ease;
+}
+
+.target-item::before {
+  content: "✶";
+  color: rgba(217, 119, 6, 0.65);
+  font-size: 1.1rem;
+}
+
+.target-item.is-found {
+  background: rgba(34, 197, 94, 0.25);
+  color: #0b3a20;
+  transform: translateX(6px);
+}
+
+.target-item.is-found::before {
+  content: "✨";
+  color: rgba(24, 121, 48, 0.75);
+}
+
+.scene-wrapper {
+  position: relative;
+  border-radius: 28px;
+  overflow: hidden;
+  background: linear-gradient(180deg, rgba(14, 165, 233, 0.35), rgba(8, 47, 73, 0.85));
+  border: 2px solid rgba(125, 211, 252, 0.35);
+  min-height: 28rem;
+}
+
+.ambient-swim {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.fish-layer {
+  position: absolute;
+  width: 120%;
+  height: 40%;
+  background: repeating-linear-gradient(
+    90deg,
+    rgba(125, 211, 252, 0.05) 0%,
+    rgba(125, 211, 252, 0.45) 4%,
+    rgba(14, 165, 233, 0.1) 8%
+  );
+  mix-blend-mode: screen;
+  opacity: 0.45;
+}
+
+.fish-one {
+  top: 10%;
+  animation: swimAcross 18s linear infinite;
+}
+
+.fish-two {
+  bottom: 8%;
+  animation: swimAcross 24s linear infinite reverse;
+}
+
+.seaweed {
+  position: absolute;
+  bottom: -4%;
+  width: 18%;
+  height: 60%;
+  background: radial-gradient(circle at 50% 100%, rgba(45, 212, 191, 0.8), rgba(6, 95, 70, 0));
+  filter: blur(0.5px);
+}
+
+.seaweed-left {
+  left: 2%;
+  animation: sway 6s ease-in-out infinite;
+}
+
+.seaweed-right {
+  right: 4%;
+  animation: sway 7s ease-in-out infinite reverse;
+}
+
+.search-scene {
+  position: relative;
+  z-index: 2;
+  min-height: 28rem;
+  background: linear-gradient(180deg, rgba(14, 116, 144, 0.85), rgba(2, 44, 69, 0.95));
+  border-radius: 26px;
+  overflow: hidden;
+}
+
+.search-scene::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% -10%, rgba(56, 189, 248, 0.35), transparent 55%);
+  z-index: 0;
+}
+
+.search-scene[data-scene="grotto"] {
+  background: linear-gradient(180deg, rgba(14, 165, 233, 0.85), rgba(8, 47, 73, 0.95));
+}
+
+.search-scene[data-scene="reef"] {
+  background: linear-gradient(180deg, rgba(59, 130, 246, 0.85), rgba(14, 69, 102, 0.95));
+}
+
+.search-scene[data-scene="ship"] {
+  background: linear-gradient(180deg, rgba(46, 16, 101, 0.85), rgba(12, 36, 64, 0.95));
+}
+
+.scene-detail {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  opacity: 0.22;
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+.treasure-item,
+.decoy-item {
+  position: absolute;
+  border: none;
+  border-radius: 999px;
+  padding: 0;
+  background: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.treasure-item::after,
+.decoy-item::after {
+  content: attr(data-icon);
+  font-size: clamp(1.6rem, 2.4vw + 1rem, 3.2rem);
+  display: grid;
+  place-items: center;
+  width: 4rem;
+  height: 4rem;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0));
+  box-shadow: 0 8px 18px rgba(15, 118, 110, 0.45);
+}
+
+.treasure-item:hover,
+.treasure-item:focus-visible,
+.decoy-item:hover,
+.decoy-item:focus-visible {
+  transform: scale(1.08);
+  filter: brightness(1.15);
+  outline: none;
+}
+
+.treasure-item.is-found {
+  pointer-events: none;
+  animation: sparkleOut 0.6s ease forwards;
+}
+
+.treasure-item.is-found::after {
+  background: radial-gradient(circle at 50% 50%, rgba(253, 224, 71, 0.95), rgba(253, 224, 71, 0));
+  box-shadow: 0 12px 26px rgba(253, 224, 71, 0.5);
+}
+
+.treasure-highlight {
+  position: absolute;
+  border-radius: 50%;
+  background: rgba(253, 224, 71, 0.18);
+  border: 2px dashed rgba(253, 224, 71, 0.8);
+  pointer-events: none;
+  animation: pulse 1.2s ease-in-out infinite;
+  z-index: 3;
+}
+
+.flounder-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(13, 202, 240, 0.18);
+  backdrop-filter: blur(3px);
+  display: grid;
+  place-items: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+}
+
+.flounder-overlay.is-active {
+  opacity: 1;
+  pointer-events: all;
+}
+
+.flounder {
+  width: clamp(8rem, 20vw, 14rem);
+  aspect-ratio: 1.4 / 1;
+  border-radius: 46% 54% 48% 52% / 52% 42% 58% 48%;
+  background: radial-gradient(circle at 30% 40%, #fde68a, #facc15);
+  box-shadow: inset -12px -18px 0 rgba(234, 179, 8, 0.45);
+  position: relative;
+  animation: flounderSwim 0.8s ease-in-out infinite alternate;
+}
+
+.flounder::before,
+.flounder::after {
+  content: "";
+  position: absolute;
+  background: rgba(14, 165, 233, 0.8);
+}
+
+.flounder::before {
+  width: 40%;
+  height: 16%;
+  top: 12%;
+  left: -18%;
+  border-radius: 40% 60% 60% 40% / 60% 60% 40% 40%;
+  box-shadow: 0 0 12px rgba(6, 182, 212, 0.3);
+}
+
+.flounder::after {
+  width: 36%;
+  height: 32%;
+  bottom: 4%;
+  right: -18%;
+  border-radius: 60% 40% 40% 60% / 60% 60% 40% 40%;
+  box-shadow: 0 0 12px rgba(6, 182, 212, 0.3);
+}
+
+.status-panel {
+  background: rgba(3, 105, 161, 0.65);
+  border-radius: 20px;
+  padding: 1rem 1.25rem;
+  min-height: 3.5rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  box-shadow: inset 0 0 12px rgba(125, 211, 252, 0.35);
+}
+
+.log-panel {
+  background: rgba(15, 118, 110, 0.35);
+  border-radius: 20px;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(45, 212, 191, 0.35);
+  display: grid;
+  gap: 0.75rem;
+  max-height: 14rem;
+  overflow: hidden;
+}
+
+.log-entries {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+  overflow-y: auto;
+  max-height: 10rem;
+}
+
+.log-entry {
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.log-entry[data-tone="success"] {
+  color: #bbf7d0;
+}
+
+.log-entry[data-tone="warning"] {
+  color: #fef08a;
+}
+
+.log-entry[data-tone="danger"] {
+  color: #fecaca;
+}
+
+.wrapup {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 7, 18, 0.78);
+  display: grid;
+  place-items: center;
+  z-index: 10;
+}
+
+.wrapup-card {
+  background: linear-gradient(180deg, rgba(14, 165, 233, 0.75), rgba(8, 47, 73, 0.9));
+  border-radius: 28px;
+  border: 2px solid rgba(125, 211, 252, 0.45);
+  padding: 2rem;
+  width: min(90vw, 34rem);
+  display: grid;
+  gap: 1.25rem;
+  box-shadow: 0 28px 42px rgba(8, 47, 73, 0.6);
+}
+
+.wrapup-score {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.wrapup-treasures ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.wrapup-treasures li {
+  background: rgba(14, 116, 144, 0.45);
+  border-radius: 16px;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  line-height: 1.4;
+}
+
+.wrapup-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.sparkle-trail {
+  position: fixed;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 40%, #fef9c3, rgba(253, 224, 71, 0));
+  pointer-events: none;
+  z-index: 12;
+}
+
+@keyframes swimAcross {
+  0% {
+    transform: translateX(-20%) translateY(0);
+  }
+  100% {
+    transform: translateX(20%) translateY(0);
+  }
+}
+
+@keyframes sway {
+  0% {
+    transform: rotate(-4deg) translateY(0);
+  }
+  50% {
+    transform: rotate(4deg) translateY(6px);
+  }
+  100% {
+    transform: rotate(-4deg) translateY(0);
+  }
+}
+
+@keyframes sparkleOut {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  40% {
+    transform: scale(1.2);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(0.4);
+    opacity: 0;
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.7;
+  }
+  50% {
+    transform: scale(1.08);
+    opacity: 1;
+  }
+}
+
+@keyframes flounderSwim {
+  0% {
+    transform: translateX(-10px) rotate(-2deg);
+  }
+  100% {
+    transform: translateX(10px) rotate(2deg);
+  }
+}
+
+@media (max-width: 1120px) {
+  .undersea-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .simulator {
+    order: -1;
+  }
+}
+
+@media (max-width: 720px) {
+  .hud {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .scene-wrapper {
+    min-height: 22rem;
+  }
+
+  .search-scene {
+    min-height: 22rem;
+  }
+}

--- a/madia.new/public/secret/1989/under-the-sea-scramble/under-the-sea-scramble.js
+++ b/madia.new/public/secret/1989/under-the-sea-scramble/under-the-sea-scramble.js
@@ -1,0 +1,724 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+import { mountParticleField } from "../particles.js";
+import { autoEnhanceFeedback, createLogChannel, createStatusChannel } from "../feedback.js";
+
+const particleField = mountParticleField({
+  effects: {
+    palette: ["#4cc9f0", "#38bdf8", "#c084fc", "#facc15"],
+    ambientDensity: 0.5,
+  },
+});
+
+const scoreConfig = getScoreConfig("under-the-sea-scramble");
+const highScore = initHighScoreBanner({
+  gameId: "under-the-sea-scramble",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
+const sceneNameEl = document.getElementById("scene-name");
+const timerValueEl = document.getElementById("timer-value");
+const timerFillEl = document.getElementById("timer-fill");
+const scoreValueEl = document.getElementById("score-value");
+const helpButton = document.getElementById("help-button");
+const startButton = document.getElementById("start-button");
+const resetButton = document.getElementById("reset-button");
+const searchScene = document.getElementById("search-scene");
+const targetList = document.getElementById("target-list");
+const statusBanner = document.getElementById("status-banner");
+const logList = document.getElementById("log-feed");
+const clearLogButton = document.getElementById("clear-log");
+const flounderOverlay = document.getElementById("flounder-overlay");
+const wrapupScreen = document.getElementById("wrapup-screen");
+const wrapupScore = document.getElementById("wrapup-score");
+const wrapupAccuracy = document.getElementById("wrapup-accuracy");
+const wrapupTreasureList = document.getElementById("wrapup-treasure-list");
+const wrapupClose = document.getElementById("wrapup-close");
+const playAgainButton = document.getElementById("play-again");
+
+autoEnhanceFeedback();
+
+const statusChannel = createStatusChannel(statusBanner);
+const logChannel = createLogChannel(logList, { limit: 32 });
+
+let audioContext = null;
+
+function ensureAudioContext() {
+  if (audioContext) {
+    return audioContext;
+  }
+  try {
+    audioContext = new AudioContext();
+  } catch (error) {
+    console.warn("Unable to initialize audio context", error);
+  }
+  return audioContext;
+}
+
+function playChime() {
+  const ctx = ensureAudioContext();
+  if (!ctx) {
+    return;
+  }
+  const now = ctx.currentTime + 0.01;
+  const oscillator = ctx.createOscillator();
+  oscillator.type = "sine";
+  oscillator.frequency.setValueAtTime(660, now);
+  oscillator.frequency.exponentialRampToValueAtTime(1320, now + 0.25);
+  const gain = ctx.createGain();
+  gain.gain.setValueAtTime(0.0001, now);
+  gain.gain.exponentialRampToValueAtTime(0.35, now + 0.04);
+  gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.45);
+  oscillator.connect(gain).connect(ctx.destination);
+  oscillator.start(now);
+  oscillator.stop(now + 0.5);
+  const bubble = ctx.createOscillator();
+  bubble.type = "triangle";
+  bubble.frequency.setValueAtTime(320, now);
+  bubble.frequency.exponentialRampToValueAtTime(520, now + 0.3);
+  const bubbleGain = ctx.createGain();
+  bubbleGain.gain.setValueAtTime(0.0001, now);
+  bubbleGain.gain.exponentialRampToValueAtTime(0.18, now + 0.05);
+  bubbleGain.gain.exponentialRampToValueAtTime(0.0001, now + 0.35);
+  bubble.connect(bubbleGain).connect(ctx.destination);
+  bubble.start(now);
+  bubble.stop(now + 0.4);
+}
+
+function playPenalty() {
+  const ctx = ensureAudioContext();
+  if (!ctx) {
+    return;
+  }
+  const now = ctx.currentTime + 0.01;
+  const oscillator = ctx.createOscillator();
+  oscillator.type = "sawtooth";
+  oscillator.frequency.setValueAtTime(280, now);
+  oscillator.frequency.linearRampToValueAtTime(180, now + 0.35);
+  const gain = ctx.createGain();
+  gain.gain.setValueAtTime(0.0001, now);
+  gain.gain.exponentialRampToValueAtTime(0.25, now + 0.02);
+  gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.45);
+  oscillator.connect(gain).connect(ctx.destination);
+  oscillator.start(now);
+  oscillator.stop(now + 0.5);
+}
+
+const TREASURES = {
+  dinglehopper: {
+    label: "A dinglehopper",
+    icon: "🍴",
+    scuttleNote: "Prime hair-straightening fork. Humans keep these in their windy cabinets.",
+  },
+  snarfblat: {
+    label: "A snarfblat",
+    icon: "🪈",
+    scuttleNote: "Classic human nose trumpet. They blow bubbles out their ears with it!",
+  },
+  spyglass: {
+    label: "A spyglass",
+    icon: "🔭",
+    scuttleNote: "A human squint-extender. Lets you see someone waving four oceans away.",
+  },
+  compass: {
+    label: "An ornate compass",
+    icon: "🧭",
+    scuttleNote: "Human pocket pizza cutter. Slices their maps into fashionable wedges.",
+  },
+  candelabra: {
+    label: "A tarnished candelabra",
+    icon: "🕯️",
+    scuttleNote: "Guaranteed to toast seaweed evenly. Humans sit around and watch it melt.",
+  },
+  pocketwatch: {
+    label: "A pocket watch",
+    icon: "⌚",
+    scuttleNote: "This marvel tells you when the moon is hungry. Humans love punctual tides.",
+  },
+  musicbox: {
+    label: "A music box",
+    icon: "🎼",
+    scuttleNote: "Wind it up and humans perform their mating chirps. Very advanced courting tech.",
+  },
+  magnifier: {
+    label: "A magnifying lens",
+    icon: "🔍",
+    scuttleNote: "A sun-catching circle. Humans use it to brown tiny pastries.",
+  },
+  silvercup: {
+    label: "A silver goblet",
+    icon: "🍷",
+    scuttleNote: "Perfect for drinking fresh rainlight. They toast clouds with it.",
+  },
+  windupfish: {
+    label: "A wind-up fish toy",
+    icon: "🤖",
+    scuttleNote: "Mechanical cousin! Humans wind it and pretend they know how to swim.",
+  },
+  globe: {
+    label: "A tabletop globe",
+    icon: "🌐",
+    scuttleNote: "Humans shrink their oceans for travel planning. Spin it to choose tonight's dinner current.",
+  },
+  tophat: {
+    label: "A velvet top hat",
+    icon: "🎩",
+    scuttleNote: "A surface-dweller clam shell. They trap air in it to keep their heads afloat at fancy gatherings.",
+  },
+};
+
+const SCENES = [
+  {
+    id: "grotto",
+    name: "Ariel's Grotto",
+    timeLimit: 60,
+    timeBonusMultiplier: 12,
+    intro: "Ariel left her starter collection by the glowing vents. Gather her favorite gadgets before the clams close for curfew.",
+    targets: [
+      {
+        id: "dinglehopper",
+        position: { left: 16, top: 58 },
+        scale: 0.95,
+        rotation: -12,
+        score: 220,
+        hint: "Check the rock ledge near the pearl clams.",
+      },
+      {
+        id: "snarfblat",
+        position: { left: 54, top: 32 },
+        scale: 1.05,
+        rotation: 8,
+        score: 240,
+        hint: "A school of fish is trying to play this as a flute.",
+      },
+      {
+        id: "musicbox",
+        position: { left: 74, top: 66 },
+        scale: 0.92,
+        rotation: 6,
+        score: 250,
+        hint: "Hear that muffled lullaby? It's hiding behind the coral arch.",
+      },
+    ],
+    decoys: [
+      { icon: "🪞", label: "Shell mirror", left: 30, top: 46, scale: 1 },
+      { icon: "🧺", label: "Woven basket", left: 68, top: 18, scale: 0.9 },
+      { icon: "🦀", label: "Chatty crab", left: 40, top: 68, scale: 1.2 },
+    ],
+  },
+  {
+    id: "reef",
+    name: "Coral Bazaar",
+    timeLimit: 48,
+    timeBonusMultiplier: 16,
+    intro: "Vendors flooded the reef with trinkets. Sift through the swirl of shells before the tide flips.",
+    targets: [
+      {
+        id: "pocketwatch",
+        position: { left: 22, top: 26 },
+        scale: 0.8,
+        rotation: 18,
+        score: 280,
+        hint: "A jellyfish is using it as a disco ball.",
+      },
+      {
+        id: "magnifier",
+        position: { left: 58, top: 52 },
+        scale: 1.15,
+        rotation: -10,
+        score: 260,
+        hint: "Check the sandy shelf beside the sea fan spiral.",
+      },
+      {
+        id: "silvercup",
+        position: { left: 76, top: 28 },
+        scale: 1,
+        rotation: 6,
+        score: 290,
+        hint: "It's balancing on drifting kelp near the light beam.",
+      },
+      {
+        id: "spyglass",
+        position: { left: 38, top: 70 },
+        scale: 0.95,
+        rotation: -14,
+        score: 310,
+        hint: "A sea turtle is borrowing it near the anemone stage.",
+      },
+    ],
+    decoys: [
+      { icon: "🐠", label: "Distracting fish", left: 12, top: 60, scale: 1.4 },
+      { icon: "🪸", label: "Coral harp", left: 50, top: 18, scale: 1.1 },
+      { icon: "🥽", label: "Diver goggles", left: 80, top: 64, scale: 0.95 },
+      { icon: "🪙", label: "Doubloon spill", left: 64, top: 82, scale: 0.9 },
+    ],
+  },
+  {
+    id: "ship",
+    name: "Sunken Shipwreck",
+    timeLimit: 40,
+    timeBonusMultiplier: 22,
+    intro: "The brig is jammed with human keepsakes and ghostly currents. Snag the valuables before the lantern fades.",
+    targets: [
+      {
+        id: "compass",
+        position: { left: 18, top: 40 },
+        scale: 0.9,
+        rotation: 14,
+        score: 340,
+        hint: "Wedged between two broken planks near the prow.",
+      },
+      {
+        id: "candelabra",
+        position: { left: 46, top: 22 },
+        scale: 1.1,
+        rotation: -18,
+        score: 320,
+        hint: "Look for a faint glow above the captain's chair.",
+      },
+      {
+        id: "windupfish",
+        position: { left: 60, top: 68 },
+        scale: 1.05,
+        rotation: 10,
+        score: 300,
+        hint: "Mechanical fins are tangled in sailcloth at mid-deck.",
+      },
+      {
+        id: "globe",
+        position: { left: 82, top: 54 },
+        scale: 0.9,
+        rotation: -6,
+        score: 340,
+        hint: "Spin the glass sphere bobbing by the broken porthole.",
+      },
+      {
+        id: "tophat",
+        position: { left: 70, top: 24 },
+        scale: 1,
+        rotation: 2,
+        score: 360,
+        hint: "Look for the velvet brim perched atop a rope coil.",
+      },
+    ],
+    decoys: [
+      { icon: "⚓", label: "Anchor", left: 30, top: 64, scale: 1.2 },
+      { icon: "🪙", label: "Coin stack", left: 52, top: 44, scale: 0.85 },
+      { icon: "🪵", label: "Loose plank", left: 10, top: 22, scale: 1.4 },
+      { icon: "🧜", label: "Figurine", left: 90, top: 32, scale: 0.8 },
+      { icon: "🪤", label: "Crab trap", left: 44, top: 82, scale: 1 },
+    ],
+  },
+];
+
+const state = {
+  active: false,
+  sceneIndex: 0,
+  score: 0,
+  timerId: null,
+  timeLeft: 0,
+  sceneDuration: 0,
+  helpUsedThisScene: false,
+  totalHelpCalls: 0,
+  totalTimeBonus: 0,
+  totalClicks: 0,
+  correctClicks: 0,
+  collected: [],
+  foundInScene: new Set(),
+};
+
+function resetState() {
+  state.active = false;
+  state.sceneIndex = 0;
+  state.score = 0;
+  state.timeLeft = 0;
+  state.sceneDuration = 0;
+  state.helpUsedThisScene = false;
+  state.totalHelpCalls = 0;
+  state.totalTimeBonus = 0;
+  state.totalClicks = 0;
+  state.correctClicks = 0;
+  state.collected = [];
+  state.foundInScene = new Set();
+  window.clearInterval(state.timerId);
+  state.timerId = null;
+}
+
+function stopTimer() {
+  window.clearInterval(state.timerId);
+  state.timerId = null;
+}
+
+function formatTime(seconds) {
+  const safe = Math.max(0, Math.ceil(seconds));
+  const mins = Math.floor(safe / 60);
+  const secs = safe % 60;
+  return `${String(mins).padStart(2, "0")}:${String(secs).padStart(2, "0")}`;
+}
+
+function updateTimerDisplay() {
+  timerValueEl.textContent = formatTime(state.timeLeft);
+  if (state.sceneDuration > 0) {
+    const progress = Math.max(0, Math.min(1, state.timeLeft / state.sceneDuration));
+    timerFillEl.style.width = `${progress * 100}%`;
+  } else {
+    timerFillEl.style.width = "0%";
+  }
+}
+
+function updateScoreDisplay() {
+  scoreValueEl.textContent = state.score.toLocaleString();
+}
+
+function clearSceneElements() {
+  searchScene.innerHTML = "";
+  targetList.innerHTML = "";
+  searchScene.dataset.scene = "";
+  searchScene.dataset.status = "idle";
+}
+
+function createTreasureElement(target, sceneConfig) {
+  const treasureData = TREASURES[target.id];
+  const button = document.createElement("button");
+  button.className = "treasure-item";
+  button.type = "button";
+  button.dataset.icon = treasureData?.icon ?? "❓";
+  button.dataset.id = target.id;
+  button.style.left = `${target.position.left}%`;
+  button.style.top = `${target.position.top}%`;
+  button.style.transform = `translate(-50%, -50%) rotate(${target.rotation ?? 0}deg) scale(${target.scale ?? 1})`;
+  button.setAttribute("aria-label", treasureData?.label ?? target.id);
+  button.addEventListener("click", (event) => {
+    event.stopPropagation();
+    handleTreasureClick(target, sceneConfig, button);
+  });
+  return button;
+}
+
+function createDecoyElement(decoy) {
+  const button = document.createElement("button");
+  button.className = "decoy-item";
+  button.type = "button";
+  button.dataset.icon = decoy.icon;
+  button.setAttribute("aria-label", decoy.label);
+  button.style.left = `${decoy.left}%`;
+  button.style.top = `${decoy.top}%`;
+  button.style.transform = `translate(-50%, -50%) scale(${decoy.scale ?? 1})`;
+  button.addEventListener("click", (event) => {
+    event.stopPropagation();
+    handleDecoyClick(decoy);
+  });
+  return button;
+}
+
+function createTargetListItem(target) {
+  const treasureData = TREASURES[target.id];
+  const item = document.createElement("li");
+  item.className = "target-item";
+  item.dataset.targetId = target.id;
+  item.textContent = treasureData?.label ?? target.id;
+  return item;
+}
+
+function animateTreasureToList(treasureEl, listItem) {
+  const startRect = treasureEl.getBoundingClientRect();
+  const endRect = listItem.getBoundingClientRect();
+  const sparkle = document.createElement("div");
+  sparkle.className = "sparkle-trail";
+  sparkle.style.left = `${startRect.left + startRect.width / 2}px`;
+  sparkle.style.top = `${startRect.top + startRect.height / 2}px`;
+  document.body.appendChild(sparkle);
+  const animation = sparkle.animate(
+    [
+      {
+        transform: "translate(-50%, -50%) scale(0.6)",
+        opacity: 1,
+      },
+      {
+        transform: `translate(${endRect.left + endRect.width / 2 - startRect.left - startRect.width / 2}px, ${
+          endRect.top + endRect.height / 2 - startRect.top - startRect.height / 2
+        }px) scale(1.1)`,
+        opacity: 0,
+      },
+    ],
+    {
+      duration: 620,
+      easing: "cubic-bezier(0.22, 1, 0.36, 1)",
+      fill: "forwards",
+    }
+  );
+  animation.addEventListener("finish", () => {
+    sparkle.remove();
+  });
+}
+
+function handleTreasureClick(target, sceneConfig, button) {
+  if (!state.active || state.foundInScene.has(target.id)) {
+    return;
+  }
+  ensureAudioContext();
+  state.totalClicks += 1;
+  state.correctClicks += 1;
+  state.foundInScene.add(target.id);
+  const treasureData = TREASURES[target.id];
+  state.score += target.score;
+  state.collected.push({ id: target.id, sceneId: sceneConfig.id, score: target.score });
+  updateScoreDisplay();
+  playChime();
+  const listItem = targetList.querySelector(`[data-target-id="${target.id}"]`);
+  if (listItem) {
+    listItem.classList.add("is-found");
+    animateTreasureToList(button, listItem);
+  }
+  button.classList.add("is-found");
+  logChannel.push(`${treasureData?.label ?? target.id} secured · +${target.score} pts`, "success");
+  statusChannel(`${treasureData?.label ?? target.id} added to the trove!`, "success");
+  if (state.foundInScene.size === sceneConfig.targets.length) {
+    completeScene(true);
+  }
+}
+
+function handleDecoyClick(decoy) {
+  if (!state.active) {
+    return;
+  }
+  ensureAudioContext();
+  state.totalClicks += 1;
+  applyPenalty(`${decoy.label} was just clutter.`, 120);
+}
+
+function applyPenalty(message, deduction) {
+  state.score = Math.max(0, state.score - deduction);
+  updateScoreDisplay();
+  playPenalty();
+  flounderOverlay.classList.add("is-active");
+  statusChannel(`Flounder panics! ${message}`, "danger");
+  logChannel.push(`${message} -${deduction} pts`, "danger");
+  window.setTimeout(() => {
+    flounderOverlay.classList.remove("is-active");
+  }, 2000);
+}
+
+function addSceneDetails(sceneConfig) {
+  const detail = document.createElement("div");
+  detail.className = "scene-detail";
+  if (sceneConfig.id === "grotto") {
+    detail.style.backgroundImage = "radial-gradient(circle at 20% 40%, rgba(253, 224, 71, 0.25), transparent 60%)";
+  } else if (sceneConfig.id === "reef") {
+    detail.style.backgroundImage = "radial-gradient(circle at 80% 30%, rgba(190, 242, 100, 0.25), transparent 60%)";
+  } else {
+    detail.style.backgroundImage = "radial-gradient(circle at 40% 60%, rgba(252, 165, 165, 0.25), transparent 60%)";
+  }
+  searchScene.appendChild(detail);
+}
+
+function setupScene(sceneIndex) {
+  const sceneConfig = SCENES[sceneIndex];
+  if (!sceneConfig) {
+    finishDive();
+    return;
+  }
+  clearSceneElements();
+  state.sceneIndex = sceneIndex;
+  state.foundInScene = new Set();
+  state.helpUsedThisScene = false;
+  state.sceneDuration = sceneConfig.timeLimit;
+  state.timeLeft = sceneConfig.timeLimit;
+  state.active = true;
+  searchScene.dataset.scene = sceneConfig.id;
+  searchScene.dataset.status = "active";
+  sceneNameEl.textContent = sceneConfig.name;
+  updateTimerDisplay();
+  helpButton.disabled = false;
+  helpButton.textContent = "Available";
+  addSceneDetails(sceneConfig);
+  sceneConfig.targets.forEach((target) => {
+    const treasureEl = createTreasureElement(target, sceneConfig);
+    searchScene.appendChild(treasureEl);
+    const listItem = createTargetListItem(target);
+    targetList.appendChild(listItem);
+  });
+  sceneConfig.decoys.forEach((decoy) => {
+    const decoyEl = createDecoyElement(decoy);
+    searchScene.appendChild(decoyEl);
+  });
+  statusChannel(sceneConfig.intro, "info");
+  logChannel.push(`Entering ${sceneConfig.name}. ${sceneConfig.targets.length} treasures on the list.`, "info");
+  startTimer();
+}
+
+function startTimer() {
+  stopTimer();
+  updateTimerDisplay();
+  state.timerId = window.setInterval(() => {
+    state.timeLeft -= 1;
+    updateTimerDisplay();
+    if (state.timeLeft <= 0) {
+      stopTimer();
+      completeScene(false);
+    }
+  }, 1000);
+}
+
+function completeScene(success) {
+  stopTimer();
+  state.active = false;
+  helpButton.disabled = true;
+  const sceneConfig = SCENES[state.sceneIndex];
+  if (!sceneConfig) {
+    finishDive();
+    return;
+  }
+  if (success) {
+    const remaining = Math.max(0, state.timeLeft);
+    let timeBonus = 0;
+    if (!state.helpUsedThisScene) {
+      timeBonus = Math.round(remaining * sceneConfig.timeBonusMultiplier);
+      state.score += timeBonus;
+      state.totalTimeBonus += timeBonus;
+      updateScoreDisplay();
+    }
+    const bonusMessage = timeBonus > 0 ? ` +${timeBonus} time bonus!` : state.helpUsedThisScene ? " (Scuttle claimed your time bonus)" : "";
+    statusChannel(`List cleared!${bonusMessage}`, timeBonus > 0 ? "success" : "info");
+    logChannel.push(
+      `Cleared ${sceneConfig.name} with ${Math.ceil(remaining)}s left${
+        timeBonus > 0 ? ` · +${timeBonus} bonus` : state.helpUsedThisScene ? " · No bonus after Scuttle's tip" : ""
+      }`,
+      timeBonus > 0 ? "success" : "warning"
+    );
+    window.setTimeout(() => {
+      setupScene(state.sceneIndex + 1);
+    }, 1400);
+  } else {
+    statusChannel("Time's up! Ariel has to stash what you found.", "danger");
+    logChannel.push(`Time expired in ${sceneConfig.name}.`, "danger");
+    finishDive();
+  }
+}
+
+function finishDive() {
+  stopTimer();
+  state.active = false;
+  helpButton.disabled = true;
+  const totalAccuracy = state.totalClicks > 0 ? Math.round((state.correctClicks / state.totalClicks) * 100) : 0;
+  wrapupScore.textContent = state.score.toLocaleString();
+  wrapupAccuracy.textContent = `Accuracy: ${totalAccuracy}% · Time bonus ${state.totalTimeBonus.toLocaleString()} pts`;
+  wrapupTreasureList.innerHTML = "";
+  if (state.collected.length === 0) {
+    const empty = document.createElement("li");
+    empty.textContent = "Scuttle shrugs—no treasures logged.";
+    wrapupTreasureList.appendChild(empty);
+  } else {
+    state.collected.forEach((entry) => {
+      const treasureData = TREASURES[entry.id];
+      const li = document.createElement("li");
+      li.innerHTML = `<strong>${treasureData?.label ?? entry.id}</strong><br />${
+        treasureData?.scuttleNote ?? "Scuttle can't identify this one."
+      }`;
+      wrapupTreasureList.appendChild(li);
+    });
+  }
+  wrapupScreen.hidden = false;
+  particleField?.burst?.({ intensity: 1.2 });
+  highScore.submit(state.score, {
+    accuracy: totalAccuracy,
+    timeBonus: state.totalTimeBonus,
+    helpCalls: state.totalHelpCalls,
+  });
+}
+
+function closeWrapup() {
+  wrapupScreen.hidden = true;
+}
+
+function handleHelpRequest() {
+  if (!state.active || state.helpUsedThisScene) {
+    return;
+  }
+  const sceneConfig = SCENES[state.sceneIndex];
+  if (!sceneConfig) {
+    return;
+  }
+  const remainingTargets = sceneConfig.targets.filter((target) => !state.foundInScene.has(target.id));
+  if (remainingTargets.length === 0) {
+    statusChannel("List already cleared—save Scuttle for later!", "info");
+    return;
+  }
+  state.helpUsedThisScene = true;
+  state.totalHelpCalls += 1;
+  helpButton.disabled = true;
+  helpButton.textContent = "Used";
+  const target = remainingTargets[Math.floor(Math.random() * remainingTargets.length)];
+  const highlight = document.createElement("div");
+  highlight.className = "treasure-highlight";
+  highlight.style.left = `${target.position.left}%`;
+  highlight.style.top = `${target.position.top}%`;
+  highlight.style.width = "9rem";
+  highlight.style.height = "9rem";
+  searchScene.appendChild(highlight);
+  window.setTimeout(() => {
+    highlight.remove();
+  }, 4000);
+  statusChannel(`Scuttle circles the area: ${target.hint}`, "warning");
+  logChannel.push(`Scuttle hint used: ${target.hint}`, "warning");
+}
+
+function startDive() {
+  closeWrapup();
+  resetState();
+  clearSceneElements();
+  updateScoreDisplay();
+  timerFillEl.style.width = "0%";
+  state.active = true;
+  setupScene(0);
+}
+
+function resetDive() {
+  closeWrapup();
+  resetState();
+  clearSceneElements();
+  updateScoreDisplay();
+  timerFillEl.style.width = "0%";
+  sceneNameEl.textContent = "Grotto Warm-Up";
+  timerValueEl.textContent = "00:00";
+  helpButton.disabled = true;
+  helpButton.textContent = "Unavailable";
+  statusChannel("Reset complete. Ready when you are!", "info");
+}
+
+function wireControls() {
+  startButton.addEventListener("click", () => {
+    startDive();
+  });
+  resetButton.addEventListener("click", () => {
+    resetDive();
+  });
+  helpButton.addEventListener("click", () => {
+    handleHelpRequest();
+  });
+  clearLogButton.addEventListener("click", () => {
+    logList.innerHTML = "";
+  });
+  wrapupClose.addEventListener("click", () => {
+    closeWrapup();
+  });
+  playAgainButton.addEventListener("click", () => {
+    startDive();
+  });
+  searchScene.addEventListener("click", () => {
+    if (!state.active) {
+      return;
+    }
+    state.totalClicks += 1;
+    applyPenalty("That patch held nothing useful.", 90);
+  });
+}
+
+function init() {
+  resetDive();
+  wireControls();
+}
+
+init();


### PR DESCRIPTION
## Summary
- add the Under the Sea Scramble hidden-object cabinet with animated HUD, multi-location rounds, and wrap-up scoring
- register the new game with the arcade catalog and scoreboard configuration
- document the Level 13 addition in the 1989 coverage overview

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68e0373eccc48328a8542614ca28809e