### PR TITLE
feat: rework Dojo Duality bead stream puzzler

### DIFF
--- a/madia.new/public/secret/1989/dojo-duality/index.html
+++ b/madia.new/public/secret/1989/dojo-duality/index.html
@@ -22,14 +22,14 @@
       <section class="briefing" aria-labelledby="briefing-title">
         <h2 id="briefing-title">Training Brief</h2>
         <p>
-          Terry Silver's mind games tilt the tatami with every drop. Miyagi-Do blocks steady Daniel's breathing, while Cobra
-          Kai strikes crank the fear meter. Lock pieces, clear aligned stances, and keep the balance meter hovering near zero
-          long enough to earn your Crane Kick wipeout.
+          Terry Silver's mind games tilt the tatami with every drop. Chi streams of three focus beads rain down in fixed columns;
+          Miyagi-Do beads steady Daniel's breathing while Cobra Kai beads amp the pressure. Thread the streams, group like
+          energy, and keep the balance meter hovering near zero long enough to earn your Crane Kick wipeout.
         </p>
         <ul class="callouts">
           <li>
-            <strong>Balance meter:</strong> Tracks Daniel's focus from calm (center) to overwhelmed (edges). Matching like
-            blocks pushes it toward their dojo—keeping it near zero protects your breathing room.
+            <strong>Balance meter:</strong> Tracks Daniel's focus from calm (center) to overwhelmed (edges). Matching like beads
+            pushes it toward their dojo—keeping it near zero protects your breathing room.
           </li>
           <li>
             <strong>Defense combo:</strong> Clearing Miyagi-Do formations fills this reserve. Max it out to ready a Crane Kick
@@ -48,15 +48,15 @@
           <dl>
             <div>
               <dt>Start match</dt>
-              <dd>Press <strong>Begin Match</strong> to drop the first block.</dd>
+              <dd>Press <strong>Begin Match</strong> to drop the first stream.</dd>
             </div>
             <div>
-              <dt>Move stance</dt>
-              <dd>Use <strong>←</strong>/<strong>→</strong> to slide, <strong>↓</strong> to fast drop, and <strong>Z</strong>/<strong>X</strong> to rotate.</dd>
+              <dt>Slide stream</dt>
+              <dd>Use <strong>←</strong>/<strong>→</strong> to slide, <strong>↓</strong> to fast drop, and <strong>Z</strong>/<strong>X</strong> to reorder the beads.</dd>
             </div>
             <div>
               <dt>Crane Kick wipeout</dt>
-              <dd>Hit <strong>Crane Kick</strong> or tap <strong>Space</strong> when the Defense Combo is full to clear Cobra Kai blocks and reset.</dd>
+              <dd>Hit <strong>Crane Kick</strong> or tap <strong>Space</strong> when the Defense Combo is full to clear Cobra Kai beads and reset.</dd>
             </div>
             <div>
               <dt>Reset</dt>
@@ -111,10 +111,10 @@
           <div class="emblem-kanji">心</div>
         </div>
         <div class="board-wrapper">
-          <div class="board" id="board" role="grid" aria-label="Balance block grid"></div>
+          <div class="board" id="board" role="grid" aria-label="Balance bead grid"></div>
           <ul class="legend" aria-label="Legend">
-            <li><span class="legend-swatch positive"></span> Miyagi-Do block</li>
-            <li><span class="legend-swatch negative"></span> Cobra Kai block</li>
+            <li><span class="legend-swatch positive"></span> Miyagi-Do bead</li>
+            <li><span class="legend-swatch negative"></span> Cobra Kai bead</li>
             <li><span class="legend-swatch neutral"></span> Empty grid</li>
           </ul>
         </div>


### PR DESCRIPTION
## Summary
- replace the tetromino mechanic with falling focus streams that can be reordered instead of rotated
- align board rendering, crane kick feedback, and accessibility text with the new bead-based tokens
- refresh the training brief, controls, and legend copy to explain the revised stream puzzle

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68e07fa8fda48328871ed8d444c70205