### PR TITLE
Add Wild Thing Wind-Up cabinet to 1989 arcade

### DIFF
--- a/docs/1989/movie-coverage.md
+++ b/docs/1989/movie-coverage.md
@@ -2,6 +2,8 @@
 
 This reference tracks how the 1989 arcade cabinets map to their source films and how far the ladder has progressed up the 1989 domestic box office chart.
 
+Wild Thing Wind-Up now rockets into Level 11 with a Major League-inspired closer duel, pushing the ladder deeper into the top 25 while earlier updates below document the run-up.
+
 River of Slime Escape now shocks Level 27 with Ghostbusters II’s river chase while Three Fugitives continues anchoring Level 32, and the ladder keeps backfilling the remaining Top 50 slots.
 Three Fugitives now anchors Level 32 while Hoverboard Pursuit secures Level 26, covering another Top 10 release as the ladder continues to backfill the remaining hits.
 Rollercoaster of Life now anchors Level 25, pushing the ladder deeper into the top 25 while earlier levels keep filling in the remaining Top 50 slots.
@@ -47,6 +49,7 @@ Three Fugitives now anchors Level 32, covering the next-highest new release stil
 | 29 | The K-Mart Countdown | *Rain Man* | #5 |
 | 28 | Voice Box Swap | *Look Who's Talking* | #6 |
 | 24 | The Diner Debate | *When Harry Met Sally...* | #11 |
+| 11 | Wild Thing Wind-Up | *Major League* | #24 |
 | 29 | Flapjack Flip-Out | *Uncle Buck* | #13 |
 
 Remaining:
@@ -92,7 +95,6 @@ Remaining:
 | **14** | Star Trek V: The Final Frontier | #21 | The Final Barrier | A flying/shooting level piloting the Enterprise through a chaotic and disorienting energy field to reach a mythical planet. |
 | **13** | The Little Mermaid | #22 | Under the Sea Scramble | A hidden object or collection game in a colorful undersea environment, gathering "human gadgets." |
 | **12** | Steel Magnolias | #23 | Truvy's Salon Style | A rapid-fire styling/makeover game where you have to meet multiple clients' specific, complex hairstyle and makeup requests. |
-| **11** | Major League | #24 | Wild Thing Wind-Up | A timing/precision baseball pitching game focusing on a dramatically out-of-control, but fast, fastball. |
 | **10** | See No Evil, Hear No Evil | #25 | The Disorient Express | A cooperative or split-screen minigame where one player uses only visual cues and the other only audio cues to solve a simple puzzle. |
 | **9** | Black Rain | #26 | Osaka Motorcycle Dash | A high-speed chase level through the neon-lit streets of Osaka, avoiding gangs and following a key witness. |
 | **8** | Working Girl | #27 | Merger Madness | A quick-typing or paperwork sorting challenge in a high-rise office environment to prepare for a major business meeting. |

--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -861,6 +861,63 @@ const games = [
       </svg>
     `,
   },
+  // Level 11
+  {
+    id: "wild-thing-wind-up",
+    name: "Wild Thing Wind-Up",
+    description:
+      "Balance searing velocity with pin-point snaps while gambling on the Wild Thing zone to freeze the order.",
+    url: "./wild-thing-wind-up/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Wild Thing Wind-Up preview">
+        <defs>
+          <linearGradient id="wildSky" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(8,15,36,0.95)" />
+            <stop offset="100%" stop-color="rgba(5,10,24,0.88)" />
+          </linearGradient>
+          <linearGradient id="wildMound" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#38bdf8" />
+            <stop offset="100%" stop-color="#f97316" />
+          </linearGradient>
+          <linearGradient id="wildMeter" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(56,189,248,0.85)" />
+            <stop offset="70%" stop-color="rgba(56,189,248,0.35)" />
+            <stop offset="100%" stop-color="rgba(15,23,42,0.85)" />
+          </linearGradient>
+        </defs>
+        <rect x="8" y="8" width="144" height="104" rx="18" fill="url(#wildSky)" stroke="rgba(148,163,184,0.35)" />
+        <g>
+          <rect x="22" y="20" width="116" height="28" rx="12" fill="rgba(15,23,42,0.75)" stroke="rgba(59,130,246,0.45)" />
+          <text x="30" y="38" font-size="10" fill="#38bdf8" font-family="'Share Tech Mono', monospace">WILD THING</text>
+          <text x="134" y="38" font-size="10" fill="#f97316" font-family="'Share Tech Mono', monospace" text-anchor="end">102 MPH</text>
+        </g>
+        <g transform="translate(28 56)">
+          <rect x="0" y="0" width="32" height="48" rx="14" fill="rgba(15,23,42,0.9)" stroke="rgba(148,163,184,0.35)" />
+          <rect x="6" y="6" width="20" height="36" rx="8" fill="rgba(8,12,28,0.92)" stroke="rgba(56,189,248,0.4)" />
+          <rect x="6" y="6" width="20" height="20" rx="8" fill="url(#wildMeter)" />
+          <rect x="6" y="6" width="20" height="8" rx="4" fill="rgba(249,115,22,0.75)" opacity="0.75" />
+          <text x="16" y="44" font-size="8" fill="#f97316" font-family="'Share Tech Mono', monospace" text-anchor="middle">HEAT</text>
+        </g>
+        <g transform="translate(76 50)">
+          <rect x="0" y="0" width="70" height="60" rx="18" fill="rgba(12,18,42,0.9)" stroke="rgba(148,163,184,0.35)" />
+          <rect x="18" y="8" width="34" height="44" rx="10" fill="rgba(15,23,42,0.9)" stroke="rgba(56,189,248,0.55)" />
+          <rect x="24" y="14" width="22" height="32" rx="6" fill="rgba(15,23,42,0.75)" stroke="rgba(148,163,184,0.45)" />
+          <circle cx="35" cy="30" r="9" fill="rgba(249,115,22,0.35)" stroke="rgba(249,115,22,0.65)" />
+          <circle cx="38" cy="26" r="5" fill="#facc15" stroke="rgba(248,250,252,0.55)" />
+          <circle cx="33" cy="36" r="4" fill="#38bdf8" stroke="rgba(248,250,252,0.4)" />
+          <path d="M6 52 L64 16" stroke="rgba(249,115,22,0.6)" stroke-width="3" stroke-linecap="round" stroke-dasharray="6 4" />
+          <path d="M6 18 L64 44" stroke="rgba(56,189,248,0.4)" stroke-width="3" stroke-linecap="round" stroke-dasharray="4 6" />
+          <circle cx="12" cy="18" r="4" fill="#38bdf8" />
+          <circle cx="62" cy="44" r="4" fill="#f97316" />
+        </g>
+        <g>
+          <path d="M56 98 C72 90 90 90 104 98" fill="none" stroke="rgba(56,189,248,0.4)" stroke-width="6" stroke-linecap="round" />
+          <circle cx="80" cy="92" r="8" fill="#f97316" stroke="rgba(248,250,252,0.6)" stroke-width="1.5" />
+          <path d="M80 84 L92 72" stroke="#facc15" stroke-width="3" stroke-linecap="round" />
+        </g>
+      </svg>
+    `,
+  }, // Level 11
   {
     id: "speed-zone",
     name: "Speed Zone",

--- a/madia.new/public/secret/1989/score-config.js
+++ b/madia.new/public/secret/1989/score-config.js
@@ -238,6 +238,20 @@ export const scoreConfigs = {
       return `${value ?? 0} pts · ${comboLabel}${riskyLabel}`;
     },
   },
+  "wild-thing-wind-up": {
+    label: "Strikeouts",
+    empty: "No strikeouts recorded yet.",
+    format: ({ value, meta }) => {
+      const innings = typeof meta?.innings === "string" && meta.innings.trim()
+        ? meta.innings.trim()
+        : String(meta?.innings ?? "0.0");
+      const runs = Number(meta?.runs ?? 0);
+      const wild = Number(meta?.wildThings ?? 0);
+      const runsLabel = runs === 1 ? "1 run" : `${runs} runs`;
+      const wildLabel = wild === 1 ? "1 Wild Thing" : `${wild} Wild Things`;
+      return `${value ?? 0} Ks · ${innings} IP · ${runsLabel} · ${wildLabel}`;
+    },
+  },
   "whispers-garden": {
     label: "Field Completion",
     empty: "No whispers answered yet.",

--- a/madia.new/public/secret/1989/wild-thing-wind-up/index.html
+++ b/madia.new/public/secret/1989/wild-thing-wind-up/index.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Wild Thing Wind-Up</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="wild-thing-wind-up.css" />
+  </head>
+  <body class="secret-annex-snes">
+    <a class="skip-link" href="#main-content">Skip to game</a>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 11 · 1989 Arcade</p>
+      <h1>Wild Thing Wind-Up</h1>
+      <p class="subtitle">
+        Channel the riotous heater, nail the sign, and keep the scoreboard frozen while the crowd roars for chaos.
+      </p>
+    </header>
+    <main id="main-content" class="page-layout">
+      <section class="briefing" aria-labelledby="briefing-title">
+        <h2 id="briefing-title">Scouting Report</h2>
+        <p>
+          You own the ninth, but every batter knows the fearsome reputation of the Wild Thing. The catcher flashes the call,
+          the crowd leans in, and you must master a two-step wind-up: max out the heat without slipping into catastrophe,
+          then lace the pitch through a shrinking window before the sluggers punish your mistake.
+        </p>
+        <ul class="callouts">
+          <li>
+            <strong>Setup:</strong> Tap <span class="key-label">Start Warm-Up</span> to reset the inning and light the control booth.
+            Each inning sharpens the target window and quickens the batter's eye.
+          </li>
+          <li>
+            <strong>Power phase:</strong> Hit <span class="key-label">Start Wind-Up</span> and track the vertical meter.
+            Tap again at the apex for a controlled laser or ride into the red Wild Thing zone for a risky rocket.
+          </li>
+          <li>
+            <strong>Accuracy phase:</strong> The catcher drags the glove across the plate. Snap the release when the sweep crosses
+            the highlighted target. Wild Thing attempts make the sweep jittery and fast—hold your nerve or pay the price.
+          </li>
+          <li>
+            <strong>Risk/Reward:</strong> Wild Thing strikes guarantee a K and massive bonus points, but a miss can sail into the
+            stands, tag the mascot, or launch a souvenir home run. Judge every batter's threat.
+          </li>
+          <li>
+            <strong>Progression:</strong> Three outs close the frame and bump you deeper into the order. Runs allowed empty the
+            bullpen—give up five and you're yanked.
+          </li>
+        </ul>
+        <section class="controls" aria-labelledby="controls-title">
+          <h3 id="controls-title">Controls</h3>
+          <dl>
+            <div>
+              <dt>Start / Reset Game</dt>
+              <dd>Press <span class="key-label">Enter</span> while <strong>Start Warm-Up</strong> is focused.</dd>
+            </div>
+            <div>
+              <dt>Advance Pitch Phases</dt>
+              <dd>
+                Press <span class="key-label">Space</span> or click <strong>Start Wind-Up</strong> / <strong>Snap Release</strong>
+                to lock power, then accuracy.
+              </dd>
+            </div>
+            <div>
+              <dt>Call Time</dt>
+              <dd>Press <span class="key-label">Esc</span> or click <strong>Call Time</strong> to pause between batters.</dd>
+            </div>
+          </dl>
+        </section>
+      </section>
+      <section class="mound-console" aria-labelledby="console-title">
+        <div class="console-header">
+          <h2 id="console-title">Bullpen Telemetry</h2>
+          <div class="console-actions">
+            <button type="button" class="action-button" id="start-button">Start Warm-Up</button>
+            <button type="button" class="action-button" id="pitch-button" disabled>Start Wind-Up</button>
+            <button type="button" class="action-button" id="time-button" disabled>Call Time</button>
+          </div>
+        </div>
+        <div class="scoreboard" role="group" aria-label="Pitching line">
+          <div class="score-chip">
+            <span class="chip-label">Inning</span>
+            <span class="chip-value" id="inning-value">1</span>
+          </div>
+          <div class="score-chip">
+            <span class="chip-label">Strikeouts</span>
+            <span class="chip-value" id="strikeouts-value">0</span>
+          </div>
+          <div class="score-chip">
+            <span class="chip-label">Runs Allowed</span>
+            <span class="chip-value" id="runs-value">0</span>
+          </div>
+          <div class="score-chip">
+            <span class="chip-label">Wild Thing Hits</span>
+            <span class="chip-value" id="wild-success-value">0</span>
+          </div>
+        </div>
+        <div class="count-strip" role="group" aria-label="Count">
+          <div class="count-chip">
+            <span class="chip-label">Balls</span>
+            <span class="chip-value" id="balls-value">0</span>
+          </div>
+          <div class="count-chip">
+            <span class="chip-label">Strikes</span>
+            <span class="chip-value" id="strikes-value">0</span>
+          </div>
+          <div class="count-chip">
+            <span class="chip-label">Outs</span>
+            <span class="chip-value" id="outs-value">0</span>
+          </div>
+        </div>
+        <div class="meter-grid">
+          <section class="power-module" aria-labelledby="power-title">
+            <header class="module-header">
+              <h3 id="power-title">Power Meter</h3>
+              <p class="module-note">Ride the surge. Red is the Wild Thing zone.</p>
+            </header>
+            <div
+              class="power-track"
+              role="progressbar"
+              aria-valuemin="0"
+              aria-valuemax="115"
+              aria-valuenow="0"
+              aria-label="Pitch power"
+              id="power-track"
+            >
+              <div class="power-fill" id="power-fill"></div>
+              <span class="wild-band" aria-hidden="true"></span>
+            </div>
+            <p class="power-readout">
+              Power: <span id="power-readout">0%</span>
+              <span class="power-state" id="power-state">Idle</span>
+            </p>
+          </section>
+          <section class="accuracy-module" aria-labelledby="accuracy-title">
+            <header class="module-header">
+              <h3 id="accuracy-title">Accuracy Window</h3>
+              <p class="module-note">Stick the glove. Wild Thing attempts jitter like crazy.</p>
+            </header>
+            <div class="plate-lane" id="plate-lane" aria-hidden="true">
+              <div class="target-call" id="catcher-call">Target: Middle</div>
+              <div class="strike-zone" id="strike-zone">
+                <div class="target-marker" id="target-marker"></div>
+                <div class="accuracy-sweep" id="accuracy-sweep"></div>
+              </div>
+              <div class="ball-flight" id="ball-flight" aria-hidden="true"></div>
+            </div>
+          </section>
+        </div>
+        <p class="status-readout" id="status-bar">Tap Start Warm-Up to take the mound.</p>
+        <section class="log-panel" aria-labelledby="log-title">
+          <h3 id="log-title">Pitch Log</h3>
+          <ul id="event-log" aria-live="polite"></ul>
+        </section>
+      </section>
+    </main>
+    <footer class="page-footer">
+      <p>
+        Pace yourself through the opening batter, then start layering Wild Thing gambles when the crowd needs a jolt.
+        A single miss can erase an entire inning of brilliance.
+      </p>
+    </footer>
+    <section class="wrap-up" id="wrap-up" hidden aria-labelledby="wrap-up-title" role="dialog" aria-modal="true">
+      <div class="wrap-up-card">
+        <h2 id="wrap-up-title">Box Score Summary</h2>
+        <p class="wrap-up-highlight">
+          Strikeouts: <span id="wrap-up-strikeouts">0</span>
+        </p>
+        <dl class="wrap-up-stats">
+          <div>
+            <dt>Innings Pitched</dt>
+            <dd id="wrap-up-innings">0.0</dd>
+          </div>
+          <div>
+            <dt>Runs Allowed</dt>
+            <dd id="wrap-up-runs">0</dd>
+          </div>
+          <div>
+            <dt>Wild Thing Specials</dt>
+            <dd id="wrap-up-wild">0</dd>
+          </div>
+        </dl>
+        <p class="wrap-up-note" id="wrap-up-note">Punch out the order again to push your high score even higher.</p>
+        <div class="wrap-up-actions">
+          <button type="button" class="action-button" id="wrap-up-replay">Run It Back</button>
+          <button type="button" class="action-button" id="wrap-up-close">Close</button>
+        </div>
+      </div>
+    </section>
+    <script type="module" src="wild-thing-wind-up.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/1989/wild-thing-wind-up/wild-thing-wind-up.css
+++ b/madia.new/public/secret/1989/wild-thing-wind-up/wild-thing-wind-up.css
@@ -1,0 +1,457 @@
+:root {
+  --wild-red: #f97316;
+  --wild-gold: #facc15;
+  --wild-blue: #38bdf8;
+  --wild-violet: #a855f7;
+  --panel-bg: rgba(12, 18, 42, 0.86);
+  --panel-border: rgba(148, 163, 184, 0.45);
+  --panel-highlight: rgba(56, 189, 248, 0.6);
+  --plate-outline: rgba(148, 163, 184, 0.4);
+  --plate-grid: rgba(148, 163, 184, 0.18);
+  --plate-glow: rgba(59, 130, 246, 0.38);
+  --log-bg: rgba(15, 23, 42, 0.78);
+}
+
+.page-layout {
+  align-items: flex-start;
+}
+
+.briefing {
+  max-width: 28rem;
+}
+
+.mound-console {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 1rem 2.5rem rgba(6, 11, 25, 0.6);
+}
+
+.console-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.console-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.scoreboard,
+.count-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+  gap: 0.75rem;
+}
+
+.score-chip,
+.count-chip {
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.75));
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  box-shadow: inset 0 0 0.75rem rgba(8, 12, 28, 0.7), 0 0.6rem 1.2rem rgba(6, 10, 22, 0.55);
+}
+
+.score-chip .chip-label,
+.count-chip .chip-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.score-chip .chip-value,
+.count-chip .chip-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.meter-grid {
+  display: grid;
+  grid-template-columns: minmax(12rem, 1fr) minmax(16rem, 1.2fr);
+  gap: 1.5rem;
+}
+
+@media (max-width: 960px) {
+  .meter-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.power-module,
+.accuracy-module {
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.75), rgba(8, 12, 28, 0.92));
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  position: relative;
+}
+
+.module-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.module-note {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.72);
+}
+
+.power-track {
+  position: relative;
+  height: 14rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: linear-gradient(180deg, rgba(11, 15, 32, 0.9), rgba(15, 23, 42, 0.45));
+  overflow: hidden;
+}
+
+.power-fill {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 0%;
+  background: linear-gradient(180deg, rgba(56, 189, 248, 0.25), rgba(56, 189, 248, 0.85));
+  transition: height 80ms linear;
+}
+
+.wild-band {
+  position: absolute;
+  inset: 0;
+  top: 18%;
+  background: linear-gradient(180deg, transparent 0%, rgba(249, 115, 22, 0.12) 45%, rgba(249, 115, 22, 0.55) 80%, transparent 100%);
+  pointer-events: none;
+}
+
+.power-readout {
+  font-family: "Share Tech Mono", "Segoe UI", sans-serif;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.power-state {
+  font-weight: 700;
+  color: var(--wild-blue);
+}
+
+.power-state[data-state="wild"] {
+  color: var(--wild-red);
+}
+
+.power-state[data-state="locked"] {
+  color: var(--wild-gold);
+}
+
+.plate-lane {
+  position: relative;
+  background: radial-gradient(circle at 50% 110%, rgba(56, 189, 248, 0.14), rgba(15, 23, 42, 0.9));
+  border-radius: 1.25rem;
+  padding: 1.25rem 1rem 1.75rem;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: inset 0 1.2rem 2rem rgba(6, 10, 22, 0.5);
+}
+
+.plate-lane::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% -20%, rgba(56, 189, 248, 0.2), transparent 60%);
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.plate-lane.is-shake {
+  animation: mound-shake 320ms ease-in-out 0s 1;
+}
+
+@keyframes mound-shake {
+  0%, 100% {
+    transform: translate3d(0, 0, 0);
+  }
+  25% {
+    transform: translate3d(-6px, 2px, 0);
+  }
+  50% {
+    transform: translate3d(8px, -4px, 0);
+  }
+  75% {
+    transform: translate3d(-4px, 3px, 0);
+  }
+}
+
+.target-call {
+  position: absolute;
+  top: 0.6rem;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+  font-family: "Share Tech Mono", "Segoe UI", sans-serif;
+}
+
+.strike-zone {
+  position: relative;
+  margin: 1.5rem auto 0;
+  width: min(18rem, 80%);
+  aspect-ratio: 3 / 4;
+  border-radius: 1rem;
+  border: 2px solid var(--plate-outline);
+  box-shadow: inset 0 0 1.5rem rgba(56, 189, 248, 0.35);
+  background:
+    linear-gradient(90deg, transparent 47%, rgba(59, 130, 246, 0.15) 50%, transparent 53%),
+    linear-gradient(0deg, transparent 47%, rgba(59, 130, 246, 0.15) 50%, transparent 53%),
+    rgba(13, 21, 45, 0.8);
+}
+
+.target-marker {
+  position: absolute;
+  width: 28%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  border: 2px dashed rgba(250, 204, 21, 0.65);
+  box-shadow: 0 0 1rem rgba(250, 204, 21, 0.45);
+  transform: translate(-50%, -50%);
+  top: 50%;
+  left: 50%;
+  transition: top 160ms ease, left 160ms ease, transform 160ms ease;
+}
+
+.accuracy-sweep {
+  position: absolute;
+  width: 16%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  border: 2px solid rgba(56, 189, 248, 0.85);
+  box-shadow: 0 0 1.4rem rgba(56, 189, 248, 0.6);
+  transform: translate(-50%, -50%);
+  top: 50%;
+  left: 50%;
+}
+
+.accuracy-module.is-active .accuracy-sweep {
+  animation: sweep-pulse 0.6s ease-in-out infinite alternate;
+}
+
+@keyframes sweep-pulse {
+  0% {
+    transform: translate(-50%, -50%) scale(0.9);
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1.05);
+  }
+}
+
+.accuracy-module.is-wild .accuracy-sweep {
+  box-shadow: 0 0 2.4rem rgba(249, 115, 22, 0.75);
+  border-color: rgba(249, 115, 22, 0.85);
+}
+
+.ball-flight {
+  position: absolute;
+  left: 50%;
+  bottom: 0.3rem;
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  background: var(--wild-blue);
+  opacity: 0;
+  transform: translate(-50%, 0) scale(0.5);
+}
+
+.ball-flight.is-standard {
+  animation: pitch-standard 420ms ease-out forwards;
+}
+
+.ball-flight.is-wild {
+  background: var(--wild-red);
+  box-shadow: 0 0 1.5rem rgba(249, 115, 22, 0.95);
+  animation: pitch-wild 360ms cubic-bezier(0.2, 0, 0.32, 1.2) forwards;
+}
+
+.ball-flight.is-chaos {
+  background: #f472b6;
+  animation: pitch-chaos 520ms ease-in forwards;
+}
+
+@keyframes pitch-standard {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, 1.5rem) scale(0.6);
+  }
+  100% {
+    opacity: 1;
+    transform: translate(-50%, -10.5rem) scale(0.95);
+  }
+}
+
+@keyframes pitch-wild {
+  0% {
+    opacity: 0.7;
+    transform: translate(-50%, 2rem) scale(0.8);
+    box-shadow: 0 0 0.8rem rgba(249, 115, 22, 0.45);
+  }
+  50% {
+    opacity: 1;
+    transform: translate(-50%, -6rem) scale(1.1);
+    box-shadow: 0 0 2.8rem rgba(249, 115, 22, 0.9);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -13rem) scale(0.4);
+    box-shadow: 0 0 3.6rem rgba(250, 204, 21, 0.85);
+  }
+}
+
+@keyframes pitch-chaos {
+  0% {
+    opacity: 0.8;
+    transform: translate(-50%, 2rem) scale(0.75) rotate(0deg);
+  }
+  60% {
+    transform: translate(-10rem, -7rem) scale(1) rotate(-18deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(12rem, -2rem) scale(0.6) rotate(24deg);
+    opacity: 0;
+  }
+}
+
+.status-readout {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.85rem;
+  padding: 0.85rem 1rem;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.92);
+  font-family: "Share Tech Mono", "Segoe UI", sans-serif;
+}
+
+.log-panel {
+  background: var(--log-bg);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+}
+
+.log-panel ul {
+  max-height: 12rem;
+  overflow-y: auto;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.log-panel li {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.6rem;
+  background: rgba(8, 12, 28, 0.75);
+  color: rgba(226, 232, 240, 0.92);
+  font-size: 0.9rem;
+}
+
+.wrap-up {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  backdrop-filter: blur(6px);
+  background: rgba(6, 10, 22, 0.68);
+  z-index: 30;
+}
+
+.wrap-up-card {
+  width: min(32rem, 92%);
+  background: rgba(12, 18, 42, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.55);
+  border-radius: 1.2rem;
+  padding: 2rem 2.25rem;
+  box-shadow: 0 1.8rem 3.2rem rgba(6, 10, 22, 0.72);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  text-align: center;
+}
+
+.wrap-up-highlight {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--wild-gold);
+}
+
+.wrap-up-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.wrap-up-stats dt {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.wrap-up-stats dd {
+  margin: 0.35rem 0 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.wrap-up-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.wrap-up-note {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+@media (max-width: 720px) {
+  .mound-console {
+    padding: 1.25rem;
+  }
+
+  .scoreboard,
+  .count-strip {
+    grid-template-columns: repeat(auto-fit, minmax(7rem, 1fr));
+  }
+
+  .power-track {
+    height: 12rem;
+  }
+
+  .strike-zone {
+    width: min(16rem, 90%);
+  }
+}

--- a/madia.new/public/secret/1989/wild-thing-wind-up/wild-thing-wind-up.js
+++ b/madia.new/public/secret/1989/wild-thing-wind-up/wild-thing-wind-up.js
@@ -1,0 +1,738 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+import { mountParticleField } from "../particles.js";
+import { autoEnhanceFeedback, createLogChannel, createStatusChannel } from "../feedback.js";
+
+const GAME_ID = "wild-thing-wind-up";
+const RUN_LIMIT = 5;
+const POWER_MAX = 1.15;
+const WILD_THRESHOLD = 1.0;
+const POWER_SPEED = 0.95; // units per second
+const SWEEP_MIN = 0.18;
+const SWEEP_MAX = 0.82;
+
+const particleField = mountParticleField({
+  effects: {
+    palette: ["#f97316", "#38bdf8", "#facc15", "#22d3ee", "#a855f7"],
+    ambientDensity: 0.48,
+  },
+});
+
+const scoreConfig = getScoreConfig(GAME_ID);
+const highScore = initHighScoreBanner({
+  gameId: GAME_ID,
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
+autoEnhanceFeedback({ statusSelectors: ["#status-bar"], logSelectors: ["#event-log"] });
+
+const startButton = document.getElementById("start-button");
+const pitchButton = document.getElementById("pitch-button");
+const timeButton = document.getElementById("time-button");
+
+const inningValue = document.getElementById("inning-value");
+const strikeoutsValue = document.getElementById("strikeouts-value");
+const runsValue = document.getElementById("runs-value");
+const wildSuccessValue = document.getElementById("wild-success-value");
+const ballsValue = document.getElementById("balls-value");
+const strikesValue = document.getElementById("strikes-value");
+const outsValue = document.getElementById("outs-value");
+
+const powerTrack = document.getElementById("power-track");
+const powerFill = document.getElementById("power-fill");
+const powerReadout = document.getElementById("power-readout");
+const powerState = document.getElementById("power-state");
+
+const plateLane = document.getElementById("plate-lane");
+const catcherCall = document.getElementById("catcher-call");
+const strikeZone = document.getElementById("strike-zone");
+const targetMarker = document.getElementById("target-marker");
+const accuracySweep = document.getElementById("accuracy-sweep");
+const ballFlight = document.getElementById("ball-flight");
+const accuracyModule = document.querySelector(".accuracy-module");
+
+const statusChannel = createStatusChannel(document.getElementById("status-bar"));
+const logChannel = createLogChannel(document.getElementById("event-log"), { limit: 16 });
+
+const wrapUpRoot = document.getElementById("wrap-up");
+const wrapUpStrikeouts = document.getElementById("wrap-up-strikeouts");
+const wrapUpInnings = document.getElementById("wrap-up-innings");
+const wrapUpRuns = document.getElementById("wrap-up-runs");
+const wrapUpWild = document.getElementById("wrap-up-wild");
+const wrapUpNote = document.getElementById("wrap-up-note");
+const wrapUpReplay = document.getElementById("wrap-up-replay");
+const wrapUpClose = document.getElementById("wrap-up-close");
+
+const TARGET_ZONES = [
+  { label: "High Inside", x: 0.32, y: 0.24 },
+  { label: "High Away", x: 0.68, y: 0.22 },
+  { label: "Middle", x: 0.5, y: 0.5 },
+  { label: "Low In", x: 0.36, y: 0.78 },
+  { label: "Low Away", x: 0.7, y: 0.8 },
+  { label: "Down the Pipe", x: 0.5, y: 0.42 },
+  { label: "Backdoor Drop", x: 0.76, y: 0.46 },
+  { label: "Front Door", x: 0.28, y: 0.55 },
+];
+
+const WILD_FAIL_OUTCOMES = [
+  "The ball rockets into the press box—camera ducks too late!",
+  "Mascot takes one off the foam snout and tumbles backward over the dugout.",
+  "That heater drills the on-deck circle and explodes a pyramid of helmets.",
+  "It caroms off the backstop, showering popcorn on the luxury boxes.",
+  "Line-drive souvenir. Some lucky fan just caught a 105 mph gift.",
+];
+
+const CROWD_ROARS = [
+  "Crowd erupts as the mitt detonates!",
+  "The stadium lights flicker from that sonic boom!",
+  "Every seat is shaking—Wild Thing owns the moment!",
+];
+
+let powerAnimation = null;
+let accuracyAnimation = null;
+
+const state = {
+  active: false,
+  gameOver: false,
+  phase: "idle",
+  inning: 1,
+  completedInnings: 0,
+  outs: 0,
+  balls: 0,
+  strikes: 0,
+  runs: 0,
+  strikeouts: 0,
+  wildSuccesses: 0,
+  powerLevel: 0,
+  powerDirection: 1,
+  lastPowerTimestamp: 0,
+  target: TARGET_ZONES[2],
+  pointerX: 0.5,
+  pointerY: 0.5,
+  pointerDirection: 1,
+  lastAccuracyTimestamp: 0,
+  isWildAttempt: false,
+  powerLocked: 0,
+  difficulty: getDifficulty(1),
+};
+
+setup();
+
+function setup() {
+  updateScoreboard();
+  updateCounts();
+  updatePowerDisplay();
+  setNewTarget();
+  logChannel.push("Tap Start Warm-Up to take the mound.", "info");
+  statusChannel("Tap Start Warm-Up to take the mound.", "info");
+
+  startButton.addEventListener("click", () => {
+    if (state.gameOver) {
+      hideWrapUp();
+    }
+    startGame();
+  });
+
+  pitchButton.addEventListener("click", () => {
+    advancePitchPhase();
+  });
+
+  timeButton.addEventListener("click", () => {
+    callTime();
+  });
+
+  wrapUpReplay.addEventListener("click", () => {
+    hideWrapUp();
+    startGame();
+  });
+
+  wrapUpClose.addEventListener("click", () => {
+    hideWrapUp();
+    statusChannel("Take a breather, then warm up for another shot.", "info");
+  });
+
+  ballFlight.addEventListener("animationend", () => {
+    ballFlight.className = "ball-flight";
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.defaultPrevented) {
+      return;
+    }
+    if (event.key === "Escape") {
+      if (state.active && !state.gameOver) {
+        callTime();
+        event.preventDefault();
+      }
+      return;
+    }
+    if (event.code === "Space") {
+      if (state.active && !state.gameOver) {
+        advancePitchPhase();
+        event.preventDefault();
+      }
+    }
+  });
+}
+
+function startGame() {
+  resetState();
+  state.active = true;
+  state.gameOver = false;
+  startButton.textContent = "Restart Warm-Up";
+  pitchButton.disabled = false;
+  pitchButton.textContent = "Start Wind-Up";
+  pitchButton.setAttribute("aria-label", "Start the wind-up phase");
+  timeButton.disabled = false;
+  logChannel.push("Bullpen door opens. The Wild Thing stalks to the hill.", "info");
+  statusChannel("Wind up to fire the first pitch.", "info");
+}
+
+function resetState() {
+  cancelPowerAnimation();
+  cancelAccuracyAnimation();
+  state.phase = "idle";
+  state.inning = 1;
+  state.completedInnings = 0;
+  state.outs = 0;
+  state.balls = 0;
+  state.strikes = 0;
+  state.runs = 0;
+  state.strikeouts = 0;
+  state.wildSuccesses = 0;
+  state.powerLevel = 0;
+  state.powerDirection = 1;
+  state.lastPowerTimestamp = 0;
+  state.pointerX = 0.5;
+  state.pointerY = 0.5;
+  state.pointerDirection = 1;
+  state.lastAccuracyTimestamp = 0;
+  state.isWildAttempt = false;
+  state.powerLocked = 0;
+  state.difficulty = getDifficulty(1);
+  updateScoreboard();
+  updateCounts();
+  updatePowerDisplay();
+  setNewTarget();
+  hideWrapUp();
+}
+
+function advancePitchPhase() {
+  if (!state.active || state.gameOver) {
+    return;
+  }
+  if (state.phase === "idle") {
+    startPowerPhase();
+    return;
+  }
+  if (state.phase === "power") {
+    lockPowerLevel();
+    return;
+  }
+  if (state.phase === "accuracy") {
+    lockAccuracy();
+  }
+}
+
+function startPowerPhase() {
+  state.phase = "power";
+  state.powerLevel = 0;
+  state.powerDirection = 1;
+  state.lastPowerTimestamp = performance.now();
+  updatePowerDisplay();
+  setPowerState("Building Heat", "charging");
+  pitchButton.textContent = "Lock Power";
+  pitchButton.setAttribute("aria-label", "Lock the power level");
+  logChannel.push("Power meter live. Ride the surge.", "info");
+  statusChannel("Ride the power meter and lock it near the peak.", "info");
+  cancelPowerAnimation();
+  powerAnimation = window.requestAnimationFrame(stepPowerMeter);
+}
+
+function stepPowerMeter(timestamp) {
+  if (state.phase !== "power") {
+    return;
+  }
+  const deltaSeconds = Math.min((timestamp - state.lastPowerTimestamp) / 1000, 0.12);
+  state.lastPowerTimestamp = timestamp;
+  state.powerLevel += state.powerDirection * POWER_SPEED * deltaSeconds;
+  if (state.powerLevel >= POWER_MAX) {
+    state.powerLevel = POWER_MAX;
+    state.powerDirection = -1;
+  } else if (state.powerLevel <= 0) {
+    state.powerLevel = 0;
+    state.powerDirection = 1;
+  }
+  updatePowerDisplay();
+  powerAnimation = window.requestAnimationFrame(stepPowerMeter);
+}
+
+function lockPowerLevel() {
+  if (state.phase !== "power") {
+    return;
+  }
+  cancelPowerAnimation();
+  state.powerLocked = state.powerLevel;
+  state.isWildAttempt = state.powerLocked >= WILD_THRESHOLD;
+  setPowerState(state.isWildAttempt ? "Wild Thing" : "Locked", state.isWildAttempt ? "wild" : "locked");
+  pitchButton.textContent = "Snap Release";
+  pitchButton.setAttribute("aria-label", "Snap the release for accuracy");
+  statusChannel(state.isWildAttempt ? "Wild Thing attempt! The accuracy sweep is about to go berserk." : "Power locked. Track the glove and snap the release.", state.isWildAttempt ? "warning" : "info");
+  startAccuracyPhase();
+}
+
+function startAccuracyPhase() {
+  state.phase = "accuracy";
+  state.pointerX = state.target.x;
+  state.pointerY = state.target.y;
+  state.pointerDirection = Math.random() > 0.5 ? 1 : -1;
+  state.lastAccuracyTimestamp = performance.now();
+  accuracyModule.classList.add("is-active");
+  accuracyModule.classList.toggle("is-wild", state.isWildAttempt);
+  cancelAccuracyAnimation();
+  accuracyAnimation = window.requestAnimationFrame(stepAccuracyMeter);
+}
+
+function stepAccuracyMeter(timestamp) {
+  if (state.phase !== "accuracy") {
+    return;
+  }
+  const deltaSeconds = Math.min((timestamp - state.lastAccuracyTimestamp) / 1000, 0.12);
+  state.lastAccuracyTimestamp = timestamp;
+  const speed = getSweepSpeed();
+  state.pointerX += state.pointerDirection * speed * deltaSeconds;
+  if (state.pointerX <= SWEEP_MIN) {
+    state.pointerX = SWEEP_MIN;
+    state.pointerDirection = 1;
+  } else if (state.pointerX >= SWEEP_MAX) {
+    state.pointerX = SWEEP_MAX;
+    state.pointerDirection = -1;
+  }
+
+  const jitterStrength = state.isWildAttempt
+    ? state.difficulty.jitter * 4
+    : state.difficulty.jitter * 1.5;
+  const jitter = (Math.random() - 0.5) * jitterStrength;
+  state.pointerY = clamp(state.target.y + jitter, 0.2, 0.85);
+
+  positionSweep();
+  accuracyAnimation = window.requestAnimationFrame(stepAccuracyMeter);
+}
+
+function lockAccuracy() {
+  if (state.phase !== "accuracy") {
+    return;
+  }
+  cancelAccuracyAnimation();
+  accuracyModule.classList.remove("is-active");
+  accuracyModule.classList.remove("is-wild");
+  resolvePitch();
+}
+
+function resolvePitch() {
+  state.phase = "idle";
+  const dx = state.pointerX - state.target.x;
+  const dy = state.pointerY - state.target.y;
+  const diff = Math.hypot(dx, dy);
+  const baseTolerance = state.difficulty.window * (state.isWildAttempt ? 0.72 : 1);
+  const perfectCutoff = baseTolerance * 0.45;
+  const chaseCutoff = baseTolerance;
+  const contactCutoff = baseTolerance * (state.isWildAttempt ? 1.18 : 1.42);
+  const chaosCutoff = baseTolerance * (state.isWildAttempt ? 1.72 : 1.95);
+  const velocity = state.powerLocked;
+
+  if (state.isWildAttempt && diff <= perfectCutoff) {
+    triggerBallFlight("wild");
+    particleField.emitBurst(1.45);
+    shakePlate();
+    const result = registerStrike({ forceStrikeout: true, wildBonus: true });
+    logChannel.push("Wild Thing detonates the mitt! Automatic punch-out.", "success");
+    statusChannel(randomChoice(CROWD_ROARS), "success");
+    afterPitch(result);
+    return;
+  }
+
+  if (diff <= perfectCutoff) {
+    triggerBallFlight(state.isWildAttempt ? "wild" : "standard");
+    particleField.emitSparkle(state.isWildAttempt ? 1.1 : 0.8);
+    const message = velocity >= 0.9
+      ? "Heater paints the letters. Batter frozen."
+      : "Painted the black. Ump rings him up.";
+    const result = registerStrike({});
+    logChannel.push(message, "success");
+    statusChannel(`Strike! Count ${state.balls}-${state.strikes}.`, "success");
+    afterPitch(result);
+    return;
+  }
+
+  if (diff <= chaseCutoff) {
+    const aggressive = velocity >= 0.75 || state.isWildAttempt;
+    if (aggressive) {
+      triggerBallFlight(state.isWildAttempt ? "wild" : "standard");
+      particleField.emitSparkle(0.7);
+      const foul = Math.random() < 0.24 && state.strikes >= 2;
+      const result = registerStrike({ foul });
+      if (foul) {
+        logChannel.push("Foul tip keeps the at-bat alive.", "info");
+        statusChannel(`Foul tip. Count ${state.balls}-${state.strikes}.`, "info");
+      } else {
+        logChannel.push("Batter chases the breaker out of the zone.", "success");
+        statusChannel(`Swing and miss! Count ${state.balls}-${state.strikes}.`, "success");
+      }
+      afterPitch(result);
+    } else {
+      triggerBallFlight("standard");
+      const outcome = registerBall({ addRun: false });
+      logChannel.push("Just off the plate. The batter watches it sail by.", "warning");
+      statusChannel(`Ball. Count ${state.balls}-${state.strikes}.`, "warning");
+      afterPitch(outcome);
+    }
+    return;
+  }
+
+  if (diff <= contactCutoff) {
+    const foulChance = state.strikes < 2 ? 0.58 : 0.34;
+    if (Math.random() < foulChance) {
+      triggerBallFlight("standard");
+      const result = registerStrike({ foul: true });
+      logChannel.push("Foul into the third deck netting.", "info");
+      statusChannel(`Foul. Count ${state.balls}-${state.strikes}.`, "info");
+      afterPitch(result);
+      return;
+    }
+    const outChance = Math.max(0.25, 0.55 - state.inning * 0.04 - state.runs * 0.02);
+    if (Math.random() < outChance) {
+      triggerBallFlight("standard");
+      const result = registerContact({ type: "out" });
+      logChannel.push("Weak dribbler to short. Easy toss for the out.", "success");
+      statusChannel(`Out recorded. ${state.outs} ${state.outs === 1 ? "out" : "outs"}.`, "success");
+      afterPitch(result);
+    } else {
+      triggerBallFlight("standard");
+      const result = registerContact({ type: "run" });
+      logChannel.push("Shot through the gap! Run crosses the plate.", "danger");
+      statusChannel(`Run scores. Total runs ${state.runs}.`, "danger");
+      afterPitch(result);
+    }
+    return;
+  }
+
+  if (diff <= chaosCutoff) {
+    triggerBallFlight("standard");
+    if (velocity <= 0.5) {
+      const outcome = registerBall({ addRun: false });
+      logChannel.push("Off-speed tumbles out of the zone.", "warning");
+      statusChannel(`Ball. Count ${state.balls}-${state.strikes}.`, "warning");
+      afterPitch(outcome);
+    } else {
+      const result = registerContact({ type: "run" });
+      logChannel.push("Batter ropes it down the line. RBI single.", "danger");
+      statusChannel(`Run scores. Total runs ${state.runs}.`, "danger");
+      triggerBallFlight("chaos");
+      shakePlate();
+      afterPitch(result);
+    }
+    return;
+  }
+
+  triggerBallFlight("chaos");
+  shakePlate();
+  const chaosOutcome = state.isWildAttempt ? randomChoice(WILD_FAIL_OUTCOMES) : "That one drills the batter—he takes his base.";
+  const result = registerBall({ addRun: true });
+  logChannel.push(state.isWildAttempt ? chaosOutcome : "Plunked him. The dugout is jawing.", "danger");
+  statusChannel(`Wild miss. Run scores. Total runs ${state.runs}.`, "danger");
+  afterPitch(result);
+}
+
+function afterPitch(result) {
+  updatePowerDisplay();
+  if (!state.gameOver) {
+    setPowerState("Idle", "idle");
+    pitchButton.textContent = "Start Wind-Up";
+    pitchButton.setAttribute("aria-label", "Start the next wind-up");
+    setNewTarget();
+  }
+  if (result === "game-over") {
+    concludeGame();
+  }
+}
+
+function registerStrike({ foul = false, forceStrikeout = false, wildBonus = false }) {
+  if (forceStrikeout) {
+    state.strikeouts += 1;
+    state.outs += 1;
+    state.balls = 0;
+    state.strikes = 0;
+    if (wildBonus) {
+      state.wildSuccesses += 1;
+    }
+    updateCounts();
+    updateScoreboard();
+    const inningResult = checkInningProgress();
+    return inningResult;
+  }
+
+  if (foul) {
+    if (state.strikes < 2) {
+      state.strikes += 1;
+    }
+    updateCounts();
+    return "foul";
+  }
+
+  state.strikes += 1;
+  if (state.strikes >= 3) {
+    state.strikes = 0;
+    state.balls = 0;
+    state.strikeouts += 1;
+    state.outs += 1;
+    if (wildBonus) {
+      state.wildSuccesses += 1;
+    }
+    updateCounts();
+    updateScoreboard();
+    const inningResult = checkInningProgress();
+    return inningResult;
+  }
+  if (wildBonus) {
+    state.wildSuccesses += 1;
+    updateScoreboard();
+  }
+  updateCounts();
+  return "strike";
+}
+
+function registerBall({ addRun }) {
+  if (addRun) {
+    state.runs += 1;
+    state.balls = 0;
+    state.strikes = 0;
+    updateCounts();
+    updateScoreboard();
+    if (state.runs >= RUN_LIMIT) {
+      state.gameOver = true;
+      return "game-over";
+    }
+    return "run";
+  }
+  state.balls += 1;
+  if (state.balls >= 4) {
+    state.runs += 1;
+    state.balls = 0;
+    state.strikes = 0;
+    updateCounts();
+    updateScoreboard();
+    if (state.runs >= RUN_LIMIT) {
+      state.gameOver = true;
+      return "game-over";
+    }
+    return "walk";
+  }
+  updateCounts();
+  return "ball";
+}
+
+function registerContact({ type }) {
+  state.balls = 0;
+  state.strikes = 0;
+  if (type === "out") {
+    state.outs += 1;
+    updateCounts();
+    const inningResult = checkInningProgress();
+    return inningResult;
+  }
+  if (type === "run") {
+    state.runs += 1;
+    updateCounts();
+    updateScoreboard();
+    if (state.runs >= RUN_LIMIT) {
+      state.gameOver = true;
+      return "game-over";
+    }
+    return "run";
+  }
+  updateCounts();
+  return "ball";
+}
+
+function checkInningProgress() {
+  if (state.outs >= 3) {
+    state.completedInnings += 1;
+    state.outs = 0;
+    state.balls = 0;
+    state.strikes = 0;
+    state.inning += 1;
+    state.difficulty = getDifficulty(state.inning);
+    updateCounts();
+    updateScoreboard();
+    logChannel.push(`Inning ${state.inning - 1} closed. The lineup sharpens for the next frame.`, "info");
+    statusChannel(`Frame complete. Welcome to inning ${state.inning}. Target window tightens.`, "info");
+    setNewTarget();
+    return "inning";
+  }
+  return "strikeout";
+}
+
+function concludeGame() {
+  state.gameOver = true;
+  state.active = false;
+  pitchButton.disabled = true;
+  timeButton.disabled = true;
+  startButton.textContent = "Start Warm-Up";
+  setPowerState("Idle", "idle");
+  const inningsPitched = formatInningsPitched();
+  wrapUpStrikeouts.textContent = String(state.strikeouts);
+  wrapUpRuns.textContent = String(state.runs);
+  wrapUpWild.textContent = String(state.wildSuccesses);
+  wrapUpInnings.textContent = inningsPitched;
+  const scoreResult = highScore.submit(state.strikeouts, {
+    innings: inningsPitched,
+    runs: state.runs,
+    wildThings: state.wildSuccesses,
+  });
+  if (scoreResult.updated) {
+    wrapUpNote.textContent = "New high score! The scoreboard crew paints your name in neon.";
+  } else if (scoreResult.entry) {
+    wrapUpNote.textContent = `High score still stands at ${scoreConfig.format(scoreResult.entry)}.`;
+  } else {
+    wrapUpNote.textContent = "Punch out the order again to push your high score even higher.";
+  }
+  wrapUpRoot.hidden = false;
+  window.setTimeout(() => {
+    wrapUpReplay.focus();
+  }, 90);
+  statusChannel("Skipper signals for the pen. Game over—check the box score.", "warning");
+}
+
+function hideWrapUp() {
+  wrapUpRoot.hidden = true;
+}
+
+function callTime() {
+  if (!state.active || state.gameOver) {
+    return;
+  }
+  cancelPowerAnimation();
+  cancelAccuracyAnimation();
+  state.phase = "idle";
+  setPowerState("Idle", "idle");
+  pitchButton.textContent = "Start Wind-Up";
+  pitchButton.setAttribute("aria-label", "Start the wind-up phase");
+  statusChannel("Time is called. Reset the sign and breathe.", "info");
+}
+
+function cancelPowerAnimation() {
+  if (powerAnimation !== null) {
+    window.cancelAnimationFrame(powerAnimation);
+    powerAnimation = null;
+  }
+}
+
+function cancelAccuracyAnimation() {
+  if (accuracyAnimation !== null) {
+    window.cancelAnimationFrame(accuracyAnimation);
+    accuracyAnimation = null;
+  }
+}
+
+function updateScoreboard() {
+  inningValue.textContent = String(state.inning);
+  strikeoutsValue.textContent = String(state.strikeouts);
+  runsValue.textContent = String(state.runs);
+  wildSuccessValue.textContent = String(state.wildSuccesses);
+}
+
+function updateCounts() {
+  ballsValue.textContent = String(state.balls);
+  strikesValue.textContent = String(state.strikes);
+  outsValue.textContent = String(state.outs);
+}
+
+function updatePowerDisplay() {
+  const clamped = Math.max(0, Math.min(POWER_MAX, state.powerLevel));
+  const percent = Math.round((clamped / POWER_MAX) * 115);
+  powerFill.style.height = `${(clamped / POWER_MAX) * 100}%`;
+  powerReadout.textContent = `${percent}%`;
+  powerTrack.setAttribute("aria-valuenow", String(Math.round((clamped / POWER_MAX) * 115)));
+  if (state.phase === "idle" && !state.isWildAttempt) {
+    setPowerState("Idle", "idle");
+  } else if (state.phase === "power") {
+    if (clamped >= WILD_THRESHOLD) {
+      setPowerState("Wild Thing", "wild");
+    } else {
+      setPowerState("Building Heat", "charging");
+    }
+  }
+}
+
+function setPowerState(label, stateName) {
+  powerState.textContent = label;
+  powerState.dataset.state = stateName;
+}
+
+function setNewTarget() {
+  state.target = randomChoice(TARGET_ZONES);
+  catcherCall.textContent = `Target: ${state.target.label}`;
+  const size = Math.max(0.14, state.difficulty.window);
+  targetMarker.style.width = `${size * 100}%`;
+  targetMarker.style.height = `${size * 100}%`;
+  targetMarker.style.left = `${state.target.x * 100}%`;
+  targetMarker.style.top = `${state.target.y * 100}%`;
+  const sweepSize = Math.max(0.11, state.difficulty.window * 0.68);
+  accuracySweep.style.width = `${sweepSize * 100}%`;
+  accuracySweep.style.height = `${sweepSize * 100}%`;
+  positionSweep();
+}
+
+function positionSweep() {
+  accuracySweep.style.left = `${state.pointerX * 100}%`;
+  accuracySweep.style.top = `${state.pointerY * 100}%`;
+}
+
+function triggerBallFlight(mode) {
+  ballFlight.className = "ball-flight";
+  if (mode === "wild") {
+    ballFlight.classList.add("is-wild");
+  } else if (mode === "chaos") {
+    ballFlight.classList.add("is-chaos");
+  } else {
+    ballFlight.classList.add("is-standard");
+  }
+}
+
+function shakePlate() {
+  plateLane.classList.add("is-shake");
+  window.setTimeout(() => {
+    plateLane.classList.remove("is-shake");
+  }, 360);
+}
+
+function formatInningsPitched() {
+  const totalOuts = state.completedInnings * 3 + state.outs;
+  const whole = Math.floor(totalOuts / 3);
+  const remainder = totalOuts % 3;
+  return `${whole}.${remainder}`;
+}
+
+function getSweepSpeed() {
+  const base = state.difficulty.sweepSpeed;
+  return state.isWildAttempt ? base * 1.65 : base;
+}
+
+function getDifficulty(inning) {
+  const level = Math.max(1, Math.min(12, inning));
+  const window = Math.max(0.12, 0.28 - (level - 1) * 0.015);
+  const sweepSpeed = 0.65 + (level - 1) * 0.08;
+  const jitter = 0.008 + (level - 1) * 0.0025;
+  return { window, sweepSpeed, jitter };
+}
+
+function randomChoice(list) {
+  return list[Math.floor(Math.random() * list.length)];
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}


### PR DESCRIPTION
## Summary
- build the Wild Thing Wind-Up Level 11 cabinet with two-stage pitching flow, risk/reward logging, and wrap-up recap
- style the cabinet with neon scoreboard chrome, animated wild pitch effects, and responsive layout polish
- register the cabinet in the arcade roster, wire its score banner, and document the new Major League coverage slot

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0375fbc20832891499e58284a4321