### PR TITLE
feat: hide film inspirations behind reveal button

### DIFF
--- a/madia.new/public/secret/1989/1989.css
+++ b/madia.new/public/secret/1989/1989.css
@@ -293,6 +293,19 @@ main {
   line-height: 1.5;
 }
 
+.game-attribution {
+  display: grid;
+  gap: 0.45rem;
+  align-content: start;
+}
+
+.game-film {
+  margin: 0;
+  color: rgba(224, 219, 255, 0.82);
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
 .game-score {
   margin: 0.35rem 0 0;
   font-size: 0.85rem;
@@ -339,6 +352,38 @@ main {
   font-size: 0.62rem;
   box-shadow: inset 0 -4px 0 rgba(0, 0, 0, 0.35), 0 12px 20px -14px rgba(0, 0, 0, 0.75);
   transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.reveal-button {
+  font: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  border: 0;
+  padding: 0.6rem 0.9rem;
+  border-radius: 12px;
+  background: linear-gradient(180deg, rgba(122, 112, 210, 0.8), rgba(71, 54, 173, 0.85));
+  color: #f9f7ff;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-family: var(--heading-font);
+  font-size: 0.55rem;
+  box-shadow: inset 0 -3px 0 rgba(0, 0, 0, 0.35), 0 10px 20px -16px rgba(0, 0, 0, 0.75);
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+
+.reveal-button:hover,
+.reveal-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.3), 0 18px 28px -18px rgba(0, 0, 0, 0.7);
+  background: linear-gradient(180deg, rgba(158, 148, 240, 0.95), rgba(94, 77, 201, 0.95));
+}
+
+.reveal-button:focus-visible {
+  outline: 2px solid rgba(214, 205, 255, 0.85);
+  outline-offset: 3px;
 }
 
 .play-button:hover,
@@ -398,6 +443,19 @@ main {
   align-items: center;
   flex-wrap: wrap;
   justify-content: flex-end;
+}
+
+.overlay-attribution {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.overlay-film {
+  margin: 0;
+  color: rgba(228, 224, 255, 0.88);
+  font-size: 0.9rem;
+  line-height: 1.55;
 }
 
 .fullscreen-button {

--- a/madia.new/public/secret/1989/index.html
+++ b/madia.new/public/secret/1989/index.html
@@ -32,6 +32,10 @@
         <div class="game-info">
           <h2 class="game-title"></h2>
           <p class="game-meta"></p>
+          <div class="game-attribution" hidden>
+            <button class="reveal-button" type="button">Reveal inspiration</button>
+            <p class="game-film" hidden></p>
+          </div>
           <p class="game-score" data-high-score></p>
         </div>
         <div class="card-actions">
@@ -57,6 +61,12 @@
             <p class="overlay-eyebrow">Now Playing</p>
             <h2 id="player-title"></h2>
             <p class="overlay-description" id="player-description"></p>
+            <div class="overlay-attribution" id="overlay-attribution" hidden>
+              <button class="reveal-button" type="button" id="reveal-film-button" aria-expanded="false">
+                Reveal inspiration
+              </button>
+              <p class="overlay-film" id="player-film" hidden></p>
+            </div>
           </div>
           <div class="overlay-actions">
             <button


### PR DESCRIPTION
## Summary
- add reveal buttons to the 1989 arcade cards and overlay so film tie-ins stay hidden until requested
- update the catalog logic to serve base descriptions, reveal film notes on demand, and ignore reveal-button clicks when launching cabinets
- style the new attribution controls to match the cabinet theme

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e13650dce4832884910f2d6721e78c