### PR TITLE
feat: turbocharge lawnmower labyrinth fx

### DIFF
--- a/madia.new/public/secret/1989/lawnmower-labyrinth/index.html
+++ b/madia.new/public/secret/1989/lawnmower-labyrinth/index.html
@@ -12,7 +12,7 @@
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
     <header class="page-header">
-      <p class="eyebrow">Level 15 · 1989 Arcade</p>
+      <p class="eyebrow">Level 1 · 1989 Arcade</p>
       <h1>Lawnmower Labyrinth</h1>
       <p class="subtitle">
         Shrunk to ant scale, you must weave through towering grass and sprinkler storms while a deafening mower sweeps the lawn

--- a/madia.new/public/secret/1989/lawnmower-labyrinth/lawnmower-labyrinth.css
+++ b/madia.new/public/secret/1989/lawnmower-labyrinth/lawnmower-labyrinth.css
@@ -7,6 +7,14 @@
   --sprinkler-blue: rgba(59, 130, 246, 0.18);
   --crumb-gold: #fbbf24;
   --safe-flag: #22d3ee;
+  --warning-glow: rgba(250, 204, 21, 0.6);
+  --danger-glow: rgba(248, 113, 113, 0.55);
+  --critical-glow: rgba(244, 63, 94, 0.75);
+  --sprinkler-glow: rgba(56, 189, 248, 0.42);
+  --trail-1: rgba(34, 211, 238, 0.5);
+  --trail-2: rgba(56, 189, 248, 0.32);
+  --trail-3: rgba(94, 234, 212, 0.24);
+  --trail-4: rgba(125, 211, 252, 0.18);
 }
 
 .cabinet {
@@ -99,6 +107,111 @@
   border-radius: 1rem;
   border: 1px solid rgba(148, 163, 184, 0.35);
   box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.4);
+  transition: border-color 180ms ease-out, box-shadow 180ms ease-out;
+  overflow: hidden;
+}
+
+.board::before {
+  content: "";
+  position: absolute;
+  inset: 0.4rem;
+  border-radius: 0.9rem;
+  background: radial-gradient(circle at center, rgba(59, 130, 246, 0.16), rgba(15, 23, 42, 0));
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 200ms ease-out, transform 200ms ease-out;
+}
+
+.board::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 1rem;
+  pointer-events: none;
+  opacity: 0;
+}
+
+.board[data-danger-level="alert"] {
+  border-color: rgba(250, 204, 21, 0.45);
+  box-shadow:
+    inset 0 0 0 1px rgba(15, 23, 42, 0.4),
+    0 0 20px rgba(250, 204, 21, 0.22);
+}
+
+.board[data-danger-level="alert"]::before {
+  opacity: 0.35;
+  background: radial-gradient(circle at center, rgba(250, 204, 21, 0.25), rgba(15, 23, 42, 0));
+}
+
+.board[data-danger-level="danger"] {
+  border-color: rgba(248, 113, 113, 0.45);
+  box-shadow:
+    inset 0 0 0 1px rgba(15, 23, 42, 0.4),
+    0 0 26px rgba(248, 113, 113, 0.28);
+}
+
+.board[data-danger-level="danger"]::before {
+  opacity: 0.45;
+  background: radial-gradient(circle at center, rgba(248, 113, 113, 0.32), rgba(15, 23, 42, 0));
+  animation: boardPulse 1.2s ease-in-out infinite;
+}
+
+.board[data-danger-level="critical"],
+.board[data-danger-level="impact"] {
+  border-color: rgba(244, 63, 94, 0.5);
+  box-shadow:
+    inset 0 0 0 1px rgba(15, 23, 42, 0.45),
+    0 0 32px rgba(244, 63, 94, 0.32);
+}
+
+.board[data-danger-level="critical"]::before {
+  opacity: 0.52;
+  background: radial-gradient(circle at center, rgba(244, 63, 94, 0.35), rgba(15, 23, 42, 0));
+  animation: boardCritical 1s ease-in-out infinite;
+}
+
+.board[data-danger-level="impact"]::before {
+  opacity: 0.6;
+  background: radial-gradient(circle at center, rgba(244, 63, 94, 0.45), rgba(15, 23, 42, 0));
+  animation: boardCritical 0.8s ease-in-out infinite;
+}
+
+.board[data-sprinkler="active"]::after {
+  opacity: 0.24;
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.2), rgba(8, 12, 24, 0));
+  animation: sprinklerPulse 1.4s ease-in-out infinite;
+}
+
+.board[data-outcome="success"] {
+  border-color: rgba(74, 222, 128, 0.45);
+  box-shadow:
+    inset 0 0 0 1px rgba(15, 23, 42, 0.4),
+    0 0 22px rgba(74, 222, 128, 0.25);
+}
+
+.board[data-outcome="fail"] {
+  border-color: rgba(248, 113, 113, 0.45);
+  box-shadow:
+    inset 0 0 0 1px rgba(15, 23, 42, 0.4),
+    0 0 26px rgba(244, 63, 94, 0.28);
+}
+
+.board.board-success::after {
+  opacity: 0.7;
+  background: radial-gradient(circle at center, rgba(74, 222, 128, 0.4), rgba(15, 23, 42, 0));
+  animation: boardSuccess 560ms ease-out forwards;
+}
+
+.board.board-fail::after {
+  opacity: 0.65;
+  background: radial-gradient(circle at center, rgba(244, 63, 94, 0.4), rgba(15, 23, 42, 0));
+  animation: boardFail 640ms ease-out forwards;
+}
+
+.board.sprinkler-wave::after {
+  opacity: 0.5;
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.32), rgba(8, 12, 24, 0));
+  animation: sprinklerWave 620ms ease-out forwards;
 }
 
 .board-cell {
@@ -114,8 +227,20 @@
   color: rgba(248, 250, 252, 0.85);
   border: 1px solid rgba(148, 163, 184, 0.3);
   background: var(--open-lawn);
-  transition: transform 80ms ease-out, box-shadow 120ms ease-out;
+  box-shadow: 0 0 0 rgba(15, 23, 42, 0.35);
+  transition: transform 80ms ease-out, box-shadow 140ms ease-out, border-color 140ms ease-out;
   overflow: hidden;
+}
+
+.board-cell::after {
+  content: "";
+  position: absolute;
+  inset: 4px;
+  border-radius: 0.55rem;
+  pointer-events: none;
+  opacity: 0;
+  background: transparent;
+  transition: opacity 160ms ease-out, transform 160ms ease-out;
 }
 
 .board-cell[data-type="cover"] {
@@ -142,6 +267,51 @@
   border-color: rgba(45, 212, 191, 0.6);
 }
 
+.board-cell[data-sweep="current"] {
+  box-shadow: 0 0 18px var(--danger-glow);
+}
+
+.board-cell[data-sweep="next"] {
+  box-shadow: 0 0 16px var(--warning-glow);
+}
+
+.board-cell[data-sweep="preview"] {
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.35);
+}
+
+.board-cell[data-trail="1"]::after {
+  opacity: 0.45;
+  background: radial-gradient(circle at center, var(--trail-1), rgba(15, 23, 42, 0));
+  animation: trailGlow 900ms ease-out forwards;
+}
+
+.board-cell[data-trail="2"]::after {
+  opacity: 0.32;
+  background: radial-gradient(circle at center, var(--trail-2), rgba(15, 23, 42, 0));
+}
+
+.board-cell[data-trail="3"]::after {
+  opacity: 0.26;
+  background: radial-gradient(circle at center, var(--trail-3), rgba(15, 23, 42, 0));
+}
+
+.board-cell[data-trail="4"]::after,
+.board-cell[data-trail="5"]::after {
+  opacity: 0.2;
+  background: radial-gradient(circle at center, var(--trail-4), rgba(15, 23, 42, 0));
+}
+
+.board-cell[data-danger="true"] {
+  border-color: rgba(248, 113, 113, 0.75);
+  box-shadow: 0 0 22px var(--critical-glow);
+  animation: dangerLine 520ms ease-in-out infinite alternate;
+}
+
+.board-cell[data-danger="true"]::after {
+  opacity: 0.5;
+  background: radial-gradient(circle at center, rgba(248, 113, 113, 0.35), rgba(15, 23, 42, 0));
+}
+
 .board-cell[data-sprinkler-active="true"] .sprinkler-overlay {
   opacity: 1;
   animation: droplet 320ms ease-in-out infinite alternate;
@@ -165,6 +335,29 @@
   color: var(--crumb-gold);
   filter: drop-shadow(0 0 6px rgba(251, 191, 36, 0.75));
 }
+
+.board-cell.cell-step {
+  animation: cellStepPulse 320ms ease-out;
+}
+
+.board-cell.crumb-pop::after {
+  opacity: 0.7;
+  background: radial-gradient(circle at center, rgba(251, 191, 36, 0.45), rgba(15, 23, 42, 0));
+  animation: crumbPop 420ms ease-out forwards;
+}
+
+.board-cell.dash-echo::after {
+  opacity: 0.5;
+  background: radial-gradient(circle at center, rgba(250, 204, 21, 0.35), rgba(15, 23, 42, 0));
+  animation: dashEcho 360ms ease-out forwards;
+}
+
+.board-cell.dash-echo-strong::after {
+  opacity: 0.65;
+  background: radial-gradient(circle at center, rgba(250, 204, 21, 0.5), rgba(15, 23, 42, 0));
+  animation: dashEcho 420ms ease-out forwards;
+}
+
 .player-marker,
 .mower-marker,
 .sprinkler-overlay {
@@ -184,6 +377,7 @@
 .board-cell[data-player="true"] .player-marker {
   opacity: 1;
   transform: scale(1.02);
+  animation: playerPulse 1.4s ease-in-out infinite;
 }
 
 .mower-marker {
@@ -195,6 +389,7 @@
 .board-cell[data-mower="true"] .mower-marker {
   opacity: 1;
   transform: scale(1.05);
+  animation: mowerSweep 1s ease-in-out infinite;
 }
 
 .sprinkler-overlay {
@@ -415,6 +610,173 @@
 .wrap-up p {
   margin: 0;
   color: rgba(226, 232, 240, 0.85);
+}
+
+@keyframes cellStepPulse {
+  0% {
+    box-shadow: 0 0 0 rgba(34, 211, 238, 0);
+  }
+  50% {
+    box-shadow: 0 0 14px rgba(34, 211, 238, 0.45);
+  }
+  100% {
+    box-shadow: 0 0 0 rgba(34, 211, 238, 0);
+  }
+}
+
+@keyframes crumbPop {
+  0% {
+    opacity: 0;
+    transform: scale(0.7);
+  }
+  55% {
+    opacity: 0.85;
+    transform: scale(1.05);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.25);
+  }
+}
+
+@keyframes dashEcho {
+  0% {
+    opacity: 0.75;
+    transform: scale(0.85);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.2);
+  }
+}
+
+@keyframes trailGlow {
+  0% {
+    opacity: 0;
+  }
+  35% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.2;
+  }
+}
+
+@keyframes dangerLine {
+  0% {
+    border-color: rgba(248, 113, 113, 0.45);
+  }
+  100% {
+    border-color: rgba(248, 113, 113, 0.85);
+  }
+}
+
+@keyframes boardPulse {
+  0% {
+    transform: scale(1);
+    opacity: 0.4;
+  }
+  50% {
+    transform: scale(1.02);
+    opacity: 0.6;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 0.4;
+  }
+}
+
+@keyframes boardCritical {
+  0% {
+    transform: scale(1);
+    opacity: 0.5;
+  }
+  45% {
+    transform: scale(1.03);
+    opacity: 0.75;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 0.5;
+  }
+}
+
+@keyframes boardSuccess {
+  0% {
+    opacity: 0.75;
+    transform: scale(0.95);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.25);
+  }
+}
+
+@keyframes boardFail {
+  0% {
+    opacity: 0.7;
+    transform: scale(0.96);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.15);
+  }
+}
+
+@keyframes sprinklerPulse {
+  0% {
+    opacity: 0.18;
+    transform: scale(1);
+  }
+  60% {
+    opacity: 0.36;
+    transform: scale(1.02);
+  }
+  100% {
+    opacity: 0.18;
+    transform: scale(1);
+  }
+}
+
+@keyframes sprinklerWave {
+  0% {
+    opacity: 0.6;
+    transform: scale(0.92);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.2);
+  }
+}
+
+@keyframes playerPulse {
+  0% {
+    transform: scale(1.02);
+    box-shadow: 0 0 12px rgba(59, 130, 246, 0.6);
+  }
+  50% {
+    transform: scale(1.06);
+    box-shadow: 0 0 18px rgba(59, 130, 246, 0.75);
+  }
+  100% {
+    transform: scale(1.02);
+    box-shadow: 0 0 12px rgba(59, 130, 246, 0.6);
+  }
+}
+
+@keyframes mowerSweep {
+  0% {
+    transform: scale(1.05) rotate(0deg);
+    box-shadow: 0 0 16px rgba(249, 115, 22, 0.75);
+  }
+  50% {
+    transform: scale(1.08) rotate(2deg);
+    box-shadow: 0 0 22px rgba(249, 115, 22, 0.9);
+  }
+  100% {
+    transform: scale(1.05) rotate(0deg);
+    box-shadow: 0 0 16px rgba(249, 115, 22, 0.75);
+  }
 }
 
 @media (max-width: 960px) {


### PR DESCRIPTION
## Summary
- add a reusable audio controller and trigger richer cues for dashes, crumbs, warnings, failures, and sprinkler surges
- layer new board telemetry, mower previews, player trails, and outcome pulses to make hazards and victories immediately visible
- refresh the cabinet styling and metadata so Lawnmaower Labyrinth presents as Level 1 with upgraded animations and glow states

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e16e4e98688328a5429614140afddd