### PR TITLE
Rename 1989 Parenthood cabinet to Family Flux

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -322,37 +322,37 @@ const games = [
     `,
   }, // Level 9
   {
-    id: "rollercoaster-of-life",
-    name: "Rollercoaster of Life",
+    id: "family-flux",
+    name: "Family Flux",
     description: "Race through parenting crises, weigh safe answers against wild gambles, and keep Family Harmony glowing.",
-    url: "./rollercoaster-of-life/index.html",
+    url: "./family-flux/index.html",
     thumbnail: `
-      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Rollercoaster of Life preview">
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Family Flux preview">
         <defs>
-          <linearGradient id="rolBg" x1="0" y1="0" x2="1" y2="1">
+          <linearGradient id="fluxBg" x1="0" y1="0" x2="1" y2="1">
             <stop offset="0%" stop-color="#fbbf24" />
             <stop offset="100%" stop-color="#f472b6" />
           </linearGradient>
-          <linearGradient id="rolPanel" x1="0" y1="0" x2="1" y2="1">
+          <linearGradient id="fluxPanel" x1="0" y1="0" x2="1" y2="1">
             <stop offset="0%" stop-color="rgba(15,23,42,0.92)" />
             <stop offset="100%" stop-color="rgba(30,64,175,0.82)" />
           </linearGradient>
-          <linearGradient id="rolTimer" x1="0" y1="0" x2="1" y2="0">
+          <linearGradient id="fluxTimer" x1="0" y1="0" x2="1" y2="0">
             <stop offset="0%" stop-color="#22c55e" />
             <stop offset="100%" stop-color="#f97316" />
           </linearGradient>
         </defs>
         <rect x="6" y="6" width="148" height="108" rx="20" fill="rgba(15,23,42,0.92)" stroke="rgba(148,163,184,0.35)" />
-        <rect x="14" y="14" width="132" height="92" rx="16" fill="url(#rolBg)" opacity="0.25" />
+        <rect x="14" y="14" width="132" height="92" rx="16" fill="url(#fluxBg)" opacity="0.25" />
         <g transform="translate(24 24)">
           <rect x="0" y="0" width="112" height="24" rx="12" fill="rgba(15,23,42,0.85)" stroke="rgba(148,163,184,0.35)" />
           <rect x="6" y="6" width="62" height="12" rx="6" fill="rgba(248,250,252,0.92)" />
-          <rect x="72" y="6" width="34" height="12" rx="6" fill="url(#rolTimer)" />
+          <rect x="72" y="6" width="34" height="12" rx="6" fill="url(#fluxTimer)" />
           <text x="24" y="15" font-family="'Press Start 2P', monospace" font-size="6" fill="#0ea5e9">Harmony</text>
           <text x="97" y="15" font-family="'Press Start 2P', monospace" font-size="6" fill="#f8fafc" text-anchor="end">540</text>
         </g>
         <g transform="translate(24 52)">
-          <rect x="0" y="0" width="48" height="48" rx="12" fill="url(#rolPanel)" stroke="rgba(148,163,184,0.35)" />
+          <rect x="0" y="0" width="48" height="48" rx="12" fill="url(#fluxPanel)" stroke="rgba(148,163,184,0.35)" />
           <path d="M8 38 C18 26 30 18 40 10" fill="none" stroke="#facc15" stroke-width="4" stroke-linecap="round" />
           <circle cx="20" cy="26" r="5" fill="#38bdf8" />
           <circle cx="32" cy="18" r="4" fill="#f97316" />

--- a/madia.new/public/secret/1989/family-flux/family-flux.css
+++ b/madia.new/public/secret/1989/family-flux/family-flux.css
@@ -1,11 +1,11 @@
 :root {
-  --roller-warm-sun: #fcd34d;
-  --roller-soft-pink: #f9a8d4;
-  --roller-deep-plum: #7c3aed;
-  --roller-midnight: #0f172a;
-  --roller-sage: #84cc16;
-  --roller-ember: #f97316;
-  --roller-cool-grey: #cbd5f5;
+  --flux-warm-sun: #fcd34d;
+  --flux-soft-pink: #f9a8d4;
+  --flux-deep-plum: #7c3aed;
+  --flux-midnight: #0f172a;
+  --flux-sage: #84cc16;
+  --flux-ember: #f97316;
+  --flux-cool-grey: #cbd5f5;
 }
 
 .page-layout {

--- a/madia.new/public/secret/1989/family-flux/family-flux.js
+++ b/madia.new/public/secret/1989/family-flux/family-flux.js
@@ -3,7 +3,7 @@ import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 import { autoEnhanceFeedback } from "../feedback.js";
 
-const GAME_ID = "rollercoaster-of-life";
+const GAME_ID = "family-flux";
 const INITIAL_HARMONY = 520;
 const PATIENCE_FLOOR_PERCENT = 0;
 const HARMONY_DECAY_ON_TIMEOUT = -140;

--- a/madia.new/public/secret/1989/family-flux/index.html
+++ b/madia.new/public/secret/1989/family-flux/index.html
@@ -3,17 +3,17 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Rollercoaster of Life</title>
+    <title>Family Flux</title>
     <link rel="stylesheet" href="../../secret-annex-snes.css" />
     <link rel="stylesheet" href="../common.css" />
-    <link rel="stylesheet" href="rollercoaster-of-life.css" />
+    <link rel="stylesheet" href="family-flux.css" />
   </head>
   <body class="secret-annex-snes">
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">
       <p class="eyebrow">Level 25 · Parenthood Cabinet</p>
-      <h1>Rollercoaster of Life</h1>
+      <h1>Family Flux</h1>
       <p class="subtitle">
         Shepherd the Buckman crew through escalating family crosswinds. Decide fast, balance heart and risk, and keep the Family
         Harmony meter alive.
@@ -125,6 +125,6 @@
     <footer class="page-footer">
       <p>Tip: A daring win can unlock surprise scenes. Just be sure you have the Harmony padding to weather the fallout.</p>
     </footer>
-    <script type="module" src="rollercoaster-of-life.js"></script>
+    <script type="module" src="family-flux.js"></script>
   </body>
 </html>

--- a/madia.new/public/secret/1989/score-config.js
+++ b/madia.new/public/secret/1989/score-config.js
@@ -240,11 +240,11 @@ export const scoreConfigs = {
       return `${value ?? 0} m · ${burstLabel} · ${hullLabel}`;
     },
   }, // Level 22
-  "rollercoaster-of-life": {
+  "family-flux": { // Level 25
     label: "Family Harmony",
     empty: "No harmony runs logged yet.",
     format: ({ value }) => `Harmony ${value ?? 0}`,
-  }, // rollercoaster
+  }, // Level 25
   "truvys-salon-style": {
     label: "Tip Jar",
     empty: "No tips counted yet.",


### PR DESCRIPTION
## Summary
- rename the Parenthood cabinet from Rollercoaster of Life to Family Flux across the arcade listing and score config
- update the cabinet files, assets, and paths to use the shorter Family Flux name

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0570bd3fc8328b45d722e84c4f168