### PR TITLE
Add Bat-Signal Scramble autorunner time trial

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -2214,6 +2214,87 @@ const games = [
       </svg>
     `,
   }, // Level 7
+  // Level 15
+  {
+    id: "bat-signal-scramble",
+    name: "The Bat-Signal Scramble",
+    description:
+      "Rip through Gotham's streets then vault the cathedral skyline to reach the Bat-Signal before the clock expires.",
+    url: "./bat-signal-scramble/index.html",
+    thumbnail: `
+      <svg
+        viewBox="0 0 160 120"
+        xmlns="http://www.w3.org/2000/svg"
+        role="img"
+        aria-label="The Bat-Signal Scramble preview"
+      >
+        <defs>
+          <linearGradient id="batBackdrop" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(10,18,36,0.95)" />
+            <stop offset="100%" stop-color="rgba(2,6,18,0.95)" />
+          </linearGradient>
+          <linearGradient id="batRoad" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stop-color="rgba(76,132,255,0.4)" />
+            <stop offset="100%" stop-color="rgba(108,76,255,0.55)" />
+          </linearGradient>
+          <radialGradient id="batSignal" cx="0.75" cy="0.1" r="0.6">
+            <stop offset="0%" stop-color="rgba(240,183,63,0.75)" />
+            <stop offset="100%" stop-color="rgba(240,183,63,0)" />
+          </radialGradient>
+        </defs>
+        <rect x="8" y="10" width="144" height="100" rx="20" fill="rgba(4,7,18,0.95)" stroke="rgba(99,102,241,0.4)" />
+        <rect x="18" y="20" width="124" height="80" rx="16" fill="url(#batBackdrop)" stroke="rgba(99,102,241,0.3)" />
+        <g fill="rgba(24,37,64,0.95)" stroke="rgba(148,163,184,0.35)" stroke-width="1.2">
+          ${Array.from({ length: 5 }, (_, i) => `<rect x="${26 + i * 18}" y="${32 + ((i % 2) * 6)}" width="14" height="48" rx="4" />`).join("")}
+        </g>
+        <path
+          d="M26 78 Q80 58 134 82"
+          fill="none"
+          stroke="rgba(76,132,255,0.4)"
+          stroke-width="6"
+          stroke-linecap="round"
+        />
+        <path
+          d="M26 90 Q80 66 134 92"
+          fill="none"
+          stroke="rgba(15,23,42,0.9)"
+          stroke-width="10"
+          stroke-linecap="round"
+        />
+        <rect x="52" y="70" width="48" height="18" rx="9" fill="rgba(8,12,26,0.95)" stroke="rgba(76,132,255,0.6)" />
+        <rect x="46" y="78" width="60" height="10" rx="5" fill="url(#batRoad)" opacity="0.7" />
+        <g>
+          <rect x="58" y="74" width="22" height="10" rx="4" fill="rgba(15,23,42,0.95)" stroke="rgba(76,132,255,0.6)" />
+          <rect x="82" y="74" width="22" height="10" rx="4" fill="rgba(15,23,42,0.95)" stroke="rgba(76,132,255,0.6)" />
+          <circle cx="64" cy="86" r="4" fill="#4c84ff" stroke="rgba(248,250,252,0.4)" />
+          <circle cx="96" cy="86" r="4" fill="#6c4cff" stroke="rgba(248,250,252,0.4)" />
+        </g>
+        <g>
+          <path
+            d="M90 54 L120 34"
+            stroke="rgba(108,76,255,0.6)"
+            stroke-width="4"
+            stroke-linecap="round"
+          />
+          <circle cx="120" cy="34" r="18" fill="url(#batSignal)" />
+          <path
+            d="M112 28 L128 40"
+            stroke="rgba(240,183,63,0.7)"
+            stroke-width="3"
+            stroke-linecap="round"
+          />
+        </g>
+        <path
+          d="M74 46 Q88 32 108 30"
+          fill="none"
+          stroke="rgba(249,115,22,0.55)"
+          stroke-width="3"
+          stroke-linecap="round"
+        />
+        <circle cx="72" cy="46" r="5" fill="#f0b73f" stroke="rgba(248,250,252,0.6)" />
+      </svg>
+    `,
+  }, // Level 15
   // Level 16
   {
     id: "wind-beneath-my-wings",

--- a/madia.new/public/secret/1989/bat-signal-scramble/bat-signal-scramble.css
+++ b/madia.new/public/secret/1989/bat-signal-scramble/bat-signal-scramble.css
@@ -1,0 +1,583 @@
+:root {
+  --gotham-night: #050914;
+  --gotham-sky: #0b172c;
+  --gotham-accent: #4c84ff;
+  --gotham-amber: #f0b73f;
+  --gotham-violet: #6c4cff;
+  --gotham-danger: #ff4f6d;
+  --hud-panel: rgba(10, 17, 32, 0.85);
+  --hud-border: rgba(116, 152, 208, 0.4);
+  --lane-width: 140px;
+}
+
+.page-header {
+  text-align: center;
+  color: #f8fafc;
+}
+
+.page-header .subtitle {
+  max-width: 48rem;
+  margin: 0.5rem auto 0;
+}
+
+.page-layout {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+}
+
+@media (max-width: 1100px) {
+  .page-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.briefing {
+  background: linear-gradient(135deg, rgba(29, 40, 66, 0.95), rgba(7, 12, 26, 0.92));
+  padding: 2rem;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  box-shadow: 0 22px 34px rgba(5, 9, 20, 0.65);
+}
+
+.briefing h2 {
+  font-size: 1.4rem;
+  margin-bottom: 1rem;
+}
+
+.briefing p,
+.briefing li {
+  line-height: 1.55;
+}
+
+.callouts {
+  display: grid;
+  gap: 1rem;
+  padding-left: 1.4rem;
+}
+
+.controls dl {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.controls dt {
+  font-weight: 700;
+  color: #f0f4ff;
+}
+
+.controls dd {
+  margin: 0.25rem 0 0;
+}
+
+.scramble-console {
+  background: linear-gradient(160deg, rgba(8, 10, 22, 0.95), rgba(2, 5, 14, 0.95));
+  border-radius: 1.5rem;
+  border: 1px solid rgba(76, 123, 196, 0.45);
+  box-shadow: 0 28px 48px rgba(3, 6, 14, 0.72);
+  display: flex;
+  flex-direction: column;
+  padding: 2rem;
+  gap: 1.5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.scramble-console::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 80% 15%, rgba(240, 183, 63, 0.3), transparent 55%),
+    radial-gradient(circle at 10% 80%, rgba(108, 76, 255, 0.28), transparent 50%);
+  pointer-events: none;
+}
+
+.console-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.console-header h2 {
+  font-size: 1.6rem;
+  color: #f8fafc;
+}
+
+.console-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.action-button {
+  background: linear-gradient(135deg, rgba(76, 132, 255, 0.65), rgba(38, 98, 214, 0.9));
+  color: #f8fafc;
+  border: 1px solid rgba(180, 205, 255, 0.4);
+  border-radius: 999px;
+  padding: 0.55rem 1.2rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  transition: transform 120ms ease, box-shadow 120ms ease, background 160ms ease;
+}
+
+.action-button:focus-visible,
+.action-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(76, 132, 255, 0.45);
+  background: linear-gradient(135deg, rgba(108, 76, 255, 0.75), rgba(76, 132, 255, 0.95));
+}
+
+.action-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.hud {
+  display: grid;
+  gap: 1rem;
+  background: var(--hud-panel);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  border: 1px solid var(--hud-border);
+}
+
+.timer {
+  font-size: 2.4rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-align: center;
+  color: var(--gotham-amber);
+  text-shadow: 0 0 16px rgba(240, 183, 63, 0.35);
+}
+
+.phase-tracker {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.phase-chip {
+  background: rgba(17, 30, 52, 0.85);
+  border-radius: 0.9rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(108, 118, 163, 0.45);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: border-color 160ms ease, transform 160ms ease;
+}
+
+.phase-chip[data-active="true"] {
+  border-color: rgba(76, 132, 255, 0.85);
+  transform: translateY(-1px);
+}
+
+.phase-chip[data-complete="true"] {
+  border-color: rgba(240, 183, 63, 0.8);
+}
+
+.phase-label {
+  font-weight: 700;
+  color: #dbeafe;
+}
+
+.phase-time {
+  font-family: "Share Tech Mono", monospace;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.momentum-meter {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 0.9rem;
+  background: rgba(17, 26, 44, 0.85);
+  border: 1px solid rgba(90, 147, 255, 0.35);
+}
+
+.momentum-label {
+  font-weight: 700;
+  color: #e0f2fe;
+}
+
+.momentum-track {
+  position: relative;
+  height: 0.65rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.85);
+  overflow: hidden;
+}
+
+.momentum-fill {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  background: linear-gradient(90deg, rgba(76, 132, 255, 0.9), rgba(108, 76, 255, 0.9));
+  box-shadow: 0 0 12px rgba(108, 76, 255, 0.55);
+  transition: width 180ms ease;
+}
+
+.momentum-value {
+  font-family: "Share Tech Mono", monospace;
+  color: rgba(191, 219, 254, 0.85);
+}
+
+.game-stage {
+  position: relative;
+  border-radius: 1.2rem;
+  border: 1px solid rgba(71, 85, 105, 0.6);
+  background: radial-gradient(circle at 50% 20%, rgba(8, 21, 42, 0.85), rgba(2, 4, 10, 0.95));
+  height: 16rem;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.game-stage::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(20, 29, 48, 0.85), rgba(6, 10, 18, 0.95));
+  mix-blend-mode: lighten;
+  pointer-events: none;
+}
+
+.stage-backdrop {
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+      -12deg,
+      rgba(28, 43, 74, 0.8) 0,
+      rgba(28, 43, 74, 0.8) 140px,
+      rgba(12, 20, 38, 0.95) 140px,
+      rgba(12, 20, 38, 0.95) 280px
+    ),
+    radial-gradient(circle at 50% -40%, rgba(76, 132, 255, 0.25), transparent 55%);
+  filter: blur(1.5px);
+}
+
+.batmobile,
+.batman {
+  position: absolute;
+  bottom: 1.5rem;
+  width: 9rem;
+  height: 3.5rem;
+  border-radius: 1.5rem 1.5rem 0.8rem 0.8rem;
+  transition: transform 220ms ease, opacity 220ms ease;
+}
+
+.batmobile {
+  background: linear-gradient(120deg, #0f172a, #020617);
+  border: 2px solid rgba(76, 132, 255, 0.55);
+  box-shadow: 0 0 18px rgba(76, 132, 255, 0.45);
+  transform: translateX(calc(var(--lane-offset, 0) * 1px)) scale(1);
+}
+
+.batmobile::before,
+.batmobile::after {
+  content: "";
+  position: absolute;
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 50%;
+  bottom: -0.6rem;
+  background: radial-gradient(circle, rgba(76, 132, 255, 0.9), rgba(2, 6, 23, 0.95));
+  box-shadow: 0 0 12px rgba(76, 132, 255, 0.6);
+}
+
+.batmobile::before {
+  left: 0.6rem;
+}
+
+.batmobile::after {
+  right: 0.6rem;
+}
+
+.batman {
+  width: 4.6rem;
+  height: 5.6rem;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.95), rgba(2, 6, 23, 0.98));
+  border: 2px solid rgba(108, 76, 255, 0.55);
+  border-radius: 1.8rem 1.8rem 0.6rem 0.6rem;
+  clip-path: polygon(40% 0%, 60% 0%, 80% 20%, 100% 55%, 80% 100%, 20% 100%, 0% 55%, 20% 20%);
+  opacity: 0;
+  transform: translateY(30px) scale(0.95);
+}
+
+.signal-beam {
+  position: absolute;
+  top: -2rem;
+  right: 10%;
+  width: 12rem;
+  height: 120%;
+  background: radial-gradient(circle at 50% 0%, rgba(240, 183, 63, 0.75), transparent 65%);
+  opacity: 0.4;
+  mix-blend-mode: screen;
+  transform: rotate(-12deg);
+}
+
+.game-stage[data-phase="streets"] .batmobile {
+  opacity: 1;
+}
+
+.game-stage[data-phase="streets"] .batman {
+  opacity: 0;
+}
+
+.game-stage[data-phase="rooftops"] .batmobile {
+  opacity: 0;
+  transform: translateY(40px) scale(0.9);
+}
+
+.game-stage[data-phase="rooftops"] .batman {
+  opacity: 1;
+  transform: translateX(calc(var(--lane-offset, 0) * 0.75px)) scale(1);
+}
+
+.game-stage.is-impact {
+  animation: stage-shake 220ms ease;
+}
+
+@keyframes stage-shake {
+  0% {
+    transform: translateX(-8px);
+  }
+  45% {
+    transform: translateX(6px);
+  }
+  75% {
+    transform: translateX(-4px);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+.game-stage.is-swing .stage-backdrop {
+  filter: blur(4px) saturate(1.2);
+  transition: filter 260ms ease;
+}
+
+.control-bar {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.lane-controls {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.status-bar {
+  background: rgba(12, 21, 40, 0.85);
+  border: 1px solid rgba(91, 132, 210, 0.35);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  min-height: 3rem;
+  display: flex;
+  align-items: center;
+  font-weight: 600;
+  color: #f1f5f9;
+}
+
+.status-bar[data-intent="alert"] {
+  color: var(--gotham-danger);
+}
+
+.event-feed {
+  background: rgba(10, 18, 36, 0.85);
+  border: 1px solid rgba(66, 99, 164, 0.35);
+  border-radius: 1rem;
+  padding: 1rem;
+}
+
+.event-feed h3 {
+  margin-bottom: 0.75rem;
+}
+
+#event-log {
+  display: grid;
+  gap: 0.35rem;
+  max-height: 14rem;
+  overflow: auto;
+  padding: 0;
+  list-style: none;
+}
+
+#event-log li {
+  font-family: "Share Tech Mono", monospace;
+  font-size: 0.9rem;
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid rgba(59, 130, 246, 0.18);
+  color: rgba(219, 234, 254, 0.92);
+}
+
+#event-log li[data-level="success"] {
+  border-color: rgba(34, 197, 94, 0.45);
+  color: rgba(190, 247, 208, 0.92);
+}
+
+#event-log li[data-level="warning"] {
+  border-color: rgba(250, 204, 21, 0.45);
+  color: rgba(254, 240, 138, 0.92);
+}
+
+#event-log li[data-level="danger"] {
+  border-color: rgba(248, 113, 113, 0.45);
+  color: rgba(254, 202, 202, 0.92);
+}
+
+.page-footer {
+  text-align: center;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.wrap-up {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 6, 14, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  backdrop-filter: blur(6px);
+  z-index: 80;
+}
+
+.wrap-up-card {
+  background: linear-gradient(145deg, rgba(9, 14, 28, 0.95), rgba(2, 6, 15, 0.95));
+  border-radius: 1.5rem;
+  border: 1px solid rgba(108, 76, 255, 0.45);
+  padding: 2.5rem;
+  max-width: 38rem;
+  width: min(90vw, 38rem);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.wrap-up-time {
+  font-size: 1.6rem;
+  font-family: "Share Tech Mono", monospace;
+  color: var(--gotham-amber);
+}
+
+.wrap-up-delta {
+  font-size: 1rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.split-list {
+  display: grid;
+  gap: 0.75rem;
+  background: rgba(14, 23, 45, 0.85);
+  border-radius: 1rem;
+  padding: 1rem;
+  border: 1px solid rgba(79, 114, 176, 0.35);
+}
+
+.split-list dt {
+  font-weight: 700;
+  color: #e2e8f0;
+}
+
+.split-list dd {
+  margin: 0.25rem 0 0;
+  font-family: "Share Tech Mono", monospace;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.route-map {
+  background: rgba(9, 16, 33, 0.85);
+  border-radius: 1rem;
+  border: 1px solid rgba(76, 132, 255, 0.3);
+  padding: 1rem;
+  display: grid;
+  gap: 0.5rem;
+  max-height: 14rem;
+  overflow: auto;
+}
+
+.route-map h3 {
+  margin-bottom: 0.75rem;
+}
+
+#route-map {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+#route-map li {
+  border: 1px solid rgba(71, 85, 105, 0.45);
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  font-family: "Share Tech Mono", monospace;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+#route-map li[data-outcome="shortcut-success"] {
+  border-color: rgba(34, 197, 94, 0.6);
+  background: rgba(34, 197, 94, 0.12);
+}
+
+#route-map li[data-outcome="shortcut-fail"] {
+  border-color: rgba(248, 113, 113, 0.6);
+  background: rgba(248, 113, 113, 0.12);
+}
+
+#route-map li[data-outcome="impact"] {
+  border-color: rgba(248, 113, 113, 0.45);
+}
+
+#route-map li[data-outcome="momentum"] {
+  border-color: rgba(14, 165, 233, 0.5);
+  background: rgba(14, 165, 233, 0.12);
+}
+
+.wrap-up-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+@media (max-width: 720px) {
+  .scramble-console {
+    padding: 1.5rem;
+  }
+
+  .console-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .console-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .momentum-meter {
+    grid-template-columns: 1fr;
+  }
+
+  .control-bar {
+    justify-content: center;
+  }
+
+  .wrap-up-card {
+    padding: 2rem;
+  }
+}

--- a/madia.new/public/secret/1989/bat-signal-scramble/bat-signal-scramble.js
+++ b/madia.new/public/secret/1989/bat-signal-scramble/bat-signal-scramble.js
@@ -1,0 +1,827 @@
+import { mountParticleField } from "../particles.js";
+import { initHighScoreBanner, getHighScore } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+import { autoEnhanceFeedback, createLogChannel, createStatusChannel } from "../feedback.js";
+
+const particleField = mountParticleField({
+  density: 0.0002,
+  effects: {
+    palette: ["#4c84ff", "#6c4cff", "#f0b73f", "#1e293b"],
+    ambientDensity: 0.58,
+  },
+});
+
+const scoreConfig = getScoreConfig("bat-signal-scramble");
+const highScore = initHighScoreBanner({
+  gameId: "bat-signal-scramble",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
+const responseTimerEl = document.getElementById("response-timer");
+const momentumFill = document.getElementById("momentum-fill");
+const momentumValue = document.getElementById("momentum-value");
+const momentumMeter = document.getElementById("momentum-meter");
+const momentumButton = document.getElementById("momentum-button");
+const gameStage = document.getElementById("game-stage");
+const batmobile = document.getElementById("batmobile");
+const batman = document.getElementById("batman");
+const statusBar = document.getElementById("status-bar");
+const eventLogList = document.getElementById("event-log");
+const startButton = document.getElementById("start-button");
+const resetButton = document.getElementById("reset-button");
+const shortcutButton = document.getElementById("shortcut-button");
+const gadgetButton = document.getElementById("gadget-button");
+const jumpButton = document.getElementById("jump-button");
+const laneButtons = Array.from(document.querySelectorAll("[data-direction]"));
+const phaseTimeEls = {
+  streets: document.querySelector('[data-phase-time="streets"]'),
+  rooftops: document.querySelector('[data-phase-time="rooftops"]'),
+};
+const phaseChips = {
+  streets: document.querySelector('.phase-chip[data-phase="streets"]'),
+  rooftops: document.querySelector('.phase-chip[data-phase="rooftops"]'),
+};
+
+const wrapUp = document.getElementById("wrap-up");
+const finalTimeEl = document.getElementById("final-time");
+const finalDeltaEl = document.getElementById("final-delta");
+const splitStreetsEl = document.getElementById("split-streets");
+const splitRooftopsEl = document.getElementById("split-rooftops");
+const routeSummaryEl = document.getElementById("route-summary");
+const routeMapList = document.getElementById("route-map");
+const replayButton = document.getElementById("replay-button");
+const closeWrapUpButton = document.getElementById("close-wrap-up");
+
+autoEnhanceFeedback();
+
+const log = createLogChannel(eventLogList, { limit: 20 });
+const setStatus = createStatusChannel(statusBar);
+
+const BOOST_MULTIPLIER = 1.65;
+const RECOVERY_DURATION = 1400;
+const IMPACT_CLASS_TIMEOUT = 320;
+
+const PHASES = [
+  {
+    id: "streets",
+    name: "Narrows Pursuit",
+    intro: "Turbines hot. The Narrows gridlock is already folding toward you.",
+    outro: "Cathedral ramp ahead. Brace for rooftop deployment.",
+    baseSpeed: 0.27,
+    length: 780,
+    laneOffsets: [-140, 0, 140],
+    events: [
+      {
+        id: "streets-convoy",
+        type: "traffic",
+        label: "Armored Convoy",
+        offset: 70,
+        lane: 1,
+        penalty: 2400,
+        perfectWindow: 420,
+        momentum: 16,
+      },
+      {
+        id: "streets-barricade",
+        type: "traffic",
+        label: "Police Barricade",
+        offset: 150,
+        lane: 2,
+        penalty: 2600,
+        perfectWindow: 420,
+        momentum: 18,
+      },
+      {
+        id: "streets-grapple-turn",
+        type: "gadget",
+        label: "Side Grapple Hairpin",
+        offset: 210,
+        window: 1400,
+        skip: 60,
+        momentum: 22,
+      },
+      {
+        id: "streets-shortcut-axis",
+        type: "shortcut",
+        label: "Axis Alley Shortcut",
+        offset: 300,
+        window: 1300,
+        skip: 110,
+        penalty: 3200,
+        risk: "Debris-strewn service lane",
+        momentum: 24,
+      },
+      {
+        id: "streets-tanker",
+        type: "traffic",
+        label: "Chemical Tanker",
+        offset: 410,
+        lane: 0,
+        penalty: 2800,
+        perfectWindow: 360,
+        momentum: 18,
+      },
+      {
+        id: "streets-grapple-snap",
+        type: "gadget",
+        label: "Grapple Turnabout",
+        offset: 520,
+        window: 1300,
+        skip: 70,
+        momentum: 24,
+      },
+      {
+        id: "streets-shortcut-theater",
+        type: "shortcut",
+        label: "Monarch Theater Cut",
+        offset: 600,
+        window: 1200,
+        skip: 140,
+        penalty: 3400,
+        risk: "Collapsed marquee",
+        momentum: 28,
+      },
+      {
+        id: "streets-final-squeeze",
+        type: "traffic",
+        label: "Narrows Squeeze",
+        offset: 710,
+        lane: 1,
+        penalty: 2600,
+        perfectWindow: 380,
+        momentum: 20,
+      },
+    ],
+  },
+  {
+    id: "rooftops",
+    name: "Rooftop Gauntlet",
+    intro: "Grapnel ready. Cathedral spires ahead—mind the searchlights.",
+    outro: "Signal tower in sight. Hit the beam.",
+    baseSpeed: 0.25,
+    length: 660,
+    laneOffsets: [-120, 0, 120],
+    events: [
+      {
+        id: "roof-first-gap",
+        type: "jump",
+        label: "Cathedral Gap",
+        offset: 80,
+        window: 1300,
+        penalty: 3200,
+        momentum: 22,
+      },
+      {
+        id: "roof-spotlight",
+        type: "traffic",
+        label: "Spotlight Sweep",
+        offset: 140,
+        lane: 0,
+        penalty: 2400,
+        perfectWindow: 420,
+        momentum: 16,
+      },
+      {
+        id: "roof-grapple",
+        type: "grapple",
+        label: "Clocktower Grapple",
+        offset: 220,
+        window: 1400,
+        skip: 90,
+        penalty: 3600,
+        momentum: 26,
+      },
+      {
+        id: "roof-shortcut",
+        type: "shortcut",
+        label: "Glass Atrium Drop",
+        offset: 310,
+        window: 1100,
+        skip: 150,
+        penalty: 4200,
+        risk: "Shattering skylight",
+        momentum: 30,
+      },
+      {
+        id: "roof-gargoyle",
+        type: "jump",
+        label: "Gargoyle Leap",
+        offset: 420,
+        window: 1200,
+        penalty: 3000,
+        momentum: 20,
+      },
+      {
+        id: "roof-grapple-final",
+        type: "grapple",
+        label: "Billboard Swing",
+        offset: 520,
+        window: 1200,
+        skip: 110,
+        penalty: 3800,
+        momentum: 28,
+      },
+      {
+        id: "roof-final-gap",
+        type: "jump",
+        label: "Tower Vault",
+        offset: 620,
+        window: 1300,
+        penalty: 3400,
+        momentum: 22,
+      },
+    ],
+  },
+];
+
+const state = {
+  running: false,
+  phaseIndex: 0,
+  phaseProgress: 0,
+  phaseEventIndex: 0,
+  totalTime: 0,
+  lastFrame: 0,
+  lane: 1,
+  momentum: 0,
+  boostTimer: 0,
+  recoveryTimer: 0,
+  pendingPrompt: null,
+  eventLog: [],
+  shortcutsTaken: 0,
+  totalShortcuts: PHASES.reduce((sum, phase) => sum + phase.events.filter((event) => event.type === "shortcut").length, 0),
+  momentumBursts: 0,
+  phaseTimes: {
+    streets: 0,
+    rooftops: 0,
+  },
+};
+
+let animationFrame = null;
+let previousBestSnapshot = getHighScore("bat-signal-scramble");
+
+function formatTime(ms) {
+  const safe = Math.max(0, Math.round(ms));
+  const minutes = Math.floor(safe / 60000);
+  const seconds = Math.floor((safe % 60000) / 1000);
+  const millis = safe % 1000;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}.${String(millis).padStart(3, "0")}`;
+}
+
+function setPhaseState(phaseId, stateValue) {
+  const chip = phaseChips[phaseId];
+  if (!chip) {
+    return;
+  }
+  if (stateValue === "active") {
+    chip.dataset.active = "true";
+    chip.dataset.complete = "false";
+  } else if (stateValue === "complete") {
+    chip.dataset.active = "false";
+    chip.dataset.complete = "true";
+  } else {
+    chip.dataset.active = "false";
+    chip.dataset.complete = "false";
+  }
+}
+
+function updatePhaseTimerDisplay(phaseId, time) {
+  const el = phaseTimeEls[phaseId];
+  if (!el) {
+    return;
+  }
+  el.textContent = formatTime(time);
+}
+
+function clearPhaseTimers() {
+  Object.keys(phaseTimeEls).forEach((key) => {
+    if (phaseTimeEls[key]) {
+      phaseTimeEls[key].textContent = "--:--.---";
+    }
+  });
+}
+
+function clampLane(lane, phase) {
+  const max = phase.laneOffsets.length - 1;
+  return Math.max(0, Math.min(max, lane));
+}
+
+function applyLaneVisual() {
+  const phase = PHASES[state.phaseIndex];
+  const offsets = phase.laneOffsets;
+  const offset = offsets[state.lane] ?? 0;
+  if (phase.id === "streets") {
+    batmobile.style.setProperty("--lane-offset", String(offset));
+  } else {
+    batman.style.setProperty("--lane-offset", String(offset));
+  }
+}
+
+function setLane(nextLane) {
+  const phase = PHASES[state.phaseIndex];
+  const safeLane = clampLane(nextLane, phase);
+  if (safeLane === state.lane) {
+    return;
+  }
+  state.lane = safeLane;
+  state.lastLaneShift = performance.now();
+  applyLaneVisual();
+  log.push(`Lane shift ➜ ${["Left", "Center", "Right"][state.lane] ?? "Path"}`);
+}
+
+function adjustMomentum(amount, reason) {
+  const next = Math.max(0, Math.min(100, state.momentum + amount));
+  state.momentum = next;
+  momentumFill.style.width = `${next}%`;
+  momentumMeter.setAttribute("aria-valuenow", String(Math.round(next)));
+  momentumValue.textContent = `${Math.round(next)}%`;
+  if (amount > 0) {
+    log.push(`${reason} (+${Math.round(amount)} Momentum)`, "success");
+  }
+  if (state.momentum >= 100) {
+    momentumButton.disabled = false;
+    momentumButton.setAttribute("aria-pressed", "true");
+    momentumButton.classList.add("is-ready");
+    setStatus("Momentum charged. Deploy Turbine Dash or Grapnel Launch.", "success");
+  } else {
+    momentumButton.disabled = true;
+    momentumButton.setAttribute("aria-pressed", "false");
+    momentumButton.classList.remove("is-ready");
+  }
+}
+
+function resetMomentum() {
+  state.momentum = 0;
+  momentumFill.style.width = "0%";
+  momentumMeter.setAttribute("aria-valuenow", "0");
+  momentumValue.textContent = "0%";
+  momentumButton.disabled = true;
+  momentumButton.setAttribute("aria-pressed", "false");
+  momentumButton.classList.remove("is-ready");
+}
+
+function queuePrompt(type, event, { window = 1200, onSuccess, onFail, message, intent = "warning" } = {}) {
+  const expiresAt = performance.now() + window;
+  state.pendingPrompt = {
+    type,
+    event,
+    expiresAt,
+    onSuccess,
+    onFail,
+  };
+  const intentTone = intent === "danger" ? "danger" : intent === "success" ? "success" : "warning";
+  setStatus(message ?? "Action required", intentTone);
+  if (type === "shortcut") {
+    shortcutButton.classList.add("is-armed");
+  } else if (type === "gadget" || type === "grapple") {
+    gadgetButton.classList.add("is-armed");
+  } else if (type === "jump") {
+    jumpButton.classList.add("is-armed");
+  }
+}
+
+function clearPrompt() {
+  state.pendingPrompt = null;
+  shortcutButton.classList.remove("is-armed");
+  gadgetButton.classList.remove("is-armed");
+  jumpButton.classList.remove("is-armed");
+}
+
+function registerEventResult(event, outcome, detail) {
+  state.eventLog.push({
+    phaseId: PHASES[state.phaseIndex].id,
+    phaseName: PHASES[state.phaseIndex].name,
+    label: event?.label ?? "", 
+    outcome,
+    detail,
+  });
+}
+
+function triggerImpact(penalty, message) {
+  state.totalTime += penalty;
+  state.recoveryTimer = RECOVERY_DURATION;
+  gameStage.classList.add("is-impact");
+  window.setTimeout(() => {
+    gameStage.classList.remove("is-impact");
+  }, IMPACT_CLASS_TIMEOUT);
+  resetMomentum();
+  setStatus(message, "danger");
+  log.push(`${message} (+${formatTime(penalty)} penalty)`, "danger");
+}
+
+function resolvePrompt(type) {
+  if (!state.pendingPrompt || state.pendingPrompt.type !== type) {
+    return false;
+  }
+  const prompt = state.pendingPrompt;
+  clearPrompt();
+  if (typeof prompt.onSuccess === "function") {
+    prompt.onSuccess();
+  }
+  return true;
+}
+
+function failPrompt(prompt) {
+  clearPrompt();
+  if (typeof prompt?.onFail === "function") {
+    prompt.onFail();
+  }
+}
+
+function handleTraffic(event) {
+  const phase = PHASES[state.phaseIndex];
+  if (state.lane === event.lane) {
+    triggerImpact(event.penalty ?? 2600, `${event.label} collision!`);
+    registerEventResult(event, "impact", "Collision");
+    return;
+  }
+  const lastShiftAgo = performance.now() - (state.lastLaneShift ?? 0);
+  const perfect = Number.isFinite(event.perfectWindow) && lastShiftAgo <= event.perfectWindow;
+  const momentumGain = perfect ? (event.momentum ?? 18) : Math.max(6, (event.momentum ?? 18) * 0.5);
+  adjustMomentum(momentumGain, `${perfect ? "Perfect" : "Clean"} dodge: ${event.label}`);
+  registerEventResult(event, perfect ? "momentum" : "success", perfect ? "Perfect dodge" : "Avoided");
+}
+
+function handleShortcut(event) {
+  queuePrompt("shortcut", event, {
+    window: event.window ?? 1200,
+    message: `${event.label} ready. Hit shortcut to engage (${event.risk ?? "High risk"}).`,
+    onSuccess: () => {
+      state.shortcutsTaken += 1;
+      state.phaseProgress += event.skip ?? 100;
+      adjustMomentum(event.momentum ?? 22, `${event.label} cleared`);
+      registerEventResult(event, "shortcut-success", "Saved route time");
+      log.push(`${event.label} threaded. Route compressed.`, "success");
+      setStatus(`${event.label} secured. Momentum surging.`, "success");
+    },
+    onFail: () => {
+      triggerImpact(event.penalty ?? 3200, `${event.label} collapse!`);
+      registerEventResult(event, "shortcut-fail", "Missed shortcut");
+    },
+  });
+}
+
+function handleGadget(event) {
+  queuePrompt("gadget", event, {
+    window: event.window ?? 1200,
+    message: `${event.label}! Fire grapples now.`,
+    onSuccess: () => {
+      state.phaseProgress += event.skip ?? 60;
+      adjustMomentum(event.momentum ?? 20, `${event.label} executed`);
+      registerEventResult(event, "momentum", "Gadget combo");
+      log.push(`${event.label} executed flawlessly.`, "success");
+      setStatus(`${event.label} locked. Keep the dash alive.`, "success");
+    },
+    onFail: () => {
+      triggerImpact(event.penalty ?? 2800, `${event.label} missed!`);
+      registerEventResult(event, "impact", "Gadget miss");
+    },
+  });
+}
+
+function handleJump(event) {
+  queuePrompt("jump", event, {
+    window: event.window ?? 1100,
+    message: `${event.label}! Vault now.`,
+    onSuccess: () => {
+      adjustMomentum(event.momentum ?? 18, `${event.label} cleared`);
+      registerEventResult(event, "momentum", "Perfect vault");
+      log.push(`${event.label} lands clean.`, "success");
+      gameStage.classList.add("is-swing");
+      window.setTimeout(() => gameStage.classList.remove("is-swing"), 320);
+    },
+    onFail: () => {
+      triggerImpact(event.penalty ?? 3200, `${event.label} fail!`);
+      registerEventResult(event, "impact", "Missed jump");
+    },
+  });
+}
+
+function handleGrapple(event) {
+  queuePrompt("grapple", event, {
+    window: event.window ?? 1200,
+    message: `${event.label}! Grapnel ready.`,
+    onSuccess: () => {
+      state.phaseProgress += event.skip ?? 80;
+      adjustMomentum(event.momentum ?? 24, `${event.label} swing`);
+      registerEventResult(event, "momentum", "Grapnel surge");
+      log.push(`${event.label} sling complete.`, "success");
+      gameStage.classList.add("is-swing");
+      window.setTimeout(() => gameStage.classList.remove("is-swing"), 360);
+    },
+    onFail: () => {
+      triggerImpact(event.penalty ?? 3600, `${event.label} miss!`);
+      registerEventResult(event, "impact", "Missed grapnel");
+    },
+  });
+}
+
+function processPhaseEvents() {
+  const phase = PHASES[state.phaseIndex];
+  while (state.phaseEventIndex < phase.events.length && state.phaseProgress >= phase.events[state.phaseEventIndex].offset) {
+    const event = phase.events[state.phaseEventIndex];
+    state.phaseEventIndex += 1;
+    switch (event.type) {
+      case "traffic":
+        handleTraffic(event);
+        break;
+      case "shortcut":
+        handleShortcut(event);
+        break;
+      case "gadget":
+        handleGadget(event);
+        break;
+      case "jump":
+        handleJump(event);
+        break;
+      case "grapple":
+        handleGrapple(event);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+function activateMomentumSurge() {
+  if (state.momentum < 100) {
+    return;
+  }
+  const phase = PHASES[state.phaseIndex];
+  state.momentumBursts += 1;
+  state.boostTimer = 2400;
+  adjustMomentum(-100, "Momentum spent");
+  momentumButton.disabled = true;
+  momentumButton.setAttribute("aria-pressed", "false");
+  momentumButton.classList.remove("is-ready");
+  if (phase.id === "streets") {
+    log.push("Turbine Dash unleashed!", "success");
+    setStatus("Turbine Dash active—hold the line!", "success");
+    registerEventResult({ label: "Turbine Dash" }, "momentum", "Phase I boost");
+  } else {
+    log.push("Grapnel Launch engaged—slinging forward!", "success");
+    setStatus("Grapnel Launch arcs across the skyline!", "success");
+    registerEventResult({ label: "Grapnel Launch" }, "momentum", "Phase II boost");
+    state.phaseProgress += 110;
+  }
+}
+
+function step(timestamp) {
+  if (!state.running) {
+    return;
+  }
+  if (!state.lastFrame) {
+    state.lastFrame = timestamp;
+  }
+  const delta = Math.min(80, timestamp - state.lastFrame);
+  state.lastFrame = timestamp;
+  state.totalTime += delta;
+  responseTimerEl.textContent = formatTime(state.totalTime);
+
+  if (state.recoveryTimer > 0) {
+    state.recoveryTimer = Math.max(0, state.recoveryTimer - delta);
+  }
+  if (state.boostTimer > 0) {
+    state.boostTimer = Math.max(0, state.boostTimer - delta);
+  }
+
+  const phase = PHASES[state.phaseIndex];
+  const speedMultiplier = (state.recoveryTimer > 0 ? 0.55 : 1) * (state.boostTimer > 0 ? BOOST_MULTIPLIER : 1);
+  state.phaseProgress += delta * phase.baseSpeed * speedMultiplier;
+
+  if (state.pendingPrompt && performance.now() >= state.pendingPrompt.expiresAt) {
+    const expiredPrompt = state.pendingPrompt;
+    clearPrompt();
+    failPrompt(expiredPrompt);
+  }
+
+  processPhaseEvents();
+
+  if (state.phaseProgress >= phase.length) {
+    advancePhase();
+  }
+
+  animationFrame = window.requestAnimationFrame(step);
+}
+
+function advancePhase() {
+  const phase = PHASES[state.phaseIndex];
+  const phaseTime = state.totalTime - (state.phaseIndex === 0 ? 0 : state.phaseTimes.streets);
+  if (phase.id === "streets") {
+    state.phaseTimes.streets = state.totalTime;
+  } else {
+    state.phaseTimes.rooftops = state.totalTime;
+  }
+  updatePhaseTimerDisplay(phase.id, phase.id === "streets" ? state.phaseTimes.streets : state.totalTime - state.phaseTimes.streets);
+  setPhaseState(phase.id, "complete");
+  log.push(`${phase.name} cleared in ${phase.id === "streets" ? formatTime(state.phaseTimes.streets) : formatTime(state.totalTime - state.phaseTimes.streets)}.`, "info");
+
+  if (state.phaseIndex >= PHASES.length - 1) {
+    finishRun();
+    return;
+  }
+  state.phaseIndex += 1;
+  state.phaseProgress = 0;
+  state.phaseEventIndex = 0;
+  clearPrompt();
+  const nextPhase = PHASES[state.phaseIndex];
+  setPhaseState(nextPhase.id, "active");
+  gameStage.dataset.phase = nextPhase.id;
+  setStatus(nextPhase.intro, "info");
+  applyLaneVisual();
+}
+
+function finishRun() {
+  state.running = false;
+  if (animationFrame) {
+    window.cancelAnimationFrame(animationFrame);
+    animationFrame = null;
+  }
+  clearPrompt();
+  const finalTime = state.totalTime;
+  const streetsSplit = state.phaseTimes.streets;
+  const rooftopSplit = finalTime - state.phaseTimes.streets;
+  updatePhaseTimerDisplay("rooftops", rooftopSplit);
+  finalTimeEl.textContent = formatTime(finalTime);
+  splitStreetsEl.textContent = formatTime(streetsSplit);
+  splitRooftopsEl.textContent = formatTime(rooftopSplit);
+
+  const scoreValue = Math.max(0, 1000000 - Math.round(finalTime));
+  const meta = {
+    finalTimeMs: Math.round(finalTime),
+    display: formatTime(finalTime),
+    splits: {
+      streets: formatTime(streetsSplit),
+      rooftops: formatTime(rooftopSplit),
+    },
+    shortcuts: {
+      cleared: state.shortcutsTaken,
+      total: state.totalShortcuts,
+    },
+    momentumBursts: state.momentumBursts,
+    route: state.eventLog,
+  };
+  const result = highScore.submit(scoreValue, meta);
+
+  const bestBefore = previousBestSnapshot?.meta?.finalTimeMs;
+  if (result.updated) {
+    finalDeltaEl.textContent = bestBefore
+      ? `New personal best! −${formatTime(Math.abs(finalTime - bestBefore))}`
+      : "New personal best registered.";
+    previousBestSnapshot = result.entry;
+  } else if (bestBefore) {
+    const diff = finalTime - bestBefore;
+    finalDeltaEl.textContent = `${diff >= 0 ? "+" : "−"}${formatTime(Math.abs(diff))} vs personal best.`;
+  } else {
+    finalDeltaEl.textContent = "Run logged. Beat it to claim the cabinet.";
+  }
+
+  routeSummaryEl.textContent = `Shortcuts: ${state.shortcutsTaken}/${state.totalShortcuts} · Momentum Bursts: ${state.momentumBursts}`;
+  routeMapList.innerHTML = "";
+  state.eventLog.forEach((entry) => {
+    const item = document.createElement("li");
+    item.dataset.outcome = entry.outcome;
+    item.textContent = `[${entry.phaseName}] ${entry.label} — ${entry.detail ?? entry.outcome}`;
+    routeMapList.appendChild(item);
+  });
+
+  wrapUp.hidden = false;
+  setStatus("Scramble complete. Review the route and reset when ready.", "success");
+}
+
+function resetRun({ soft = false } = {}) {
+  state.running = false;
+  if (animationFrame) {
+    window.cancelAnimationFrame(animationFrame);
+    animationFrame = null;
+  }
+  state.phaseIndex = 0;
+  state.phaseProgress = 0;
+  state.phaseEventIndex = 0;
+  state.totalTime = 0;
+  state.lastFrame = 0;
+  state.lane = 1;
+  state.momentum = 0;
+  state.boostTimer = 0;
+  state.recoveryTimer = 0;
+  state.pendingPrompt = null;
+  state.eventLog = [];
+  state.shortcutsTaken = 0;
+  state.momentumBursts = 0;
+  state.phaseTimes = { streets: 0, rooftops: 0 };
+  responseTimerEl.textContent = "00:00.000";
+  clearPhaseTimers();
+  resetMomentum();
+  gameStage.dataset.phase = "streets";
+  applyLaneVisual();
+  setPhaseState("streets", "inactive");
+  setPhaseState("rooftops", "inactive");
+  clearPrompt();
+  log.push("Run reset. Gotham awaits.", "info");
+  if (!soft) {
+    setStatus("Awaiting ignition.", "info");
+  }
+}
+
+function startRun() {
+  if (state.running) {
+    return;
+  }
+  resetRun({ soft: true });
+  state.running = true;
+  previousBestSnapshot = getHighScore("bat-signal-scramble");
+  setPhaseState("streets", "active");
+  setStatus(PHASES[0].intro, "info");
+  log.push("Scramble initiated. Keep it clean.", "info");
+  state.lastFrame = performance.now();
+  animationFrame = window.requestAnimationFrame(step);
+}
+
+function closeWrapUp() {
+  wrapUp.hidden = true;
+}
+
+startButton.addEventListener("click", () => {
+  closeWrapUp();
+  startRun();
+});
+
+resetButton.addEventListener("click", () => {
+  closeWrapUp();
+  resetRun();
+});
+
+replayButton.addEventListener("click", () => {
+  closeWrapUp();
+  startRun();
+});
+
+closeWrapUpButton.addEventListener("click", () => {
+  closeWrapUp();
+});
+
+laneButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    const direction = button.dataset.direction === "left" ? -1 : 1;
+    setLane(state.lane + direction);
+  });
+});
+
+shortcutButton.addEventListener("click", () => {
+  if (!resolvePrompt("shortcut")) {
+    log.push("Shortcut unavailable.", "warning");
+  }
+});
+
+gadgetButton.addEventListener("click", () => {
+  if (!resolvePrompt("gadget") && !resolvePrompt("grapple")) {
+    log.push("No gadget cue active.", "warning");
+  }
+});
+
+jumpButton.addEventListener("click", () => {
+  if (!resolvePrompt("jump")) {
+    log.push("No jump queued.", "warning");
+  }
+});
+
+momentumButton.addEventListener("click", () => {
+  activateMomentumSurge();
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.target && event.target.tagName === "INPUT") {
+    return;
+  }
+  if (event.key === "ArrowLeft") {
+    event.preventDefault();
+    setLane(state.lane - 1);
+  } else if (event.key === "ArrowRight") {
+    event.preventDefault();
+    setLane(state.lane + 1);
+  } else if (event.key === "s" || event.key === "S") {
+    event.preventDefault();
+    resolvePrompt("shortcut");
+  } else if (event.key === "g" || event.key === "G") {
+    event.preventDefault();
+    if (!resolvePrompt("gadget")) {
+      resolvePrompt("grapple");
+    }
+  } else if (event.key === "j" || event.key === "J") {
+    event.preventDefault();
+    resolvePrompt("jump");
+  } else if (event.key === "b" || event.key === "B") {
+    event.preventDefault();
+    activateMomentumSurge();
+  } else if (event.key === "r" || event.key === "R") {
+    event.preventDefault();
+    resetRun();
+  }
+});
+
+resetRun();
+
+window.addEventListener("beforeunload", () => {
+  particleField?.destroy?.();
+});

--- a/madia.new/public/secret/1989/bat-signal-scramble/index.html
+++ b/madia.new/public/secret/1989/bat-signal-scramble/index.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>The Bat-Signal Scramble</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="bat-signal-scramble.css" />
+  </head>
+  <body class="secret-annex-snes">
+    <a class="skip-link" href="#main-content">Skip to game</a>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 15 · 1989 Arcade</p>
+      <h1>The Bat-Signal Scramble</h1>
+      <p class="subtitle">
+        Rocket through Gotham's midnight avenues, vault onto the cathedral skyline, and hit the Bat-Signal before Commissioner
+        Gordon's patience runs out.
+      </p>
+    </header>
+    <main id="main-content" class="page-layout">
+      <section class="briefing" aria-labelledby="briefing-title">
+        <h2 id="briefing-title">Mission Brief</h2>
+        <p>
+          The scramble is a seamless two-part rush. <strong>Phase I</strong> tears through the Narrows in the Batmobile. Traffic
+          choke points, armored barricades, and alleyway shortcuts demand quick lane shifts and gadget discipline. Nail perfect
+          dodges and side-grapple turns to feed the <em>Momentum</em> meter. When it pops, the Turbine Dash slices whole blocks
+          off the route.
+        </p>
+        <p>
+          <strong>Phase II</strong> launches from the cathedral ramparts. Batman free-runs across gargoyle-lined roofs, timing
+          jumps and grapnel swings between spotlight sweeps. Wider gaps hide risky shortcuts that can put you directly on the
+          signal tower—but whiff the release and you'll tumble to the street with a brutal time penalty.
+        </p>
+        <ul class="callouts">
+          <li>
+            <strong>Primary clock:</strong> The response timer is the only score that matters. Collisions and falls tack on
+            instant penalties. Shortcuts and boosts end the run faster.
+          </li>
+          <li>
+            <strong>Risk lanes:</strong> Each phase surfaces dangerous shortcuts. They're highlighted in the HUD when available.
+            Trigger them manually—automatic routing always takes the slower, safer path.
+          </li>
+          <li>
+            <strong>Momentum combos:</strong> Chain a perfect dodge into a gadget turn or grapnel swing to rapidly charge
+            Momentum. Spend a full meter on <span class="ability-label">Turbine Dash</span> (Phase I) or
+            <span class="ability-label">Grapnel Launch</span> (Phase II) to slingshot ahead.
+          </li>
+          <li>
+            <strong>Feedback:</strong> Impacts shake the cabinet, flash the HUD, and pump a metallic crash through the speakers.
+            Grapnel swings blur the skyline to sell the speed.
+          </li>
+        </ul>
+        <section class="controls" aria-labelledby="controls-title">
+          <h3 id="controls-title">Controls</h3>
+          <dl>
+            <div>
+              <dt>Shift lanes / paths</dt>
+              <dd>
+                Press <span class="key-label">←</span> / <span class="key-label">→</span> or use the lane buttons.
+              </dd>
+            </div>
+            <div>
+              <dt>Trigger shortcut</dt>
+              <dd>Press <span class="key-label">S</span> or tap <strong>Risk Shortcut</strong> during the prompt.</dd>
+            </div>
+            <div>
+              <dt>Side Grapple / Grapnel</dt>
+              <dd>
+                Press <span class="key-label">G</span> or use <strong>Gadget</strong> when the cue appears.
+              </dd>
+            </div>
+            <div>
+              <dt>Vault / Jump</dt>
+              <dd>Press <span class="key-label">J</span> or hit <strong>Jump</strong> on rooftop prompts.</dd>
+            </div>
+            <div>
+              <dt>Momentum boost</dt>
+              <dd>Press <span class="key-label">B</span> or select <strong>Momentum Surge</strong> when the meter is full.</dd>
+            </div>
+            <div>
+              <dt>Reset run</dt>
+              <dd>Press <span class="key-label">R</span> or choose <strong>Reset Run</strong>.</dd>
+            </div>
+          </dl>
+        </section>
+      </section>
+      <section class="scramble-console" aria-labelledby="console-title">
+        <div class="console-header">
+          <h2 id="console-title">Gotham City Response Drill</h2>
+          <div class="console-actions">
+            <button type="button" class="action-button" id="start-button">Start Run</button>
+            <button type="button" class="action-button" id="reset-button">Reset Run</button>
+          </div>
+        </div>
+        <div class="hud" role="group" aria-label="Run HUD">
+          <div class="timer" id="response-timer" aria-live="polite">00:00.000</div>
+          <div class="phase-tracker" role="list">
+            <div class="phase-chip" data-phase="streets" role="listitem">
+              <span class="phase-label">Phase I · Streets</span>
+              <span class="phase-time" data-phase-time="streets">--:--.---</span>
+            </div>
+            <div class="phase-chip" data-phase="rooftops" role="listitem">
+              <span class="phase-label">Phase II · Rooftops</span>
+              <span class="phase-time" data-phase-time="rooftops">--:--.---</span>
+            </div>
+          </div>
+          <div class="momentum-meter" role="group" aria-label="Momentum meter">
+            <span class="momentum-label">Momentum</span>
+            <div
+              class="momentum-track"
+              role="progressbar"
+              aria-valuemin="0"
+              aria-valuemax="100"
+              aria-valuenow="0"
+              id="momentum-meter"
+            >
+              <div class="momentum-fill" id="momentum-fill"></div>
+            </div>
+            <span class="momentum-value" id="momentum-value">0%</span>
+            <button type="button" class="action-button" id="momentum-button" aria-pressed="false">Momentum Surge</button>
+          </div>
+        </div>
+        <div class="game-stage" id="game-stage" aria-live="polite">
+          <div class="stage-backdrop" aria-hidden="true"></div>
+          <div class="batmobile" id="batmobile" role="img" aria-label="Batmobile racing toward the Bat-Signal"></div>
+          <div class="batman" id="batman" role="img" aria-label="Batman sprinting across rooftops"></div>
+          <div class="signal-beam" aria-hidden="true"></div>
+        </div>
+        <div class="control-bar" role="group" aria-label="Direct controls">
+          <div class="lane-controls" role="group" aria-label="Lane controls">
+            <button type="button" class="action-button" data-direction="left" aria-label="Shift left">◀</button>
+            <button type="button" class="action-button" data-direction="right" aria-label="Shift right">▶</button>
+          </div>
+          <button type="button" class="action-button" id="shortcut-button">Risk Shortcut</button>
+          <button type="button" class="action-button" id="gadget-button">Gadget</button>
+          <button type="button" class="action-button" id="jump-button">Jump</button>
+        </div>
+        <div class="status-bar" id="status-bar" role="status" aria-live="assertive">Awaiting ignition.</div>
+        <section class="event-feed" aria-labelledby="event-feed-title">
+          <h3 id="event-feed-title">Run Telemetry</h3>
+          <ul id="event-log"></ul>
+        </section>
+      </section>
+    </main>
+    <footer class="page-footer">
+      <p>
+        Tip: Thread the Narrows barricade with a last-second lane shift, hook the side grapple immediately, then trigger Turbine
+        Dash. You'll rocket straight into the cathedral launch pad with Momentum to spare.
+      </p>
+    </footer>
+    <section class="wrap-up" id="wrap-up" role="dialog" aria-modal="true" aria-labelledby="wrap-up-title" hidden>
+      <div class="wrap-up-card">
+        <h2 id="wrap-up-title">Scramble Complete</h2>
+        <p class="wrap-up-time">Final Time: <span id="final-time">00:00.000</span></p>
+        <p class="wrap-up-delta" id="final-delta" aria-live="polite"></p>
+        <dl class="split-list">
+          <div>
+            <dt>Phase I · Streets</dt>
+            <dd id="split-streets">--:--.---</dd>
+          </div>
+          <div>
+            <dt>Phase II · Rooftops</dt>
+            <dd id="split-rooftops">--:--.---</dd>
+          </div>
+        </dl>
+        <section class="route-map" aria-labelledby="route-map-title">
+          <h3 id="route-map-title">Route Debrief</h3>
+          <p id="route-summary"></p>
+          <ul id="route-map"></ul>
+        </section>
+        <div class="wrap-up-actions">
+          <button type="button" class="action-button" id="replay-button">Run It Back</button>
+          <button type="button" class="action-button" id="close-wrap-up">Close</button>
+        </div>
+      </div>
+    </section>
+    <script type="module" src="bat-signal-scramble.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/1989/score-config.js
+++ b/madia.new/public/secret/1989/score-config.js
@@ -11,6 +11,23 @@ export const scoreConfigs = {
     format: ({ value }) =>
       value === 1 ? "1 bill signed" : `${value ?? 0} bills signed`,
   },
+  "bat-signal-scramble": {
+    label: "Response Time",
+    empty: "No responses logged yet.",
+    format: ({ value, meta }) => {
+      if (meta?.display) {
+        return meta.display;
+      }
+      const timeMs = Number.isFinite(meta?.finalTimeMs)
+        ? Number(meta.finalTimeMs)
+        : 1000000 - Number(value ?? 0);
+      const safeTime = Math.max(0, Math.round(timeMs));
+      const minutes = Math.floor(safeTime / 60000);
+      const seconds = Math.floor((safeTime % 60000) / 1000);
+      const millis = safeTime % 1000;
+      return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}.${String(millis).padStart(3, "0")}`;
+    },
+  },
   "cable-clash": {
     label: "Turns to Lock Circuit",
     empty: "No circuits closed yet.",


### PR DESCRIPTION
## Summary
- add the Level 15 "The Bat-Signal Scramble" cabinet with a two-phase Batmobile and rooftop autorunner experience, custom HUD, and session wrap-up analytics
- register the cabinet in the arcade catalog and expose its response-time scoring configuration

## Testing
- Manual verification: `python -m http.server 8000` (loaded the new cabinet in a browser)


------
https://chatgpt.com/codex/tasks/task_e_68e052b958e48328b261d6c4f789acb1