### PR TITLE
Add LawnMower Labyrinth arcade cabinet

### DIFF
--- a/docs/1989/lawnmower-labyrinth.md
+++ b/docs/1989/lawnmower-labyrinth.md
@@ -1,0 +1,73 @@
+# Lawnmower Labyrinth Design Brief
+
+## Elevator Pitch
+Lawnmower Labyrinth is a top-down survival stealth game inspired by *Honey, I Shrunk the Kids*. Players, shrunk to ant-size, must cross a sprawling backyard while a relentless lawnmower patrols in a predictable sweep. The experience focuses on timing, environmental cover, and daring dashes to reach safety.
+
+## Gameplay Structure
+1. **Setup Phase**
+   - Session opens with the player character dropped into towering grass. The distant rumble of an engine primes the threat.
+   - Tutorial prompts introduce basic movement, dash controls, and the importance of cover before the mower begins its route.
+2. **Survival Phase**
+   - The lawnmower operates as a moving wall of instant death, tracing deliberate back-and-forth lanes across the yard.
+   - Players weave through environmental cover—grass clusters, toys, forgotten household objects—to stay out of sight and avoid the mower's path.
+   - Sprinting across exposed turf is faster but magnifies risk; the mower's route and audio cues telegraph safe windows.
+3. **Safe Zone Arrival**
+   - Reaching the tree-root "Safe Zone" ends the run and locks in survival time and bonus pickups.
+
+## Zone Progression
+- **Zone 1 – The Open Lawn**
+  - Pure mower avoidance in mostly flat terrain with sparse cover.
+  - Encourages players to learn mower cadence and line-of-sight rules.
+- **Zone 2 – Sprinkler Alley**
+  - Adds periodic sprinkler bursts that drop large water globes.
+  - Droplets linger briefly as area-of-effect hazards; getting hit staggers the player and risks mower overlap.
+- Future zones can escalate with new threats (e.g., roaming pets, falling acorns) while maintaining clear counterplay.
+
+## Core Mechanics
+- **Movement & Dash**
+  - Standard movement is stealthy but slow; the dash triples speed for a short burst while preventing quick turns.
+  - Dash has a brief cooldown displayed on the HUD.
+- **Cover System**
+  - Tall grass and objects block line of sight. Entering cover dampens footstep audio and slows proximity alert buildup.
+  - Camera subtly tilts to showcase occlusion and emphasize scale.
+- **Lawnmower AI**
+  - Follows a deterministic sweep route per zone with slight jitter to keep tension high.
+  - Emits positional audio (engine drone, blade whine) with dynamic volume and stereo panning.
+  - Screen shake intensity scales with proximity and mower speed.
+- **Sprinkler Hazards (Zone 2)**
+  - Sprinklers telegraph with rhythmic clicks before firing.
+  - Water impacts create slippery puddles that temporarily reduce traction.
+
+## Scoring & Risk/Reward
+- **Primary Metric: Survival Time**
+  - Timer starts once the mower activates and stops when the safe zone is reached or the player dies.
+- **Bonus Collectibles**
+  - Cookie crumbs, LEGO bricks, and shiny coins appear in exposed areas.
+  - Collecting items adds to a bonus multiplier that rewards daring routes.
+- **Stealth Grade**
+  - Optional grading system based on number of close calls, time spent detected, and dash usage.
+
+## Audio-Visual Direction
+- **Scale & Atmosphere**
+  - Grass blades tower like trees; depth-of-field blur accentuates miniature perspective.
+  - Ambient insect hum and distant house noises ground the world.
+- **Threat Feedback**
+  - Engine drone intensity drives the proximity alert color from green to yellow to red.
+  - Passing mower produces heavy motion blur, debris trails, and full-screen rumble.
+  - Capture events cut to black with a sharp metallic "SLICE!" and a stinger chord.
+- **Environmental Storytelling**
+  - Scattered objects (juice boxes, baseballs, bottle caps) hint at backyard life and provide varied cover silhouettes.
+
+## HUD & UX
+- Minimalist overlay featuring:
+  - Survival timer.
+  - Proximity alert ring pulsing faster and shifting from green to red as the mower nears.
+  - Dash cooldown indicator.
+  - Collectible counter and multiplier.
+- Run summary screen highlights survival time, collectibles, and notable moments (e.g., "3 Close Calls Survived").
+
+## Failure & Replay
+- Lawn mower contact results in immediate failure with a black screen cut and "SLICE!" audio cue.
+- Leaderboards encourage speedrunning and collectible mastery.
+- Daily challenges remix mower patterns and collectible placements to extend longevity.
+

--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -2259,6 +2259,56 @@ const games = [
       </svg>
     `,
   }, // Level 16
+  { // Level 15
+    id: "lawnmower-labyrinth",
+    name: "Lawnmower Labyrinth",
+    description: "Dash between grass cover, dodge sprinkler blasts, and reach the patio flag before the mower closes in.",
+    url: "./lawnmower-labyrinth/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Lawnmower Labyrinth preview">
+        <defs>
+          <linearGradient id="lmlawn" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(13,148,136,0.9)" />
+            <stop offset="100%" stop-color="rgba(15,118,110,0.85)" />
+          </linearGradient>
+          <linearGradient id="lmcover" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="rgba(45,212,191,0.45)" />
+            <stop offset="100%" stop-color="rgba(8,47,73,0.75)" />
+          </linearGradient>
+          <linearGradient id="lmmower" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="rgba(34,197,94,0.9)" />
+            <stop offset="100%" stop-color="rgba(249,115,22,0.9)" />
+          </linearGradient>
+        </defs>
+        <rect x="10" y="12" width="140" height="96" rx="20" fill="rgba(6,12,24,0.95)" stroke="rgba(148,163,184,0.35)" />
+        <rect x="20" y="22" width="120" height="76" rx="16" fill="url(#lmlawn)" stroke="rgba(14,165,233,0.25)" />
+        <g stroke="rgba(15,52,67,0.25)" stroke-width="2">
+          ${Array.from({ length: 5 }, (_, i) => `<line x1="${30 + i * 22}" y1="26" x2="${30 + i * 22}" y2="94" />`).join("")}
+          ${Array.from({ length: 3 }, (_, i) => `<line x1="26" y1="${40 + i * 18}" x2="138" y2="${40 + i * 18}" />`).join("")}
+        </g>
+        <g>
+          <rect x="28" y="34" width="26" height="20" rx="8" fill="url(#lmcover)" stroke="rgba(125,211,252,0.4)" />
+          <rect x="52" y="66" width="24" height="18" rx="7" fill="url(#lmcover)" stroke="rgba(125,211,252,0.35)" />
+          <rect x="96" y="50" width="22" height="16" rx="7" fill="rgba(59,130,246,0.25)" stroke="rgba(59,130,246,0.5)" />
+        </g>
+        <g>
+          <rect x="80" y="34" width="28" height="20" rx="6" fill="url(#lmmower)" stroke="rgba(248,250,252,0.5)" />
+          <rect x="86" y="28" width="16" height="8" rx="3" fill="rgba(15,23,42,0.85)" />
+          <circle cx="88" cy="56" r="4" fill="rgba(15,23,42,0.85)" />
+          <circle cx="100" cy="56" r="4" fill="rgba(15,23,42,0.85)" />
+        </g>
+        <g>
+          <circle cx="124" cy="40" r="9" fill="rgba(59,130,246,0.35)" stroke="rgba(191,219,254,0.6)" stroke-width="2" />
+          <path d="M124 31 L120 20" stroke="rgba(191,219,254,0.7)" stroke-width="2" stroke-linecap="round" />
+        </g>
+        <g>
+          <polygon points="130,82 138,78 140,88" fill="rgba(22,211,238,0.85)" stroke="rgba(14,165,233,0.7)" stroke-width="2" />
+          <path d="M130 88 L122 96" stroke="rgba(125,211,252,0.6)" stroke-width="3" stroke-linecap="round" />
+        </g>
+        <path d="M36 80 C48 84 60 88 74 90" fill="none" stroke="rgba(248,250,252,0.65)" stroke-width="3" stroke-dasharray="6 4" />
+      </svg>
+    `,
+  }, // Level 15
 ];
 
 const grid = document.getElementById("game-grid");

--- a/madia.new/public/secret/1989/lawnmower-labyrinth/index.html
+++ b/madia.new/public/secret/1989/lawnmower-labyrinth/index.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lawnmower Labyrinth</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="lawnmower-labyrinth.css" />
+  </head>
+  <body class="secret-annex-snes">
+    <a class="skip-link" href="#main-content">Skip to game</a>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 15 · 1989 Arcade</p>
+      <h1>Lawnmower Labyrinth</h1>
+      <p class="subtitle">
+        Shrunk to ant scale, you must weave through towering grass and sprinkler storms while a deafening mower sweeps the lawn
+        in lethal passes. Reach the patio flag before the blades do.
+      </p>
+    </header>
+    <main id="main-content" class="page-layout">
+      <section class="briefing" aria-labelledby="briefing-title">
+        <h2 id="briefing-title">Backyard Survival Briefing</h2>
+        <p>
+          The mower is already roaring. Its route zigzags across the backyard, leaving only brief windows to sprint between
+          cover. Tall grass hides you, open turf exposes you, and the sprinkler zone pulses with crushing droplets that drench
+          the path at set intervals. Study the cadence, then choose when to crawl and when to dash.
+        </p>
+        <ul class="callouts">
+          <li>
+            <strong>Proximity Alert:</strong> A HUD gauge pulses from green to red as the mower closes in. If it reaches you while
+            you are exposed, the run ends instantly.
+          </li>
+          <li>
+            <strong>Cover vs. Speed:</strong> Moving through tall grass keeps you concealed but slow. Triggering a mad dash covers
+            twice the distance but leaves you winded for a beat—plan dashes only when the mower&rsquo;s pass is clear.
+          </li>
+          <li>
+            <strong>Sprinkler Zone:</strong> Massive droplets bombard the final stretch. Watch the sprinkler timer and slip through
+            during its dry beat or you&rsquo;ll be knocked flat.
+          </li>
+          <li>
+            <strong>Bonus Crumbs:</strong> Risky cookie crumbs glitter in the open. Snagging them increases your score multiplier,
+            but you must brave the mower&rsquo;s line of sight to reach them.
+          </li>
+        </ul>
+        <p>
+          Reach the Safe Zone flag as fast as possible. Your best survival time locks into the 1989 leaderboard, with crumb
+          pickups adding a sweet kicker. A failed run slams to black with a final slice, so listen for the engine, trust the
+          proximity meter, and keep moving.
+        </p>
+      </section>
+      <section class="cabinet" aria-labelledby="cabinet-title">
+        <div class="cabinet-header">
+          <h2 id="cabinet-title">Backyard Navigation Console</h2>
+          <div class="cabinet-controls">
+            <button type="button" class="action-button" id="start-run">Start Run</button>
+            <button type="button" class="action-button" id="reset-run">Reset</button>
+          </div>
+        </div>
+        <p class="cabinet-help">
+          Use the directional controls or arrow keys to move. Tap <strong>Mad Dash</strong> to bolt two tiles at once (short
+          cooldown). Hide in tall grass to break line of sight, and pause on <strong>Hold Position</strong> to let the mower pass
+          safely.
+        </p>
+        <section class="hud" aria-label="Run status">
+          <div class="hud-block">
+            <h3>Survival Time</h3>
+            <p class="hud-value" id="survival-time">00.00s</p>
+          </div>
+          <div class="hud-block">
+            <h3>Proximity Alert</h3>
+            <div class="proximity-meter" aria-hidden="true">
+              <div class="proximity-fill" id="proximity-fill"></div>
+            </div>
+            <p class="hud-note" id="proximity-note">Mower idle</p>
+          </div>
+          <div class="hud-block">
+            <h3>Sprinkler Cycle</h3>
+            <p class="hud-value" id="sprinkler-timer">Dry window</p>
+          </div>
+          <div class="hud-block">
+            <h3>Crumbs Collected</h3>
+            <p class="hud-value" id="crumb-count">0</p>
+          </div>
+        </section>
+        <div class="board-wrapper">
+          <div
+            class="board"
+            id="game-board"
+            role="grid"
+            aria-label="Backyard grid"
+            aria-describedby="board-legend"
+          ></div>
+          <aside class="legend" id="board-legend">
+            <h3>Legend</h3>
+            <ul>
+              <li><span class="legend-swatch is-player"></span> Player</li>
+              <li><span class="legend-swatch is-cover"></span> Tall grass cover</li>
+              <li><span class="legend-swatch is-open"></span> Fresh-cut lawn</li>
+              <li><span class="legend-swatch is-object"></span> Yard obstacle</li>
+              <li><span class="legend-swatch is-sprinkler"></span> Sprinkler zone</li>
+              <li><span class="legend-swatch is-crumb"></span> Bonus crumb</li>
+              <li><span class="legend-swatch is-safe"></span> Safe Zone flag</li>
+              <li><span class="legend-swatch is-mower"></span> Mower sweep</li>
+            </ul>
+          </aside>
+        </div>
+        <section class="control-panel" aria-label="Movement controls">
+          <div class="directional">
+            <button type="button" class="control-button" data-move="up" aria-label="Move up">▲</button>
+            <button type="button" class="control-button" data-move="left" aria-label="Move left">◀</button>
+            <button type="button" class="control-button" data-move="right" aria-label="Move right">▶</button>
+            <button type="button" class="control-button" data-move="down" aria-label="Move down">▼</button>
+          </div>
+          <div class="support-controls">
+            <button type="button" class="action-button" id="dash-button">Mad Dash</button>
+            <button type="button" class="action-button" id="wait-button">Hold Position</button>
+          </div>
+        </section>
+        <section class="session-status" aria-live="polite" id="session-status">
+          Engine rumble on standby. Start the run to engage the mower.
+        </section>
+        <section class="log-panel" aria-labelledby="log-title">
+          <div class="log-header">
+            <h3 id="log-title">Field Log</h3>
+            <button type="button" class="action-button" id="clear-log">Clear Log</button>
+          </div>
+          <ol class="log-entries" id="event-log"></ol>
+        </section>
+        <section class="wrap-up" id="wrap-up" hidden>
+          <h3>Run Summary</h3>
+          <p id="wrap-up-text"></p>
+          <p class="wrap-up-note">Replay to chase a faster time and log a better survival score.</p>
+          <button type="button" class="action-button" id="replay-button">Run Again</button>
+        </section>
+      </section>
+    </main>
+    <footer class="page-footer">
+      <p>Stay low, count the passes, and sprint only when the mower line clears. The leaderboard waits for your clean escape.</p>
+    </footer>
+    <script type="module" src="lawnmower-labyrinth.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/1989/lawnmower-labyrinth/lawnmower-labyrinth.css
+++ b/madia.new/public/secret/1989/lawnmower-labyrinth/lawnmower-labyrinth.css
@@ -1,0 +1,439 @@
+:root {
+  --mower-green: #16a34a;
+  --mower-red: #f97316;
+  --cover-green: #166534;
+  --open-lawn: rgba(148, 163, 184, 0.25);
+  --object-blue: rgba(56, 189, 248, 0.2);
+  --sprinkler-blue: rgba(59, 130, 246, 0.18);
+  --crumb-gold: #fbbf24;
+  --safe-flag: #22d3ee;
+}
+
+.cabinet {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.cabinet-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.cabinet-controls {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.cabinet-help {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.hud {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.hud-block {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.2);
+}
+
+.hud h3 {
+  margin: 0 0 0.25rem;
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.hud-value {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+  color: #f8fafc;
+}
+
+.hud-note {
+  margin: 0.5rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.proximity-meter {
+  width: 100%;
+  height: 0.6rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.85);
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.proximity-fill {
+  width: 10%;
+  height: 100%;
+  background: linear-gradient(90deg, #22c55e, #facc15, #ef4444);
+  transform-origin: left center;
+  transition: width 120ms ease-out;
+}
+
+.board-wrapper {
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) 200px;
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.board {
+  position: relative;
+  display: grid;
+  gap: 0.25rem;
+  background: rgba(8, 12, 24, 0.9);
+  padding: 0.75rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.4);
+}
+
+.board-cell {
+  width: 46px;
+  height: 46px;
+  border-radius: 0.6rem;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(248, 250, 252, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: var(--open-lawn);
+  transition: transform 80ms ease-out, box-shadow 120ms ease-out;
+  overflow: hidden;
+}
+
+.board-cell[data-type="cover"] {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.4), rgba(2, 44, 34, 0.9));
+  border-color: rgba(45, 212, 191, 0.35);
+}
+
+.board-cell[data-type="object"] {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.4), rgba(30, 64, 175, 0.8));
+  border-color: rgba(191, 219, 254, 0.5);
+}
+
+.board-cell[data-type="sprinkler"] {
+  background: linear-gradient(135deg, rgba(30, 64, 175, 0.35), rgba(59, 130, 246, 0.55));
+  border-color: rgba(129, 140, 248, 0.6);
+}
+
+.board-cell[data-type="start"] {
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.35), rgba(3, 105, 161, 0.8));
+}
+
+.board-cell[data-type="safe"] {
+  background: linear-gradient(135deg, rgba(20, 184, 166, 0.45), rgba(22, 163, 74, 0.9));
+  border-color: rgba(45, 212, 191, 0.6);
+}
+
+.board-cell[data-sprinkler-active="true"] .sprinkler-overlay {
+  opacity: 1;
+  animation: droplet 320ms ease-in-out infinite alternate;
+}
+
+@keyframes droplet {
+  from {
+    opacity: 0.8;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 0.3;
+    transform: scale(1.05);
+  }
+}
+
+.board-cell[data-crumb="true"]::before {
+  content: "•";
+  position: absolute;
+  font-size: 1.6rem;
+  color: var(--crumb-gold);
+  filter: drop-shadow(0 0 6px rgba(251, 191, 36, 0.75));
+}
+.player-marker,
+.mower-marker,
+.sprinkler-overlay {
+  position: absolute;
+  inset: 4px;
+  border-radius: 0.55rem;
+  pointer-events: none;
+  transition: opacity 120ms ease-out, transform 120ms ease-out;
+}
+
+.player-marker {
+  background: linear-gradient(135deg, rgba(34, 211, 238, 0.9), rgba(59, 130, 246, 0.9));
+  box-shadow: 0 0 12px rgba(59, 130, 246, 0.6);
+  opacity: 0;
+}
+
+.board-cell[data-player="true"] .player-marker {
+  opacity: 1;
+  transform: scale(1.02);
+}
+
+.mower-marker {
+  background: linear-gradient(135deg, rgba(22, 163, 74, 0.95), rgba(249, 115, 22, 0.95));
+  box-shadow: 0 0 16px rgba(249, 115, 22, 0.75);
+  opacity: 0;
+}
+
+.board-cell[data-mower="true"] .mower-marker {
+  opacity: 1;
+  transform: scale(1.05);
+}
+
+.sprinkler-overlay {
+  background: rgba(59, 130, 246, 0.35);
+  opacity: 0;
+}
+
+.legend {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 1rem;
+}
+
+.legend h3 {
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.legend ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.legend-swatch {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  margin-right: 0.5rem;
+  border-radius: 0.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.legend-swatch.is-player {
+  background: linear-gradient(135deg, rgba(34, 211, 238, 0.9), rgba(59, 130, 246, 0.9));
+}
+
+.legend-swatch.is-cover {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.4), rgba(2, 44, 34, 0.9));
+}
+
+.legend-swatch.is-open {
+  background: var(--open-lawn);
+}
+
+.legend-swatch.is-object {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.4), rgba(30, 64, 175, 0.8));
+}
+
+.legend-swatch.is-sprinkler {
+  background: linear-gradient(135deg, rgba(30, 64, 175, 0.35), rgba(59, 130, 246, 0.55));
+}
+
+.legend-swatch.is-crumb {
+  background: linear-gradient(135deg, #facc15, #f97316);
+}
+
+.legend-swatch.is-safe {
+  background: linear-gradient(135deg, rgba(20, 184, 166, 0.45), rgba(22, 163, 74, 0.9));
+}
+
+.legend-swatch.is-mower {
+  background: linear-gradient(135deg, rgba(22, 163, 74, 0.95), rgba(249, 115, 22, 0.95));
+}
+
+.control-panel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.directional {
+  display: grid;
+  grid-template-columns: repeat(3, 56px);
+  grid-template-rows: repeat(3, 56px);
+  gap: 0.5rem;
+  justify-content: center;
+  align-content: center;
+}
+
+.directional .control-button {
+  width: 56px;
+  height: 56px;
+  font-size: 1.3rem;
+  border-radius: 0.75rem;
+}
+
+.directional [data-move="up"] {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.directional [data-move="left"] {
+  grid-column: 1;
+  grid-row: 2;
+}
+
+.directional [data-move="right"] {
+  grid-column: 3;
+  grid-row: 2;
+}
+
+.directional [data-move="down"] {
+  grid-column: 2;
+  grid-row: 3;
+}
+
+.support-controls {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.control-button {
+  background: rgba(15, 23, 42, 0.8);
+  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 0.5rem;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.45);
+  transition: transform 80ms ease-out, box-shadow 120ms ease-out, background 120ms ease-out;
+}
+
+.control-button:hover,
+.control-button:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 14px rgba(15, 23, 42, 0.45);
+  outline: none;
+}
+
+.control-button:active {
+  transform: translateY(1px) scale(0.98);
+}
+
+.session-status {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  min-height: 3rem;
+}
+
+.session-status[data-tone="success"] {
+  border-color: rgba(74, 222, 128, 0.6);
+  color: #4ade80;
+}
+
+.session-status[data-tone="warning"] {
+  border-color: rgba(250, 204, 21, 0.6);
+  color: #facc15;
+}
+
+.session-status[data-tone="danger"] {
+  border-color: rgba(248, 113, 113, 0.6);
+  color: #f87171;
+}
+
+.log-panel {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1rem;
+  padding: 1rem;
+}
+
+.log-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.log-entries {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.5rem;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.log-entries li {
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.log-entries li[data-tone="success"] {
+  color: #4ade80;
+}
+
+.log-entries li[data-tone="warning"] {
+  color: #facc15;
+}
+
+.log-entries li[data-tone="danger"] {
+  color: #f87171;
+}
+
+.wrap-up {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.wrap-up h3 {
+  margin: 0;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.wrap-up p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+@media (max-width: 960px) {
+  .board-wrapper {
+    grid-template-columns: 1fr;
+  }
+
+  .legend {
+    order: -1;
+  }
+}
+
+@media (max-width: 720px) {
+  .board {
+    justify-items: center;
+  }
+
+  .board-cell {
+    width: 42px;
+    height: 42px;
+  }
+}

--- a/madia.new/public/secret/1989/lawnmower-labyrinth/lawnmower-labyrinth.js
+++ b/madia.new/public/secret/1989/lawnmower-labyrinth/lawnmower-labyrinth.js
@@ -1,0 +1,679 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+import { mountParticleField } from "../particles.js";
+import { autoEnhanceFeedback } from "../feedback.js";
+
+const particleField = mountParticleField({
+  effects: {
+    palette: ["#38bdf8", "#22c55e", "#f97316", "#facc15"],
+    ambientDensity: 0.5,
+  },
+});
+
+autoEnhanceFeedback();
+
+const scoreConfig = getScoreConfig("lawnmower-labyrinth");
+const highScore = initHighScoreBanner({
+  gameId: "lawnmower-labyrinth",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
+const layout = [
+  "CCPPPPPPPPPF",
+  "C.CPPPPBPPPP",
+  "C.CCOOPPPPPP",
+  "C.OOC.PBPPPP",
+  "C...C.P.PPPP",
+  "S..CCC...PP.",
+  "C.CCC...CPP.",
+  "C.....C..PP.",
+];
+
+const GRID_ROWS = layout.length;
+const GRID_COLS = layout[0].length;
+const MAX_PROXIMITY_DISTANCE = GRID_ROWS + GRID_COLS;
+const STEP_COOLDOWN_MS = 220;
+const DASH_COOLDOWN_MS = 2400;
+const DASH_STUN_MS = 620;
+const MOWER_STEP_MS = 420;
+const START_DELAY_MS = 1600;
+const SPRINKLER_CYCLE_MS = 5200;
+const SPRINKLER_ACTIVE_MS = 2000;
+const HOLD_COOLDOWN_MS = 300;
+
+const SYMBOL_MAP = {
+  C: { type: "cover", passable: true, cover: true },
+  ".": { type: "open", passable: true, cover: false },
+  O: { type: "object", passable: true, cover: true },
+  P: { type: "sprinkler", passable: true, cover: false, sprinkler: true },
+  S: { type: "start", passable: true, cover: true },
+  F: { type: "safe", passable: true, cover: false },
+  B: { type: "open", passable: true, cover: false, crumb: true },
+};
+
+const boardEl = document.getElementById("game-board");
+const survivalTimeEl = document.getElementById("survival-time");
+const sprinklerTimerEl = document.getElementById("sprinkler-timer");
+const crumbCountEl = document.getElementById("crumb-count");
+const proximityFillEl = document.getElementById("proximity-fill");
+const proximityNoteEl = document.getElementById("proximity-note");
+const sessionStatusEl = document.getElementById("session-status");
+const startButton = document.getElementById("start-run");
+const resetButton = document.getElementById("reset-run");
+const dashButton = document.getElementById("dash-button");
+const waitButton = document.getElementById("wait-button");
+const controlButtons = Array.from(document.querySelectorAll("[data-move]"));
+const clearLogButton = document.getElementById("clear-log");
+const eventLog = document.getElementById("event-log");
+const wrapUp = document.getElementById("wrap-up");
+const wrapUpText = document.getElementById("wrap-up-text");
+const replayButton = document.getElementById("replay-button");
+
+boardEl.style.gridTemplateColumns = `repeat(${GRID_COLS}, 46px)`;
+
+const tiles = [];
+const sprinklerCells = [];
+const crumbOrigins = new Set();
+let startPosition = { x: 0, y: 0 };
+
+for (let rowIndex = 0; rowIndex < GRID_ROWS; rowIndex += 1) {
+  const rowTiles = [];
+  const rowString = layout[rowIndex];
+  for (let colIndex = 0; colIndex < GRID_COLS; colIndex += 1) {
+    const symbol = rowString[colIndex];
+    const definition = SYMBOL_MAP[symbol] ?? SYMBOL_MAP["."];
+    const tile = {
+      x: colIndex,
+      y: rowIndex,
+      type: definition.type,
+      passable: definition.passable,
+      cover: Boolean(definition.cover),
+      sprinkler: Boolean(definition.sprinkler),
+      crumb: Boolean(definition.crumb),
+    };
+    const cell = document.createElement("div");
+    cell.className = "board-cell";
+    cell.dataset.type = tile.type;
+    cell.dataset.player = "false";
+    cell.dataset.mower = "false";
+    cell.dataset.crumb = tile.crumb ? "true" : "false";
+    if (tile.sprinkler) {
+      sprinklerCells.push(cell);
+    }
+    const playerMarker = document.createElement("div");
+    playerMarker.className = "player-marker";
+    const mowerMarker = document.createElement("div");
+    mowerMarker.className = "mower-marker";
+    const sprinklerOverlay = document.createElement("div");
+    sprinklerOverlay.className = "sprinkler-overlay";
+    cell.append(playerMarker, mowerMarker, sprinklerOverlay);
+    boardEl.appendChild(cell);
+    tile.cell = cell;
+    rowTiles.push(tile);
+
+    if (tile.type === "start") {
+      startPosition = { x: colIndex, y: rowIndex };
+    }
+    if (tile.crumb) {
+      crumbOrigins.add(keyFrom(colIndex, rowIndex));
+    }
+  }
+  tiles.push(rowTiles);
+}
+
+const mowerRoute = buildMowerRoute();
+
+const state = {
+  running: false,
+  ended: false,
+  timeMs: 0,
+  moveCooldown: 0,
+  dashCooldown: 0,
+  mowerDelay: START_DELAY_MS,
+  mowerIndex: 0,
+  mowerPos: { ...mowerRoute[0] },
+  playerPos: { ...startPosition },
+  sprinklerTimer: 0,
+  collectedCrumbs: new Set(),
+  lastDirection: { dx: 1, dy: 0 },
+  pendingAnimation: null,
+  lastFrame: null,
+  mowerProgress: 0,
+  logs: [],
+};
+
+placePlayer();
+placeMower();
+resetSprinklerCells(false);
+updateHud();
+
+startButton.addEventListener("click", () => {
+  if (state.running) {
+    setSessionStatus("Run already active. Keep moving!", "warning");
+    return;
+  }
+  beginRun();
+});
+
+resetButton.addEventListener("click", () => {
+  resetRun();
+});
+
+replayButton.addEventListener("click", () => {
+  resetRun();
+  beginRun();
+});
+
+dashButton.addEventListener("click", () => {
+  performDash();
+});
+
+waitButton.addEventListener("click", () => {
+  holdPosition();
+});
+
+controlButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    const direction = button.dataset.move;
+    const vector = getDirectionVector(direction);
+    if (!vector) {
+      return;
+    }
+    attemptMove(vector.dx, vector.dy);
+  });
+});
+
+clearLogButton.addEventListener("click", () => {
+  state.logs = [];
+  renderLog();
+  setSessionStatus("Log cleared. Sensors recalibrated.");
+});
+
+window.addEventListener("keydown", (event) => {
+  if (event.defaultPrevented) {
+    return;
+  }
+  const target = event.target;
+  if (target && target.closest && target.closest("input, textarea, select")) {
+    return;
+  }
+  const vector = getDirectionVector(event.key);
+  if (vector) {
+    event.preventDefault();
+    attemptMove(vector.dx, vector.dy);
+    return;
+  }
+  if (event.key === " ") {
+    event.preventDefault();
+    holdPosition();
+  }
+  if (event.key === "Shift") {
+    event.preventDefault();
+    performDash();
+  }
+});
+
+function beginRun() {
+  resetRun({ preserveLog: true });
+  state.running = true;
+  state.ended = false;
+  state.timeMs = 0;
+  state.moveCooldown = 0;
+  state.dashCooldown = 0;
+  state.mowerDelay = START_DELAY_MS;
+  state.mowerIndex = 0;
+  state.mowerPos = { ...mowerRoute[0] };
+  state.sprinklerTimer = 0;
+  state.mowerProgress = 0;
+  state.lastFrame = null;
+  state.pendingAnimation = requestAnimationFrame(step);
+  setSessionStatus("Run live. Track the mower and move with intent.", "success");
+  addLog("Engine ignites. First pass sweeping the top row.", "info");
+  startButton.disabled = true;
+  dashButton.disabled = false;
+  waitButton.disabled = false;
+  controlButtons.forEach((button) => {
+    button.disabled = false;
+  });
+  wrapUp.hidden = true;
+  placeMower();
+}
+
+function resetRun({ preserveLog = false } = {}) {
+  if (state.pendingAnimation) {
+    cancelAnimationFrame(state.pendingAnimation);
+    state.pendingAnimation = null;
+  }
+  state.running = false;
+  state.ended = false;
+  state.timeMs = 0;
+  state.moveCooldown = 0;
+  state.dashCooldown = 0;
+  state.mowerDelay = START_DELAY_MS;
+  state.mowerIndex = 0;
+  state.mowerPos = { ...mowerRoute[0] };
+  state.playerPos = { ...startPosition };
+  state.sprinklerTimer = 0;
+  state.collectedCrumbs = new Set();
+  state.lastDirection = { dx: 1, dy: 0 };
+  state.mowerProgress = 0;
+  state.lastFrame = null;
+  if (!preserveLog) {
+    state.logs = [];
+    renderLog();
+  }
+  crumbOrigins.forEach((key) => {
+    const [x, y] = key.split(",").map(Number);
+    const tile = tiles[y]?.[x];
+    if (tile) {
+      tile.crumb = true;
+      tile.cell.dataset.crumb = "true";
+    }
+  });
+  startButton.disabled = false;
+  dashButton.disabled = true;
+  waitButton.disabled = true;
+  controlButtons.forEach((button) => {
+    button.disabled = true;
+  });
+  wrapUp.hidden = true;
+  placePlayer();
+  placeMower();
+  resetSprinklerCells(false);
+  updateHud();
+  sprinklerTimerEl.textContent = "Dry window";
+  setSessionStatus("Engine rumble on standby. Start the run to engage the mower.");
+}
+
+function step(timestamp) {
+  if (!state.running) {
+    return;
+  }
+  if (!state.lastFrame) {
+    state.lastFrame = timestamp;
+  }
+  const delta = timestamp - state.lastFrame;
+  state.lastFrame = timestamp;
+  state.timeMs += delta;
+  state.moveCooldown = Math.max(0, state.moveCooldown - delta);
+  state.dashCooldown = Math.max(0, state.dashCooldown - delta);
+  state.sprinklerTimer += delta;
+  updateSprinklerCycle();
+  updateMower(delta);
+  updateHud();
+  if (!state.ended) {
+    checkHazards();
+  }
+  if (state.running) {
+    state.pendingAnimation = requestAnimationFrame(step);
+  }
+}
+
+function updateMower(delta) {
+  if (state.mowerDelay > 0) {
+    state.mowerDelay = Math.max(0, state.mowerDelay - delta);
+    return;
+  }
+  state.mowerProgress = (state.mowerProgress ?? 0) + delta;
+  if (state.mowerProgress < MOWER_STEP_MS) {
+    return;
+  }
+  state.mowerProgress -= MOWER_STEP_MS;
+  const previous = state.mowerPos;
+  state.mowerIndex = (state.mowerIndex + 1) % mowerRoute.length;
+  state.mowerPos = { ...mowerRoute[state.mowerIndex] };
+  placeMower();
+  if (previous.y !== state.mowerPos.y) {
+    addLog(`Mower drops to row ${state.mowerPos.y + 1}.`, "warning");
+  }
+}
+
+function updateSprinklerCycle() {
+  const cycle = state.sprinklerTimer % SPRINKLER_CYCLE_MS;
+  const active = cycle < SPRINKLER_ACTIVE_MS;
+  resetSprinklerCells(active);
+  if (active) {
+    const remaining = Math.max(0, SPRINKLER_ACTIVE_MS - cycle);
+    sprinklerTimerEl.textContent = `Impact! ${formatSeconds(remaining)}s`;
+  } else {
+    const until = Math.max(0, SPRINKLER_CYCLE_MS - cycle);
+    sprinklerTimerEl.textContent = `Next burst ${formatSeconds(until)}s`;
+  }
+}
+
+function resetSprinklerCells(active) {
+  sprinklerCells.forEach((cell) => {
+    cell.dataset.sprinklerActive = active ? "true" : "false";
+  });
+}
+
+function updateHud() {
+  survivalTimeEl.textContent = `${formatSeconds(state.timeMs)}s`;
+  crumbCountEl.textContent = `${state.collectedCrumbs.size}`;
+  updateProximity();
+}
+
+function updateProximity() {
+  const distance = manhattan(state.playerPos, state.mowerPos);
+  const ratio = 1 - Math.min(distance, MAX_PROXIMITY_DISTANCE) / MAX_PROXIMITY_DISTANCE;
+  proximityFillEl.style.width = `${Math.max(8, Math.round(ratio * 100))}%`;
+  if (distance >= 8) {
+    proximityNoteEl.textContent = "Mower distant";
+  } else if (distance >= 5) {
+    proximityNoteEl.textContent = "Engine hum rising";
+  } else if (distance >= 3) {
+    proximityNoteEl.textContent = "Close pass incoming";
+  } else if (distance >= 1) {
+    proximityNoteEl.textContent = "Blades at your flank";
+  } else {
+    proximityNoteEl.textContent = "On top of you";
+  }
+}
+
+function attemptMove(dx, dy) {
+  if (!state.running) {
+    setSessionStatus("Start the run before moving.", "warning");
+    return;
+  }
+  if (state.moveCooldown > 0) {
+    setSessionStatus("You need a beat before your next move.", "warning");
+    return;
+  }
+  if (dx === 0 && dy === 0) {
+    return;
+  }
+  const moved = performStep(dx, dy);
+  if (moved) {
+    state.moveCooldown = STEP_COOLDOWN_MS;
+    state.lastDirection = { dx, dy };
+  }
+}
+
+function performStep(dx, dy) {
+  const next = { x: state.playerPos.x + dx, y: state.playerPos.y + dy };
+  if (!isInside(next)) {
+    setSessionStatus("That path leads off the lawn.", "warning");
+    return false;
+  }
+  const tile = getTile(next);
+  if (!tile.passable) {
+    setSessionStatus("Obstacle blocks that route.", "warning");
+    return false;
+  }
+  state.playerPos = next;
+  placePlayer();
+  postMoveEffects(tile);
+  return true;
+}
+
+function performDash() {
+  if (!state.running) {
+    setSessionStatus("Start the run before dashing.", "warning");
+    return;
+  }
+  if (state.dashCooldown > 0) {
+    setSessionStatus("Dash cooling down. Keep to cover.", "warning");
+    return;
+  }
+  const { dx, dy } = state.lastDirection;
+  if (dx === 0 && dy === 0) {
+    setSessionStatus("Pick a direction before dashing.", "warning");
+    return;
+  }
+  let steps = 0;
+  for (let i = 0; i < 2; i += 1) {
+    if (!performStep(dx, dy)) {
+      if (steps === 0) {
+        addLog("Dash aborted against an obstacle.", "warning");
+      }
+      break;
+    }
+    steps += 1;
+    if (state.ended) {
+      break;
+    }
+  }
+  if (steps > 0) {
+    state.dashCooldown = DASH_COOLDOWN_MS;
+    state.moveCooldown = DASH_STUN_MS;
+    setSessionStatus(`Mad dash executed (${steps} tiles). Catch your breath!`, "success");
+    addLog(`Mad dash covered ${steps} tile${steps === 1 ? "" : "s"}.`, "success");
+  }
+}
+
+function holdPosition() {
+  if (!state.running) {
+    setSessionStatus("Start the run to hold position.", "warning");
+    return;
+  }
+  state.moveCooldown = HOLD_COOLDOWN_MS;
+  setSessionStatus("You hunker down and let the mower pass.", "success");
+  addLog("Holding position—staying low behind cover.", "info");
+  if (!getTile(state.playerPos).cover) {
+    addLog("Exposed on open turf. Find cover soon!", "warning");
+  }
+}
+
+function postMoveEffects(tile) {
+  setSessionStatus(`Moved to row ${state.playerPos.y + 1}, column ${state.playerPos.x + 1}.`);
+  if (tile.crumb && !state.collectedCrumbs.has(keyFrom(tile.x, tile.y))) {
+    state.collectedCrumbs.add(keyFrom(tile.x, tile.y));
+    tile.crumb = false;
+    tile.cell.dataset.crumb = "false";
+    addLog("Snagged a crumb bonus in the open!", "success");
+  }
+  if (tile.sprinkler && state.sprinklerTimer % SPRINKLER_CYCLE_MS < SPRINKLER_ACTIVE_MS) {
+    failRun("Sprinkler droplet slams you off the turf.");
+    return;
+  }
+  if (tile.type === "safe") {
+    completeRun();
+    return;
+  }
+  updateHud();
+}
+
+function checkHazards() {
+  const currentTile = getTile(state.playerPos);
+  if (state.playerPos.x === state.mowerPos.x && state.playerPos.y === state.mowerPos.y) {
+    failRun("The mower barrels over you. SLICE!");
+    return;
+  }
+  if (!currentTile.cover) {
+    const direct = manhattan(state.playerPos, state.mowerPos);
+    if (direct <= 1) {
+      failRun("Caught in the open as the mower roars by.");
+      return;
+    }
+    if (sharesLineOfSight(state.playerPos, state.mowerPos)) {
+      failRun("Line of sight exposed you to the mower blades.");
+      return;
+    }
+  }
+  if (currentTile.sprinkler && state.sprinklerTimer % SPRINKLER_CYCLE_MS < SPRINKLER_ACTIVE_MS) {
+    failRun("Sprinkler droplet slams you off the turf.");
+  }
+}
+
+function completeRun() {
+  if (!state.running || state.ended) {
+    return;
+  }
+  state.running = false;
+  state.ended = true;
+  if (state.pendingAnimation) {
+    cancelAnimationFrame(state.pendingAnimation);
+    state.pendingAnimation = null;
+  }
+  state.lastFrame = null;
+  startButton.disabled = false;
+  dashButton.disabled = true;
+  waitButton.disabled = true;
+  controlButtons.forEach((button) => {
+    button.disabled = true;
+  });
+  const finalTime = state.timeMs;
+  const crumbBonus = state.collectedCrumbs.size * 5000;
+  const scoreValue = Math.max(0, 1000000 - Math.round(finalTime)) + crumbBonus;
+  const meta = {
+    survivalTimeMs: Math.round(finalTime),
+    crumbs: state.collectedCrumbs.size,
+    display: `${formatSeconds(finalTime)}s · crumbs ${state.collectedCrumbs.size}`,
+  };
+  highScore.submit(scoreValue, meta);
+  wrapUp.hidden = false;
+  wrapUpText.textContent = `Safe Zone reached in ${formatSeconds(finalTime)}s with ${state.collectedCrumbs.size} crumb${
+    state.collectedCrumbs.size === 1 ? "" : "s"
+  } banked.`;
+  setSessionStatus("Safe Zone reached!", "success");
+  addLog("You dive beneath the patio flag—run secured!", "success");
+  particleField?.trigger?.({ intensity: 0.7 });
+}
+
+function failRun(message) {
+  if (!state.running || state.ended) {
+    return;
+  }
+  state.running = false;
+  state.ended = true;
+  if (state.pendingAnimation) {
+    cancelAnimationFrame(state.pendingAnimation);
+    state.pendingAnimation = null;
+  }
+  state.lastFrame = null;
+  startButton.disabled = false;
+  dashButton.disabled = true;
+  waitButton.disabled = true;
+  controlButtons.forEach((button) => {
+    button.disabled = true;
+  });
+  wrapUp.hidden = false;
+  wrapUpText.textContent = `${message} Try again for a faster time.`;
+  setSessionStatus(message, "danger");
+  addLog(message, "danger");
+  particleField?.trigger?.({ mode: "burst", intensity: 0.3 });
+}
+
+function placePlayer() {
+  tiles.forEach((row) => {
+    row.forEach((tile) => {
+      tile.cell.dataset.player = tile.x === state.playerPos.x && tile.y === state.playerPos.y ? "true" : "false";
+    });
+  });
+}
+
+function placeMower() {
+  tiles.forEach((row) => {
+    row.forEach((tile) => {
+      tile.cell.dataset.mower = tile.x === state.mowerPos.x && tile.y === state.mowerPos.y ? "true" : "false";
+    });
+  });
+}
+
+function getTile(position) {
+  return tiles[position.y]?.[position.x];
+}
+
+function isInside(position) {
+  return position.x >= 0 && position.x < GRID_COLS && position.y >= 0 && position.y < GRID_ROWS;
+}
+
+function manhattan(a, b) {
+  return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+}
+
+function sharesLineOfSight(a, b) {
+  if (a.x === b.x) {
+    const start = Math.min(a.y, b.y) + 1;
+    const end = Math.max(a.y, b.y);
+    for (let y = start; y < end; y += 1) {
+      if (tiles[y]?.[a.x]?.cover) {
+        return false;
+      }
+    }
+    return true;
+  }
+  if (a.y === b.y) {
+    const start = Math.min(a.x, b.x) + 1;
+    const end = Math.max(a.x, b.x);
+    for (let x = start; x < end; x += 1) {
+      if (tiles[a.y]?.[x]?.cover) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+function addLog(message, tone = "info") {
+  state.logs.unshift({ message, tone, id: crypto.randomUUID() });
+  renderLog();
+}
+
+function renderLog() {
+  eventLog.innerHTML = "";
+  state.logs.slice(0, 12).forEach((entry) => {
+    const item = document.createElement("li");
+    item.textContent = entry.message;
+    item.dataset.tone = entry.tone;
+    eventLog.appendChild(item);
+  });
+}
+
+function setSessionStatus(message, tone = "info") {
+  sessionStatusEl.textContent = message;
+  if (tone === "info") {
+    sessionStatusEl.removeAttribute("data-tone");
+  } else {
+    sessionStatusEl.dataset.tone = tone;
+  }
+}
+
+function buildMowerRoute() {
+  const route = [];
+  for (let y = 0; y < GRID_ROWS; y += 1) {
+    if (y % 2 === 0) {
+      for (let x = 0; x < GRID_COLS; x += 1) {
+        route.push({ x, y });
+      }
+    } else {
+      for (let x = GRID_COLS - 1; x >= 0; x -= 1) {
+        route.push({ x, y });
+      }
+    }
+  }
+  return route;
+}
+
+function getDirectionVector(key) {
+  switch (key) {
+    case "ArrowUp":
+    case "up":
+      return { dx: 0, dy: -1 };
+    case "ArrowDown":
+    case "down":
+      return { dx: 0, dy: 1 };
+    case "ArrowLeft":
+    case "left":
+      return { dx: -1, dy: 0 };
+    case "ArrowRight":
+    case "right":
+      return { dx: 1, dy: 0 };
+    default:
+      return null;
+  }
+}
+
+function formatSeconds(milliseconds) {
+  const seconds = Math.max(0, milliseconds) / 1000;
+  return seconds.toFixed(2);
+}
+
+function keyFrom(x, y) {
+  return `${x},${y}`;
+}
+
+resetRun();

--- a/madia.new/public/secret/1989/score-config.js
+++ b/madia.new/public/secret/1989/score-config.js
@@ -122,6 +122,21 @@ export const scoreConfigs = {
       return `${value ?? 0} pts`;
     },
   },
+  // Level 15
+  "lawnmower-labyrinth": {
+    label: "Survival Rating",
+    empty: "No lawn escapes logged yet.",
+    format: ({ value, meta }) => {
+      const timeMs = Number.isFinite(meta?.survivalTimeMs) ? Number(meta.survivalTimeMs) : null;
+      const crumbs = Number(meta?.crumbs ?? 0);
+      const crumbLabel = crumbs === 1 ? "1 crumb" : `${crumbs} crumbs`;
+      if (timeMs !== null) {
+        const seconds = Math.max(0, timeMs) / 1000;
+        return `${value ?? 0} pts · ${seconds.toFixed(2)}s · ${crumbLabel}`;
+      }
+      return `${value ?? 0} pts · ${crumbLabel}`;
+    },
+  }, // Level 15
   "freddys-dream-maze": {
     label: "Sanity Retained",
     empty: "No dream escapes logged yet.",


### PR DESCRIPTION
## Summary
- add the LawnMower Labyrinth cabinet with a playable stealth run across the backyard grid, including proximity HUD, mower AI, sprinkler cycle, and crumb bonuses
- wire the new level into the 1989 arcade catalog with SVG art and register its scoreboard entry

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e052e2ceb88328b6cf9108a6739650