### PR TITLE
feat: add grail trial puzzle cabinet

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -809,6 +809,65 @@ const games = [
       </svg>
     `,
   },
+  // Level 15
+  {
+    id: "grail-trial",
+    name: "The Grail Trial",
+    description:
+      "Step through the Breath, Word, and Path of God: memorize the sacred letters, kneel beneath the blades, and race across the invisible bridge before time erodes your worthiness.",
+    url: "./grail-trial/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="The Grail Trial preview">
+        <defs>
+          <linearGradient id="grailSky" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="rgba(15,23,42,0.95)" />
+            <stop offset="100%" stop-color="rgba(8,11,24,0.92)" />
+          </linearGradient>
+          <linearGradient id="grailGlow" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stop-color="#facc15" />
+            <stop offset="100%" stop-color="#38bdf8" />
+          </linearGradient>
+          <radialGradient id="grailDust" cx="50%" cy="45%" r="60%">
+            <stop offset="0%" stop-color="rgba(248,250,252,0.8)" />
+            <stop offset="100%" stop-color="rgba(248,250,252,0)" />
+          </radialGradient>
+        </defs>
+        <rect x="8" y="10" width="144" height="100" rx="18" fill="url(#grailSky)" stroke="rgba(148,163,184,0.35)" />
+        <g transform="translate(18 24)">
+          <rect x="0" y="0" width="46" height="72" rx="12" fill="rgba(15,23,42,0.8)" stroke="rgba(148,163,184,0.32)" />
+          ${['I','X','Q','M','S','E','T','R','H','L','O','D','N','V','A','G'].map((letter, index) => {
+            const x = (index % 4) * 11 + 6;
+            const y = Math.floor(index / 4) * 16 + 14;
+            const highlight = [0,5,8,10,13,14].includes(index) ? 'rgba(250,204,21,0.35)' : 'rgba(30,41,59,0.65)';
+            const stroke = [0,5,8,10,13,14].includes(index) ? 'rgba(250,204,21,0.6)' : 'rgba(148,163,184,0.2)';
+            return `<rect x="${x - 5}" y="${y - 10}" width="10" height="12" rx="3" fill="${highlight}" stroke="${stroke}" />` +
+              `<text x="${x}" y="${y}" text-anchor="middle" font-size="6" fill="rgba(248,250,252,0.85)" font-family="'Press Start 2P', monospace">${letter}</text>`;
+          }).join('')}
+        </g>
+        <g transform="translate(72 24)">
+          <rect x="0" y="12" width="32" height="48" rx="10" fill="rgba(15,23,42,0.78)" stroke="rgba(148,163,184,0.28)" />
+          <path d="M0 24 L32 24" stroke="rgba(248,250,252,0.18)" stroke-width="2" stroke-dasharray="4 4" />
+          <path d="M4 28 L28 40" stroke="#f97316" stroke-width="4" stroke-linecap="round" />
+          <path d="M4 40 L28 28" stroke="#38bdf8" stroke-width="4" stroke-linecap="round" />
+          <rect x="10" y="46" width="12" height="16" rx="6" fill="rgba(250,204,21,0.65)" stroke="rgba(148,163,184,0.4)" />
+          <rect x="8" y="58" width="16" height="10" rx="4" fill="rgba(59,130,246,0.55)" />
+        </g>
+        <g transform="translate(110 20)">
+          <rect x="0" y="0" width="32" height="80" rx="12" fill="rgba(15,23,42,0.82)" stroke="rgba(148,163,184,0.3)" />
+          <path d="M16 10 L16 70" stroke="rgba(56,189,248,0.4)" stroke-width="2" stroke-dasharray="6 6" />
+          <g fill="rgba(248,250,252,0.75)" opacity="0.85">
+            <circle cx="16" cy="18" r="4" />
+            <circle cx="16" cy="36" r="4" />
+            <circle cx="16" cy="54" r="4" />
+          </g>
+          <rect x="10" y="32" width="12" height="12" rx="4" fill="rgba(250,204,21,0.5)" stroke="rgba(250,204,21,0.7)" />
+          <path d="M10 64 L22 74" stroke="rgba(248,250,252,0.4)" stroke-width="3" stroke-linecap="round" />
+        </g>
+        <circle cx="120" cy="56" r="20" fill="url(#grailDust)" opacity="0.4" />
+        <path d="M18 100 L142 100" stroke="url(#grailGlow)" stroke-width="6" stroke-linecap="round" opacity="0.55" />
+      </svg>
+    `,
+  }, // Level 15
   // Level 14
   {
     id: "the-final-barrier",

--- a/madia.new/public/secret/1989/grail-trial/grail-trial.css
+++ b/madia.new/public/secret/1989/grail-trial/grail-trial.css
@@ -1,0 +1,499 @@
+:root {
+  --grail-amber: #fbbf24;
+  --grail-ember: #f97316;
+  --grail-slate: #111827;
+  --grail-stone: rgba(17, 24, 39, 0.78);
+  --grail-gold: #facc15;
+  --grail-teal: #22d3ee;
+  --grail-crimson: #ef4444;
+}
+
+.grail-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.score-hud {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.hud-tile {
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.88), rgba(15, 23, 42, 0.88));
+  border: 1px solid rgba(248, 250, 252, 0.12);
+  border-radius: 18px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  position: relative;
+  box-shadow: 0 12px 24px rgba(2, 6, 23, 0.35);
+}
+
+.hud-tile::after {
+  content: "";
+  position: absolute;
+  inset: 2px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(251, 191, 36, 0.12), rgba(56, 189, 248, 0.08));
+  pointer-events: none;
+}
+
+.hud-title {
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(248, 250, 252, 0.65);
+  margin: 0;
+}
+
+.hud-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.hud-value {
+  font-family: "Share Tech Mono", monospace;
+  font-size: 1.25rem;
+  color: #f8fafc;
+}
+
+.hud-value--score {
+  font-size: 1.8rem;
+  color: var(--grail-gold);
+  text-shadow: 0 0 12px rgba(250, 204, 21, 0.45);
+}
+
+.hud-tile--score::after {
+  background: linear-gradient(135deg, rgba(250, 204, 21, 0.2), rgba(59, 130, 246, 0.1));
+}
+
+.hud-tile--high-score .hud-value {
+  color: var(--grail-teal);
+}
+
+.trial-section {
+  background: radial-gradient(circle at top, rgba(55, 48, 163, 0.15), transparent 65%),
+    linear-gradient(155deg, rgba(15, 23, 42, 0.92), rgba(8, 11, 24, 0.92));
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 24px;
+  padding: 1.75rem;
+  box-shadow: inset 0 0 0 1px rgba(248, 250, 252, 0.05), 0 20px 28px rgba(2, 6, 23, 0.45);
+}
+
+.trial-header h2 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.4rem;
+  color: var(--grail-gold);
+}
+
+.trial-header p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.82);
+  line-height: 1.5;
+}
+
+.trial-body {
+  margin-top: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.trial-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.trial-status {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.7);
+  min-height: 1.25rem;
+}
+
+.action-button {
+  min-width: 140px;
+}
+
+.tile-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.tile-grid button {
+  position: relative;
+  aspect-ratio: 1;
+  border-radius: 18px;
+  border: 1px solid rgba(248, 250, 252, 0.14);
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.85));
+  color: rgba(226, 232, 240, 0.85);
+  font-family: "Share Tech Mono", monospace;
+  font-size: 1.8rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+}
+
+.tile-grid button[data-disabled="true"] {
+  pointer-events: none;
+  opacity: 0.45;
+}
+
+.tile-grid button:hover,
+.tile-grid button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 20px rgba(8, 11, 24, 0.6);
+  border-color: rgba(250, 204, 21, 0.6);
+}
+
+.tile-grid button.tile--lit {
+  background: linear-gradient(145deg, rgba(250, 204, 21, 0.32), rgba(15, 23, 42, 0.95));
+  color: var(--grail-gold);
+  box-shadow: 0 0 16px rgba(250, 204, 21, 0.55);
+}
+
+.tile-grid button.tile--safe {
+  background: linear-gradient(145deg, rgba(34, 197, 94, 0.4), rgba(15, 23, 42, 0.95));
+  color: #f8fafc;
+  border-color: rgba(34, 197, 94, 0.5);
+}
+
+.tile-grid button.tile--fail {
+  animation: tileFail 420ms ease;
+}
+
+@keyframes tileFail {
+  0% {
+    transform: translateY(0);
+    box-shadow: 0 0 0 rgba(239, 68, 68, 0.7);
+  }
+  45% {
+    transform: translateY(-6px);
+    box-shadow: 0 18px 28px rgba(239, 68, 68, 0.4);
+    background: rgba(239, 68, 68, 0.35);
+  }
+  100% {
+    transform: translateY(0);
+    box-shadow: 0 0 0 rgba(239, 68, 68, 0);
+  }
+}
+
+.blade-hall {
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(8, 11, 24, 0.96));
+  border-radius: 18px;
+  padding: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.blade-track {
+  position: relative;
+  width: min(520px, 100%);
+  height: 120px;
+  border-radius: 14px;
+  border: 1px dashed rgba(248, 250, 252, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1rem;
+}
+
+.blade {
+  width: 120px;
+  height: 12px;
+  border-radius: 12px;
+  background: linear-gradient(90deg, rgba(248, 250, 252, 0.2), rgba(148, 163, 184, 0.6), rgba(248, 250, 252, 0.2));
+  position: relative;
+  box-shadow: 0 0 16px rgba(148, 163, 184, 0.4);
+  transform-origin: left center;
+  animation: bladeIdle 3s ease-in-out infinite;
+}
+
+.blade::after {
+  content: "";
+  position: absolute;
+  right: -20px;
+  top: -12px;
+  width: 24px;
+  height: 36px;
+  border-radius: 10px 10px 4px 4px;
+  background: linear-gradient(135deg, rgba(248, 250, 252, 0.3), rgba(148, 163, 184, 0.65));
+}
+
+.blade--rear {
+  animation-delay: 0.6s;
+}
+
+.blade-hall[data-armed="true"] .blade {
+  animation: bladeStrike 1.4s ease-in-out infinite;
+}
+
+@keyframes bladeIdle {
+  0%,
+  100% {
+    transform: rotate(4deg);
+  }
+  50% {
+    transform: rotate(-4deg);
+  }
+}
+
+@keyframes bladeStrike {
+  0% {
+    transform: rotate(70deg);
+  }
+  45% {
+    transform: rotate(-6deg);
+  }
+  100% {
+    transform: rotate(70deg);
+  }
+}
+
+.kneeler {
+  position: absolute;
+  bottom: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 64px;
+  height: 64px;
+  border-radius: 16px;
+  background: radial-gradient(circle at 50% 35%, rgba(250, 204, 21, 0.6), rgba(15, 23, 42, 0.92));
+  border: 1px solid rgba(250, 204, 21, 0.35);
+  transition: transform 140ms ease;
+}
+
+.kneeler[data-state="duck"] {
+  transform: translate(-50%, 14px) scaleY(0.55);
+  box-shadow: 0 0 24px rgba(59, 130, 246, 0.4);
+}
+
+.chasm {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.9), rgba(8, 11, 24, 0.96));
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 1.5rem;
+}
+
+.chasm-track {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.75rem;
+  min-height: 160px;
+}
+
+.bridge-column {
+  display: grid;
+  grid-template-rows: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.bridge-tile {
+  border-radius: 14px;
+  border: 1px dashed rgba(248, 250, 252, 0.12);
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.85), rgba(8, 11, 24, 0.95));
+  position: relative;
+  overflow: hidden;
+}
+
+.bridge-tile::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 14px;
+  opacity: 0;
+  transition: opacity 200ms ease;
+  background: linear-gradient(135deg, rgba(250, 204, 21, 0.4), rgba(34, 197, 94, 0.35));
+}
+
+.bridge-tile[data-revealed="true"]::after {
+  opacity: 1;
+  box-shadow: 0 0 18px rgba(250, 204, 21, 0.5);
+}
+
+.bridge-tile[data-position="player"]::after {
+  opacity: 1;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.45), rgba(56, 189, 248, 0.4));
+  box-shadow: 0 0 20px rgba(56, 189, 248, 0.55);
+}
+
+.bridge-meter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-family: "Share Tech Mono", monospace;
+  color: rgba(248, 250, 252, 0.8);
+}
+
+.legend {
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.92), rgba(8, 11, 24, 0.92));
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 1.5rem;
+  box-shadow: inset 0 0 0 1px rgba(248, 250, 252, 0.05);
+}
+
+.legend-title {
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(248, 250, 252, 0.75);
+}
+
+.legend-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.legend-card {
+  background: linear-gradient(150deg, rgba(15, 23, 42, 0.85), rgba(30, 41, 59, 0.75));
+  border-radius: 16px;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.legend-card h3 {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  color: rgba(250, 204, 21, 0.85);
+}
+
+.legend-card p {
+  margin: 0;
+  font-family: "Share Tech Mono", monospace;
+  color: rgba(226, 232, 240, 0.76);
+}
+
+.wrapup {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 40;
+}
+
+.wrapup[hidden] {
+  display: none;
+}
+
+.wrapup-backdrop {
+  position: absolute;
+  inset: 0;
+  backdrop-filter: blur(6px);
+  background: rgba(2, 6, 23, 0.72);
+}
+
+.wrapup-dialog {
+  position: relative;
+  width: min(520px, calc(100% - 2rem));
+  padding: 2rem;
+  border-radius: 24px;
+  background: linear-gradient(165deg, rgba(15, 23, 42, 0.95), rgba(6, 11, 24, 0.95));
+  border: 1px solid rgba(250, 204, 21, 0.35);
+  box-shadow: 0 28px 40px rgba(2, 6, 23, 0.65);
+}
+
+.wrapup-header {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.wrapup-eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: rgba(226, 232, 240, 0.6);
+  font-size: 0.7rem;
+}
+
+.wrapup-subtitle {
+  margin: 0.35rem 0 0;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.wrapup-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 0 0 1.5rem;
+}
+
+.wrapup-metrics div {
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.85), rgba(8, 11, 24, 0.85));
+  border-radius: 16px;
+  padding: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.wrapup-metrics dt {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.6);
+  margin: 0 0 0.35rem;
+}
+
+.wrapup-metrics dd {
+  margin: 0;
+  font-family: "Share Tech Mono", monospace;
+  color: rgba(248, 250, 252, 0.9);
+  font-size: 1.15rem;
+}
+
+.wrapup-score {
+  text-align: center;
+  font-size: 1.4rem;
+  margin: 0 0 1.5rem;
+  color: var(--grail-gold);
+  text-shadow: 0 0 18px rgba(250, 204, 21, 0.4);
+}
+
+.wrapup-actions {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+@media (max-width: 720px) {
+  .trial-section {
+    padding: 1.25rem;
+  }
+
+  .tile-grid {
+    gap: 0.5rem;
+  }
+
+  .tile-grid button {
+    font-size: 1.4rem;
+  }
+
+  .blade-track {
+    height: 100px;
+  }
+
+  .chasm-track {
+    grid-template-columns: repeat(6, minmax(0, 80px));
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+  }
+
+  .wrapup-dialog {
+    padding: 1.5rem;
+  }
+}

--- a/madia.new/public/secret/1989/grail-trial/grail-trial.js
+++ b/madia.new/public/secret/1989/grail-trial/grail-trial.js
@@ -1,0 +1,757 @@
+import { initHighScoreBanner, recordHighScore } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+import { mountParticleField } from "../particles.js";
+import { autoEnhanceFeedback } from "../feedback.js";
+
+const particleField = mountParticleField({
+  effects: {
+    palette: ["#facc15", "#f97316", "#22d3ee", "#f472b6"],
+    ambientDensity: 0.28,
+    drift: 0.26,
+  },
+});
+
+const scoreConfig = getScoreConfig("grail-trial");
+initHighScoreBanner({
+  gameId: "grail-trial",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
+autoEnhanceFeedback();
+
+const FAILURE_PENALTY_SECONDS = 5;
+const TRIAL_COUNT = 3;
+
+const TRIAL1_GRID = [
+  ["I", "X", "Q", "M"],
+  ["S", "E", "T", "R"],
+  ["H", "L", "O", "D"],
+  ["N", "V", "A", "G"],
+];
+
+const TRIAL1_PATH = [0, 5, 8, 10, 13, 14];
+
+const TRIAL3_PATH = [1, 2, 2, 1, 0, 1];
+const TRIAL3_START_LANE = 1;
+const MAX_DUST = 9;
+
+const LIGHT_TOSS = {
+  cost: 1,
+  count: 1,
+  duration: 1600,
+  label: "A quick puff reveals a single stone.",
+};
+
+const HEAVY_TOSS = {
+  cost: 2,
+  count: 2,
+  duration: 2600,
+  label: "A sweeping throw uncovers two spans.",
+};
+
+const BASE_SCORE_PER_TRIAL = 400;
+const TIME_BONUS_BASE = 18000;
+const TIME_BONUS_FACTOR = 320;
+const FAILURE_PENALTY_POINTS = 200;
+const DUST_BONUS_POINTS = 120;
+
+const scoreValue = document.getElementById("score-value");
+const totalTimeValue = document.getElementById("total-time");
+const failureValue = document.getElementById("failure-count");
+const trialsClearedValue = document.getElementById("trials-cleared");
+const legendTrial1 = document.getElementById("legend-trial1");
+const legendTrial2 = document.getElementById("legend-trial2");
+const legendTrial3 = document.getElementById("legend-trial3");
+
+const trial1Section = document.getElementById("trial-1");
+const trial1Grid = document.getElementById("name-grid");
+const trial1StartButton = document.getElementById("trial1-start");
+const trial1SkipButton = document.getElementById("trial1-skip");
+const trial1Status = document.getElementById("trial1-status");
+
+const trial2Section = document.getElementById("trial-2");
+const trial2StartButton = document.getElementById("trial2-start");
+const duckButton = document.getElementById("duck-button");
+const trial2Status = document.getElementById("trial2-status");
+const bladeHall = document.getElementById("blade-hall");
+const kneeler = document.getElementById("kneeler");
+
+const trial3Section = document.getElementById("trial-3");
+const chasmTrack = document.getElementById("chasm-track");
+const dustCountValue = document.getElementById("dust-count");
+const lightTossButton = document.getElementById("light-toss");
+const heavyTossButton = document.getElementById("heavy-toss");
+const advanceButton = document.getElementById("advance-button");
+const trial3Status = document.getElementById("trial3-status");
+
+const wrapup = document.getElementById("wrapup");
+const wrapupDialog = wrapup.querySelector(".wrapup-dialog");
+const wrapupSubtitle = document.getElementById("wrapup-subtitle");
+const wrapupScore = document.getElementById("wrapup-score");
+const wrapupTrial1 = document.getElementById("wrapup-trial1");
+const wrapupTrial2 = document.getElementById("wrapup-trial2");
+const wrapupTrial3 = document.getElementById("wrapup-trial3");
+const wrapupTotal = document.getElementById("wrapup-total");
+const wrapupDust = document.getElementById("wrapup-dust");
+const wrapupReplay = document.getElementById("wrapup-replay");
+const wrapupClose = document.getElementById("wrapup-close");
+
+const audioState = {
+  context: null,
+};
+
+const state = {
+  currentTrial: 0,
+  totalStart: null,
+  trialStart: null,
+  trialTimes: [0, 0, 0],
+  failureCount: 0,
+  completedTrials: 0,
+  revealTimers: [],
+  trial1Input: [],
+  trial1Active: false,
+  trial1RevealRunning: false,
+  trial2Active: false,
+  trial2WindowOpen: false,
+  trial2BladeTimer: null,
+  trial2WindowTimer: null,
+  trial3Active: false,
+  trial3Dust: MAX_DUST,
+  trial3Column: 0,
+  trial3Lane: TRIAL3_START_LANE,
+  trial3PendingMoves: 0,
+  trial3RevealTimer: null,
+  trial3AdvanceUnlocked: false,
+};
+
+const trial1Tiles = [];
+const trial3Tiles = [];
+
+function ensureAudioContext() {
+  if (!audioState.context) {
+    const AudioContext = window.AudioContext || window.webkitAudioContext;
+    if (AudioContext) {
+      audioState.context = new AudioContext();
+    }
+  }
+  if (audioState.context && audioState.context.state === "suspended") {
+    audioState.context.resume().catch(() => {});
+  }
+  return audioState.context;
+}
+
+function playSuccessChord() {
+  const ctx = ensureAudioContext();
+  if (!ctx) {
+    return;
+  }
+  const notes = [392, 523.25, 659.25];
+  const now = ctx.currentTime;
+  notes.forEach((frequency, index) => {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = "triangle";
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.exponentialRampToValueAtTime(0.6, now + 0.05 + index * 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.5 + index * 0.04);
+    osc.frequency.setValueAtTime(frequency, now);
+    osc.connect(gain).connect(ctx.destination);
+    osc.start(now + index * 0.02);
+    osc.stop(now + 0.6 + index * 0.02);
+  });
+}
+
+function playFailureCrash() {
+  const ctx = ensureAudioContext();
+  if (!ctx) {
+    return;
+  }
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = "sawtooth";
+  gain.gain.setValueAtTime(0.8, ctx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.45);
+  osc.frequency.setValueAtTime(160, ctx.currentTime);
+  osc.frequency.exponentialRampToValueAtTime(45, ctx.currentTime + 0.45);
+  const noise = ctx.createBufferSource();
+  const buffer = ctx.createBuffer(1, ctx.sampleRate * 0.4, ctx.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < data.length; i += 1) {
+    data[i] = Math.random() * 2 - 1;
+  }
+  const noiseGain = ctx.createGain();
+  noiseGain.gain.setValueAtTime(0.5, ctx.currentTime);
+  noiseGain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.35);
+  noise.buffer = buffer;
+  noise.loop = false;
+  noise.connect(noiseGain).connect(ctx.destination);
+  osc.connect(gain).connect(ctx.destination);
+  osc.start();
+  osc.stop(ctx.currentTime + 0.5);
+  noise.start();
+}
+
+function formatSeconds(value) {
+  return `${value.toFixed(2)}s`;
+}
+
+function calculateTotalTime() {
+  return state.trialTimes.reduce((sum, value) => sum + value, 0);
+}
+
+function calculateScore() {
+  if (state.completedTrials === 0) {
+    return 0;
+  }
+  const completedTime = state.trialTimes
+    .slice(0, state.completedTrials)
+    .reduce((sum, value) => sum + value, 0);
+  const base = state.completedTrials * BASE_SCORE_PER_TRIAL;
+  const timeBonus = Math.max(0, Math.round(state.completedTrials * TIME_BONUS_BASE - completedTime * TIME_BONUS_FACTOR));
+  const failurePenalty = state.failureCount * FAILURE_PENALTY_POINTS;
+  const dustBonus = state.completedTrials === TRIAL_COUNT ? state.trial3Dust * DUST_BONUS_POINTS : 0;
+  return Math.max(0, base + timeBonus + dustBonus - failurePenalty);
+}
+
+function updateHud() {
+  const totalTime = calculateTotalTime();
+  totalTimeValue.textContent = formatSeconds(totalTime);
+  failureValue.textContent = String(state.failureCount);
+  trialsClearedValue.textContent = `${state.completedTrials} / ${TRIAL_COUNT}`;
+  scoreValue.textContent = calculateScore().toLocaleString();
+}
+
+function updateLegend(trialIndex, message) {
+  const total = state.trialTimes[trialIndex - 1];
+  const entry = `${formatSeconds(total)} · ${message}`;
+  if (trialIndex === 1) {
+    legendTrial1.textContent = entry;
+  } else if (trialIndex === 2) {
+    legendTrial2.textContent = entry;
+  } else if (trialIndex === 3) {
+    legendTrial3.textContent = entry;
+  }
+}
+
+function resetTrial1Tiles() {
+  trial1Tiles.forEach((tile) => {
+    tile.classList.remove("tile--lit", "tile--safe", "tile--fail");
+    tile.dataset.disabled = "true";
+  });
+}
+
+function clearRevealTimers() {
+  state.revealTimers.forEach((timer) => window.clearTimeout(timer));
+  state.revealTimers = [];
+}
+
+function setTrialStatus(section, statusElement, message) {
+  statusElement.textContent = message;
+  section.dataset.status = message;
+}
+
+function startTrial1() {
+  ensureAudioContext();
+  if (state.currentTrial === 0) {
+    resetExpedition();
+    state.totalStart = performance.now();
+  }
+  state.currentTrial = 1;
+  state.trial1Active = true;
+  state.trial1RevealRunning = true;
+  state.trial1Input = [];
+  state.trialStart = performance.now();
+  resetTrial1Tiles();
+  trial1StartButton.disabled = true;
+  trial1SkipButton.disabled = false;
+  setTrialStatus(trial1Section, trial1Status, "Observe the sacred path or trust your instincts.");
+  runTrial1Reveal();
+}
+
+function runTrial1Reveal() {
+  clearRevealTimers();
+  TRIAL1_PATH.forEach((index, position) => {
+    const tile = trial1Tiles[index];
+    if (!tile) {
+      return;
+    }
+    const revealDelay = position * 520;
+    const revealTimer = window.setTimeout(() => {
+      tile.classList.add("tile--lit");
+      const fadeTimer = window.setTimeout(() => {
+        tile.classList.remove("tile--lit");
+        if (position === TRIAL1_PATH.length - 1 && state.trial1RevealRunning) {
+          enableTrial1Input();
+        }
+      }, 360);
+      state.revealTimers.push(fadeTimer);
+    }, revealDelay);
+    state.revealTimers.push(revealTimer);
+  });
+}
+
+function enableTrial1Input() {
+  state.trial1RevealRunning = false;
+  trial1SkipButton.disabled = true;
+  trial1Tiles.forEach((tile) => {
+    tile.dataset.disabled = "false";
+  });
+  setTrialStatus(trial1Section, trial1Status, "Step only on the letters of the sacred name.");
+}
+
+function skipTrial1Reveal() {
+  clearRevealTimers();
+  trial1Tiles.forEach((tile) => tile.classList.remove("tile--lit"));
+  enableTrial1Input();
+  setTrialStatus(trial1Section, trial1Status, "You trusted your memory. Choose wisely.");
+}
+
+function handleTrial1TileClick(event) {
+  if (!state.trial1Active || state.trial1RevealRunning) {
+    return;
+  }
+  const tile = event.currentTarget;
+  if (!tile || tile.dataset.disabled === "true") {
+    return;
+  }
+  const index = Number(tile.dataset.index);
+  const expectedIndex = TRIAL1_PATH[state.trial1Input.length];
+  if (index !== expectedIndex) {
+    tile.classList.add("tile--fail");
+    failTrial(1, "The false stone crumbled beneath you.");
+    return;
+  }
+  tile.classList.add("tile--safe");
+  tile.dataset.disabled = "true";
+  state.trial1Input.push(index);
+  const remaining = TRIAL1_PATH.length - state.trial1Input.length;
+  if (remaining > 0) {
+    setTrialStatus(
+      trial1Section,
+      trial1Status,
+      `${remaining} step${remaining === 1 ? "" : "s"} remain. Keep spelling the divine name.`,
+    );
+    return;
+  }
+  completeTrial(1, "Name honored. The floor is steady.");
+}
+
+function resetTrial1ForRetry() {
+  state.trial1Active = false;
+  state.trial1Input = [];
+  clearRevealTimers();
+  trial1Tiles.forEach((tile) => {
+    tile.classList.remove("tile--lit", "tile--safe", "tile--fail");
+    tile.dataset.disabled = "true";
+  });
+  trial1StartButton.disabled = false;
+  trial1SkipButton.disabled = true;
+  setTrialStatus(
+    trial1Section,
+    trial1Status,
+    "The temple resets the letters. Begin the chant when ready.",
+  );
+}
+
+function scheduleBladeStrike() {
+  window.clearTimeout(state.trial2BladeTimer);
+  const delay = 1200 + Math.random() * 1600;
+  state.trial2BladeTimer = window.setTimeout(() => {
+    state.trial2WindowOpen = true;
+    kneeler.dataset.state = "ready";
+    setTrialStatus(trial2Section, trial2Status, "Now! Kneel before the blades clash.");
+    state.trial2WindowTimer = window.setTimeout(() => {
+      if (state.trial2WindowOpen) {
+        failTrial(2, "You hesitated and steel found you.");
+      }
+    }, 520);
+  }, delay);
+}
+
+function startTrial2() {
+  ensureAudioContext();
+  state.currentTrial = 2;
+  state.trial2Active = true;
+  state.trialStart = performance.now();
+  bladeHall.dataset.armed = "true";
+  trial2StartButton.disabled = true;
+  duckButton.disabled = false;
+  setTrialStatus(trial2Section, trial2Status, "Blades primed. Watch the rhythm.");
+  scheduleBladeStrike();
+}
+
+function resetTrial2ForRetry() {
+  state.trial2Active = false;
+  state.trial2WindowOpen = false;
+  window.clearTimeout(state.trial2BladeTimer);
+  window.clearTimeout(state.trial2WindowTimer);
+  kneeler.dataset.state = "";
+  bladeHall.dataset.armed = "false";
+  duckButton.disabled = true;
+  trial2StartButton.disabled = false;
+  setTrialStatus(trial2Section, trial2Status, "Center yourself and ready the blades again.");
+}
+
+function handleDuck() {
+  if (!state.trial2Active) {
+    return;
+  }
+  if (!state.trial2WindowOpen) {
+    failTrial(2, "You knelt too soon and the blade rebounded.");
+    return;
+  }
+  state.trial2WindowOpen = false;
+  window.clearTimeout(state.trial2BladeTimer);
+  window.clearTimeout(state.trial2WindowTimer);
+  kneeler.dataset.state = "duck";
+  setTrialStatus(trial2Section, trial2Status, "You slid under the storm of steel.");
+  completeTrial(2, "Penitence honored. The next hall opens.");
+}
+
+function buildChasmTrack() {
+  chasmTrack.innerHTML = "";
+  trial3Tiles.length = 0;
+  const columns = TRIAL3_PATH.length + 1;
+  for (let columnIndex = 0; columnIndex <= columns; columnIndex += 1) {
+    const column = document.createElement("div");
+    column.className = "bridge-column";
+    const lanes = [];
+    for (let laneIndex = 0; laneIndex < 3; laneIndex += 1) {
+      const tile = document.createElement("div");
+      tile.className = "bridge-tile";
+      tile.dataset.column = String(columnIndex);
+      tile.dataset.lane = String(laneIndex);
+      column.appendChild(tile);
+      lanes.push(tile);
+    }
+    chasmTrack.appendChild(column);
+    trial3Tiles.push(lanes);
+  }
+  state.trial3Lane = TRIAL3_START_LANE;
+  if (trial3Tiles[0]) {
+    trial3Tiles[0][TRIAL3_START_LANE].dataset.position = "player";
+  }
+}
+
+function resetChasm() {
+  trial3Tiles.forEach((lanes) => {
+    lanes.forEach((tile) => {
+      tile.dataset.position = "";
+      tile.dataset.revealed = "false";
+    });
+  });
+  state.trial3Lane = TRIAL3_START_LANE;
+  if (trial3Tiles[0]) {
+    trial3Tiles[0][TRIAL3_START_LANE].dataset.position = "player";
+  }
+}
+
+function clearTrial3Reveal() {
+  window.clearTimeout(state.trial3RevealTimer);
+  state.trial3RevealTimer = null;
+  trial3Tiles.forEach((lanes) => {
+    lanes.forEach((tile) => {
+      if (tile.dataset.revealed === "true") {
+        tile.dataset.revealed = "false";
+      }
+    });
+  });
+}
+
+function updateDustButtons() {
+  const busy = state.trial3PendingMoves > 0;
+  const active = state.trial3Active;
+  lightTossButton.disabled = !active || busy || state.trial3Dust <= 0;
+  heavyTossButton.disabled = !active || busy || state.trial3Dust < HEAVY_TOSS.cost;
+}
+
+function startTrial3() {
+  ensureAudioContext();
+  state.currentTrial = 3;
+  state.trialStart = performance.now();
+  state.trial3Active = true;
+  state.trial3Dust = MAX_DUST;
+  state.trial3Column = 0;
+  state.trial3PendingMoves = 0;
+  state.trial3AdvanceUnlocked = false;
+  clearTrial3Reveal();
+  resetChasm();
+  dustCountValue.textContent = String(state.trial3Dust);
+  updateDustButtons();
+  advanceButton.disabled = true;
+  setTrialStatus(trial3Section, trial3Status, "Throw dust to map the invisible bridge.");
+}
+
+function handleDustThrow(config) {
+  if (!state.trial3Active) {
+    return;
+  }
+  if (state.trial3PendingMoves > 0) {
+    setTrialStatus(trial3Section, trial3Status, "Step onto the revealed stones before they fade!");
+    return;
+  }
+  if (state.trial3Dust < config.cost) {
+    setTrialStatus(trial3Section, trial3Status, "Not enough dust for that throw.");
+    updateDustButtons();
+    if (state.trial3Dust <= 0 && state.trial3PendingMoves <= 0) {
+      failTrial(3, "The satchel is empty. Faith without footing ends in darkness.");
+    }
+    return;
+  }
+  state.trial3Dust -= config.cost;
+  dustCountValue.textContent = String(state.trial3Dust);
+  state.trial3PendingMoves = 0;
+  clearTrial3Reveal();
+  for (let i = 1; i <= config.count; i += 1) {
+    const targetStep = state.trial3Column + i;
+    if (targetStep > TRIAL3_PATH.length) {
+      break;
+    }
+    const lane = TRIAL3_PATH[targetStep - 1];
+    const tile = trial3Tiles[targetStep][lane];
+    if (tile) {
+      tile.dataset.revealed = "true";
+      state.trial3PendingMoves += 1;
+    }
+  }
+  updateDustButtons();
+  if (state.trial3PendingMoves === 0) {
+    if (state.trial3Column >= TRIAL3_PATH.length) {
+      completeTrial(3, "You dashed across just in time.");
+      return;
+    }
+    setTrialStatus(trial3Section, trial3Status, "No stones revealed. Try another throw.");
+    return;
+  }
+  state.trial3AdvanceUnlocked = true;
+  advanceButton.disabled = false;
+  setTrialStatus(trial3Section, trial3Status, config.label);
+  state.trial3RevealTimer = window.setTimeout(() => {
+    if (state.trial3PendingMoves > 0) {
+      failTrial(3, "The stones vanished before you moved.");
+    }
+  }, config.duration);
+}
+
+function handleAdvance() {
+  if (!state.trial3Active || !state.trial3AdvanceUnlocked) {
+    return;
+  }
+  if (state.trial3PendingMoves <= 0) {
+    failTrial(3, "You stepped without seeing and fell into the abyss.");
+    return;
+  }
+  const nextColumn = state.trial3Column + 1;
+  const lane = TRIAL3_PATH[nextColumn - 1];
+  const previousTile = trial3Tiles[state.trial3Column]?.[state.trial3Lane];
+  if (previousTile) {
+    previousTile.dataset.position = "";
+  }
+  const nextTile = trial3Tiles[nextColumn]?.[lane];
+  if (nextTile) {
+    nextTile.dataset.position = "player";
+    nextTile.dataset.revealed = "false";
+  }
+  state.trial3Column = nextColumn;
+  state.trial3Lane = lane;
+  state.trial3PendingMoves -= 1;
+  if (state.trial3Column >= TRIAL3_PATH.length) {
+    completeTrial(3, "You crossed the abyss and guard the Grail.");
+    return;
+  }
+  if (state.trial3PendingMoves <= 0) {
+    clearTrial3Reveal();
+    advanceButton.disabled = true;
+    if (state.trial3Dust <= 0) {
+      failTrial(3, "The satchel is empty. Faith without footing ends in darkness.");
+      return;
+    }
+    setTrialStatus(trial3Section, trial3Status, "The next step is hidden once more.");
+  } else {
+    setTrialStatus(trial3Section, trial3Status, "One more glimpse remains—step swiftly.");
+  }
+  updateDustButtons();
+}
+
+function resetTrial3ForRetry() {
+  state.trial3Active = false;
+  state.trial3Dust = MAX_DUST;
+  state.trial3Column = 0;
+  state.trial3PendingMoves = 0;
+  state.trial3AdvanceUnlocked = false;
+  clearTrial3Reveal();
+  resetChasm();
+  dustCountValue.textContent = String(state.trial3Dust);
+  updateDustButtons();
+  advanceButton.disabled = true;
+  setTrialStatus(trial3Section, trial3Status, "Gather yourself before the final leap.");
+}
+
+function completeTrial(trialNumber, message) {
+  const now = performance.now();
+  if (state.trialStart) {
+    state.trialTimes[trialNumber - 1] += (now - state.trialStart) / 1000;
+  }
+  state.trialStart = null;
+  state.completedTrials = Math.max(state.completedTrials, trialNumber);
+  updateHud();
+  updateLegend(trialNumber, `${message}`);
+  playSuccessChord();
+
+  if (trialNumber === 1) {
+    state.trial1Active = false;
+    trial1SkipButton.disabled = true;
+    trial2StartButton.disabled = false;
+    setTrialStatus(trial2Section, trial2Status, "The hallway hums. Ready the blades when prepared.");
+  } else if (trialNumber === 2) {
+    state.trial2Active = false;
+    duckButton.disabled = true;
+    kneeler.dataset.state = "duck";
+    bladeHall.dataset.armed = "false";
+    startTrial3();
+  } else if (trialNumber === 3) {
+    state.trial3Active = false;
+    updateDustButtons();
+    advanceButton.disabled = true;
+    finalizeRun();
+  }
+}
+
+function failTrial(trialNumber, failureMessage) {
+  const now = performance.now();
+  if (state.trialStart) {
+    state.trialTimes[trialNumber - 1] += (now - state.trialStart) / 1000;
+  }
+  state.trialStart = null;
+  state.trialTimes[trialNumber - 1] += FAILURE_PENALTY_SECONDS;
+  state.failureCount += 1;
+  playFailureCrash();
+  updateHud();
+  updateLegend(trialNumber, `${failureMessage} +${FAILURE_PENALTY_SECONDS}s penalty.`);
+
+  if (trialNumber === 1) {
+    resetTrial1ForRetry();
+  } else if (trialNumber === 2) {
+    resetTrial2ForRetry();
+  } else {
+    resetTrial3ForRetry();
+  }
+}
+
+function finalizeRun() {
+  const totalTime = calculateTotalTime();
+  const finalScore = calculateScore();
+  updateHud();
+
+  wrapupTrial1.textContent = formatSeconds(state.trialTimes[0]);
+  wrapupTrial2.textContent = formatSeconds(state.trialTimes[1]);
+  wrapupTrial3.textContent = formatSeconds(state.trialTimes[2]);
+  wrapupTotal.textContent = formatSeconds(totalTime);
+  wrapupDust.textContent = `${state.trial3Dust} dust`;
+  wrapupScore.textContent = `Worthiness Score: ${finalScore.toLocaleString()}`;
+  wrapupSubtitle.textContent = `${state.failureCount} failure${state.failureCount === 1 ? "" : "s"} · ${state.trial3Dust} dust saved`;
+
+  wrapup.hidden = false;
+  requestAnimationFrame(() => {
+    wrapupDialog.focus();
+  });
+
+  recordHighScore("grail-trial", finalScore, {
+    totalTimeMs: Math.round(totalTime * 1000),
+    trialTimesMs: state.trialTimes.map((value) => Math.round(value * 1000)),
+    failures: state.failureCount,
+    dustRemaining: state.trial3Dust,
+  });
+}
+
+function closeWrapup() {
+  wrapup.hidden = true;
+  requestAnimationFrame(() => {
+    trial1StartButton.focus({ preventScroll: true });
+  });
+}
+
+function resetExpedition() {
+  state.currentTrial = 0;
+  state.totalStart = null;
+  state.trialStart = null;
+  state.trialTimes = [0, 0, 0];
+  state.failureCount = 0;
+  state.completedTrials = 0;
+  state.trial1Input = [];
+  state.trial1Active = false;
+  state.trial1RevealRunning = false;
+  state.trial2Active = false;
+  state.trial2WindowOpen = false;
+  state.trial3Active = false;
+  state.trial3Dust = MAX_DUST;
+  state.trial3Column = 0;
+  state.trial3Lane = TRIAL3_START_LANE;
+  state.trial3PendingMoves = 0;
+  state.trial3AdvanceUnlocked = false;
+  clearRevealTimers();
+  window.clearTimeout(state.trial2BladeTimer);
+  window.clearTimeout(state.trial2WindowTimer);
+  clearTrial3Reveal();
+  resetTrial1ForRetry();
+  resetTrial2ForRetry();
+  resetTrial3ForRetry();
+  trial2StartButton.disabled = true;
+  duckButton.disabled = true;
+  lightTossButton.disabled = true;
+  heavyTossButton.disabled = true;
+  advanceButton.disabled = true;
+  setTrialStatus(trial1Section, trial1Status, "Press Begin Chant to watch the inscription ignite.");
+  setTrialStatus(trial2Section, trial2Status, "Await the verdict from Trial I.");
+  setTrialStatus(trial3Section, trial3Status, "The bridge awaits the penitent.");
+  updateLegend(1, "untouched");
+  updateLegend(2, "awaiting");
+  updateLegend(3, "awaiting");
+  updateHud();
+}
+
+
+
+function initializeTiles() {
+  TRIAL1_GRID.forEach((row) => {
+    row.forEach((letter, columnIndex) => {
+      const tile = document.createElement("button");
+      tile.type = "button";
+      tile.textContent = letter;
+      tile.dataset.index = String(trial1Tiles.length);
+      tile.dataset.disabled = "true";
+      tile.addEventListener("click", handleTrial1TileClick);
+      trial1Grid.appendChild(tile);
+      trial1Tiles.push(tile);
+    });
+  });
+}
+
+initializeTiles();
+buildChasmTrack();
+resetExpedition();
+
+trial1StartButton.addEventListener("click", startTrial1);
+trial1SkipButton.addEventListener("click", skipTrial1Reveal);
+trial2StartButton.addEventListener("click", startTrial2);
+duckButton.addEventListener("click", handleDuck);
+lightTossButton.addEventListener("click", () => handleDustThrow(LIGHT_TOSS));
+heavyTossButton.addEventListener("click", () => handleDustThrow(HEAVY_TOSS));
+advanceButton.addEventListener("click", handleAdvance);
+wrapupReplay.addEventListener("click", () => {
+  closeWrapup();
+  resetExpedition();
+});
+wrapupClose.addEventListener("click", closeWrapup);
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape" && !wrapup.hidden) {
+    closeWrapup();
+  }
+});
+
+window.addEventListener("beforeunload", () => {
+  particleField?.stop?.();
+});

--- a/madia.new/public/secret/1989/grail-trial/index.html
+++ b/madia.new/public/secret/1989/grail-trial/index.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>The Grail Trial</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="grail-trial.css" />
+  </head>
+  <body class="secret-annex-snes">
+    <a class="skip-link" href="#main-content">Skip to game</a>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 15 · 1989 Arcade</p>
+      <h1>The Grail Trial</h1>
+      <p class="subtitle">
+        Beneath the monastery ruins, three sacred trials wait in the dark. Memorize the divine name, kneel before the blades,
+        and test your nerve across an invisible bridge. Finish fast to prove your worthiness.
+      </p>
+    </header>
+    <main id="main-content" class="page-layout grail-layout">
+      <section class="score-hud" aria-label="Current expedition status">
+        <div class="hud-tile hud-tile--score">
+          <h2 class="hud-title">Worthiness Score</h2>
+          <p class="hud-value hud-value--score" id="score-value">0</p>
+        </div>
+        <div class="hud-tile">
+          <span class="hud-label">Total Time</span>
+          <span class="hud-value" id="total-time">0.00s</span>
+        </div>
+        <div class="hud-tile">
+          <span class="hud-label">Failures</span>
+          <span class="hud-value" id="failure-count">0</span>
+        </div>
+        <div class="hud-tile hud-tile--high-score">
+          <span class="hud-label">High Score</span>
+          <span class="hud-value" data-high-score>—</span>
+        </div>
+        <div class="hud-tile">
+          <span class="hud-label">Trials Cleared</span>
+          <span class="hud-value" id="trials-cleared">0 / 3</span>
+        </div>
+      </section>
+      <section class="trial-section" id="trial-1" aria-labelledby="trial1-title">
+        <header class="trial-header">
+          <h2 id="trial1-title">Trial I · The Breath of God</h2>
+          <p>
+            The dust reveals the name for just a heartbeat. Watch the letters flare, then step across in the sacred order without
+            touching the false stones.
+          </p>
+        </header>
+        <div class="trial-body">
+          <div class="tile-grid" id="name-grid" role="grid" aria-label="Floor tiles of sacred letters"></div>
+          <div class="trial-controls">
+            <button type="button" class="action-button" id="trial1-start">Begin Chant</button>
+            <button type="button" class="action-button action-button--ghost" id="trial1-skip" disabled>
+              Skip Reveal
+            </button>
+          </div>
+          <p class="trial-status" id="trial1-status">Press Begin Chant to watch the inscription ignite.</p>
+        </div>
+      </section>
+      <section class="trial-section" id="trial-2" aria-labelledby="trial2-title" aria-live="polite">
+        <header class="trial-header">
+          <h2 id="trial2-title">Trial II · The Word of God</h2>
+          <p>
+            "Only the penitent man will pass." Kneel at the exact moment the blades cross to slide under the storm.
+            Mistime it and the temple answers with steel.
+          </p>
+        </header>
+        <div class="trial-body">
+          <div class="blade-hall" id="blade-hall" aria-hidden="true">
+            <div class="blade-track">
+              <div class="blade"></div>
+              <div class="blade blade--rear"></div>
+            </div>
+            <div class="kneeler" id="kneeler"></div>
+          </div>
+          <div class="trial-controls">
+            <button type="button" class="action-button" id="trial2-start" disabled>Ready Blades</button>
+            <button type="button" class="action-button action-button--danger" id="duck-button" disabled>Duck</button>
+          </div>
+          <p class="trial-status" id="trial2-status">Await the verdict from Trial I.</p>
+        </div>
+      </section>
+      <section class="trial-section" id="trial-3" aria-labelledby="trial3-title">
+        <header class="trial-header">
+          <h2 id="trial3-title">Trial III · The Path of God</h2>
+          <p>
+            The bridge is invisible and the abyss is patient. Fling holy dust to glimpse the safe stones, then stride forward
+            before they fade. Heavy throws reveal more ground but drain the satchel.
+          </p>
+        </header>
+        <div class="trial-body">
+          <div class="chasm" role="group" aria-label="Invisible bridge">
+            <div class="chasm-track" id="chasm-track"></div>
+            <div class="bridge-meter">
+              <span class="meter-label">Dust Remaining</span>
+              <span class="meter-value" id="dust-count">0</span>
+            </div>
+          </div>
+          <div class="trial-controls">
+            <button type="button" class="action-button action-button--ghost" id="light-toss" disabled>Light Toss</button>
+            <button type="button" class="action-button" id="heavy-toss" disabled>Heavy Toss</button>
+            <button type="button" class="action-button action-button--danger" id="advance-button" disabled>
+              Step Forward
+            </button>
+          </div>
+          <p class="trial-status" id="trial3-status">The bridge awaits the penitent.</p>
+        </div>
+      </section>
+      <section class="legend" aria-label="Trial timing details">
+        <h2 class="legend-title">Trial Clocks</h2>
+        <div class="legend-grid">
+          <article class="legend-card">
+            <h3>Breath of God</h3>
+            <p id="legend-trial1">0.00s · untouched</p>
+          </article>
+          <article class="legend-card">
+            <h3>Word of God</h3>
+            <p id="legend-trial2">0.00s · awaiting</p>
+          </article>
+          <article class="legend-card">
+            <h3>Path of God</h3>
+            <p id="legend-trial3">0.00s · awaiting</p>
+          </article>
+        </div>
+      </section>
+    </main>
+    <section class="wrapup" id="wrapup" hidden>
+      <div class="wrapup-backdrop" aria-hidden="true"></div>
+      <article class="wrapup-dialog" role="dialog" aria-modal="true" aria-labelledby="wrapup-title" tabindex="-1">
+        <header class="wrapup-header">
+          <p class="wrapup-eyebrow">Trials Complete</p>
+          <h2 id="wrapup-title">Final Worthiness</h2>
+          <p class="wrapup-subtitle" id="wrapup-subtitle"></p>
+        </header>
+        <dl class="wrapup-metrics">
+          <div>
+            <dt>Breath of God</dt>
+            <dd id="wrapup-trial1">0.00s</dd>
+          </div>
+          <div>
+            <dt>Word of God</dt>
+            <dd id="wrapup-trial2">0.00s</dd>
+          </div>
+          <div>
+            <dt>Path of God</dt>
+            <dd id="wrapup-trial3">0.00s</dd>
+          </div>
+          <div>
+            <dt>Total Time</dt>
+            <dd id="wrapup-total">0.00s</dd>
+          </div>
+          <div>
+            <dt>Dust Reserved</dt>
+            <dd id="wrapup-dust">0</dd>
+          </div>
+        </dl>
+        <p class="wrapup-score" id="wrapup-score">Worthiness Score: 0</p>
+        <div class="wrapup-actions">
+          <button type="button" class="action-button" id="wrapup-replay">Attempt Again</button>
+          <button type="button" class="action-button action-button--ghost" id="wrapup-close">Close</button>
+        </div>
+      </article>
+    </section>
+    <script type="module" src="./grail-trial.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/1989/score-config.js
+++ b/madia.new/public/secret/1989/score-config.js
@@ -419,6 +419,23 @@ export const scoreConfigs = {
     },
   }, // wild things
   // Level 16
+  // Level 15
+  "grail-trial": {
+    label: "Worthiness Score",
+    empty: "No worthiness recorded yet.",
+    format: ({ value, meta }) => {
+      const totalMs = Number.isFinite(meta?.totalTimeMs)
+        ? Number(meta.totalTimeMs)
+        : Number(meta?.totalTime ?? 0);
+      const totalSeconds = Math.max(0, totalMs) / 1000;
+      const failures = Number(meta?.failures ?? 0);
+      const dustRemaining = Number(meta?.dustRemaining ?? 0);
+      const timeLabel = `${totalSeconds.toFixed(2)}s`;
+      const failureLabel = failures === 1 ? "1 failure" : `${failures} failures`;
+      const dustLabel = dustRemaining === 1 ? "1 dust" : `${dustRemaining} dust`;
+      return `${value ?? 0} pts · ${timeLabel} · ${failureLabel} · ${dustLabel}`;
+    },
+  }, // Level 15
   "wind-beneath-my-wings": {
     label: "Applause Score",
     empty: "No applause recorded yet.",


### PR DESCRIPTION
## Summary
- add The Grail Trial cabinet with three sequential trials and atmospheric wrap-up
- register the new level in the arcade catalog and scoring configuration

## Testing
- node --check madia.new/public/secret/1989/grail-trial/grail-trial.js
- node --check madia.new/public/secret/1989/1989.js
- node --check madia.new/public/secret/1989/score-config.js

------
https://chatgpt.com/codex/tasks/task_e_68e052c7f91c832896678154eb1e69c3