### PR TITLE
Enhance Freddy's Dream Maze audiovisual feedback

### DIFF
--- a/madia.new/public/secret/1989/freddys-dream-maze/freddys-dream-maze.css
+++ b/madia.new/public/secret/1989/freddys-dream-maze/freddys-dream-maze.css
@@ -44,6 +44,119 @@ body.freddys-dream-maze::before {
   }
 }
 
+.dream-haze {
+  --haze-opacity: 0.32;
+  --haze-blur: 32px;
+  --haze-duration: 28s;
+  --haze-tilt: 8deg;
+  position: fixed;
+  inset: -12vh;
+  pointer-events: none;
+  z-index: 1;
+  mix-blend-mode: screen;
+  opacity: var(--haze-opacity);
+  filter: blur(var(--haze-blur));
+  animation: hazePulse var(--haze-duration) ease-in-out infinite;
+}
+
+.dream-haze::before,
+.dream-haze::after {
+  content: "";
+  position: absolute;
+  inset: -18%;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  opacity: 0.85;
+  transform-origin: center;
+}
+
+.dream-haze::before {
+  animation: hazeDrift calc(var(--haze-duration) * 1.1) linear infinite;
+  filter: saturate(1.15);
+}
+
+.dream-haze::after {
+  animation: hazeFlicker calc(var(--haze-duration) * 0.6) ease-in-out infinite;
+  filter: saturate(1.25);
+}
+
+.dream-haze[data-state="lucid"]::before {
+  background: radial-gradient(circle at 32% 28%, rgba(56, 189, 248, 0.22), transparent 62%),
+    radial-gradient(circle at 74% 62%, rgba(148, 163, 184, 0.18), transparent 70%);
+  transform: rotate(calc(var(--haze-tilt) * -1));
+}
+
+.dream-haze[data-state="lucid"]::after {
+  background: radial-gradient(circle at 68% 32%, rgba(168, 85, 247, 0.22), transparent 58%),
+    radial-gradient(circle at 28% 72%, rgba(59, 130, 246, 0.18), transparent 68%);
+  transform: rotate(var(--haze-tilt));
+}
+
+.dream-haze[data-state="distorted"]::before {
+  background: radial-gradient(circle at 30% 26%, rgba(249, 115, 22, 0.3), transparent 60%),
+    radial-gradient(circle at 76% 64%, rgba(59, 130, 246, 0.18), transparent 68%);
+  transform: rotate(calc(var(--haze-tilt) * -1.2));
+}
+
+.dream-haze[data-state="distorted"]::after {
+  background: radial-gradient(circle at 68% 28%, rgba(236, 72, 153, 0.28), transparent 62%),
+    radial-gradient(circle at 26% 70%, rgba(251, 191, 36, 0.22), transparent 72%);
+  transform: rotate(calc(var(--haze-tilt) * 1.3));
+}
+
+.dream-haze[data-state="collapsing"]::before {
+  background: radial-gradient(circle at 34% 32%, rgba(239, 68, 68, 0.32), transparent 58%),
+    radial-gradient(circle at 70% 70%, rgba(147, 51, 234, 0.26), transparent 72%);
+  transform: rotate(calc(var(--haze-tilt) * -1.5));
+}
+
+.dream-haze[data-state="collapsing"]::after {
+  background: radial-gradient(circle at 72% 28%, rgba(234, 179, 8, 0.26), transparent 56%),
+    radial-gradient(circle at 24% 74%, rgba(236, 72, 153, 0.28), transparent 70%);
+  transform: rotate(calc(var(--haze-tilt) * 1.6));
+  opacity: 0.95;
+}
+
+@keyframes hazePulse {
+  0%,
+  100% {
+    opacity: calc(var(--haze-opacity) * 0.85);
+    filter: blur(calc(var(--haze-blur) * 0.9));
+  }
+  45% {
+    opacity: calc(var(--haze-opacity) * 1.1);
+    filter: blur(calc(var(--haze-blur) * 1.08));
+  }
+}
+
+@keyframes hazeDrift {
+  0% {
+    transform: translate3d(-6%, -4%, 0) rotate(-6deg) scale(1.05);
+  }
+  50% {
+    transform: translate3d(5%, 6%, 0) rotate(4deg) scale(1.08);
+  }
+  100% {
+    transform: translate3d(-6%, -4%, 0) rotate(-6deg) scale(1.05);
+  }
+}
+
+@keyframes hazeFlicker {
+  0%,
+  100% {
+    opacity: 0.6;
+    transform: scale(1.02) rotate(3deg);
+  }
+  40% {
+    opacity: 0.82;
+    transform: scale(1.08) rotate(-2deg);
+  }
+  55% {
+    opacity: 0.72;
+    transform: scale(1.12) rotate(5deg);
+  }
+}
+
 body[data-fear-state="lucid"].freddys-dream-maze {
   --maze-glow: rgba(56, 189, 248, 0.5);
   --maze-accent: #38bdf8;
@@ -116,6 +229,8 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
 }
 
 .simulator {
+  --sim-overlay-opacity: 0.6;
+  --sim-overlay-speed: 22s;
   position: relative;
   background: rgba(8, 11, 21, 0.8);
   border: 1px solid rgba(148, 163, 184, 0.25);
@@ -131,14 +246,46 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
   inset: 0;
   background: radial-gradient(circle at 20% 10%, rgba(248, 113, 113, 0.12), transparent 45%),
     radial-gradient(circle at 80% 90%, rgba(56, 189, 248, 0.08), transparent 50%);
-  opacity: 0.6;
+  opacity: var(--sim-overlay-opacity);
   pointer-events: none;
   z-index: 0;
+  animation: cabinetGlow var(--sim-overlay-speed) ease-in-out infinite;
 }
 
 .simulator > * {
   position: relative;
   z-index: 1;
+}
+
+@keyframes cabinetGlow {
+  0%,
+  100% {
+    opacity: calc(var(--sim-overlay-opacity) * 0.82);
+    transform: scale(1);
+  }
+  48% {
+    opacity: calc(var(--sim-overlay-opacity) * 1.05);
+    transform: scale(1.02) translateY(-1.5%);
+  }
+}
+
+body[data-fear-state="lucid"] .simulator {
+  --sim-overlay-opacity: 0.52;
+  --sim-overlay-speed: 28s;
+}
+
+body[data-fear-state="distorted"] .simulator {
+  --sim-overlay-opacity: 0.68;
+  --sim-overlay-speed: 18s;
+  box-shadow: 0 28px 64px rgba(120, 53, 15, 0.42);
+  border-color: rgba(249, 115, 22, 0.3);
+}
+
+body[data-fear-state="collapsing"] .simulator {
+  --sim-overlay-opacity: 0.82;
+  --sim-overlay-speed: 12s;
+  box-shadow: 0 36px 78px rgba(76, 29, 149, 0.45);
+  border-color: rgba(239, 68, 68, 0.32);
 }
 
 .simulator-header {
@@ -177,6 +324,7 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
   box-shadow: inset 0 0 18px rgba(59, 130, 246, 0.08);
   display: grid;
   gap: 0.4rem;
+  transition: border-color 240ms ease, box-shadow 240ms ease, transform 320ms ease;
 }
 
 .hud-label {
@@ -190,11 +338,30 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
   font-size: 1.35rem;
   font-weight: 700;
   color: #f8fafc;
+  transition: color 240ms ease;
 }
 
 .hud-note {
   font-size: 0.85rem;
   color: rgba(226, 232, 240, 0.78);
+}
+
+body[data-fear-state="distorted"] .hud-card {
+  border-color: rgba(249, 115, 22, 0.35);
+  box-shadow: inset 0 0 18px rgba(249, 115, 22, 0.18);
+}
+
+body[data-fear-state="collapsing"] .hud-card {
+  border-color: rgba(239, 68, 68, 0.45);
+  box-shadow: inset 0 0 22px rgba(239, 68, 68, 0.22);
+}
+
+body[data-fear-state="collapsing"] .hud-card:nth-child(odd) {
+  transform: translateY(2px);
+}
+
+body[data-fear-state="collapsing"] .hud-value {
+  color: #fca5a5;
 }
 
 .hud-meter .meter {
@@ -253,12 +420,16 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
 }
 
 .environment-overlay {
+  --overlay-speed: 9s;
+  --overlay-hue: 0deg;
+  --overlay-saturation: 1;
   position: absolute;
   inset: 0;
   background: conic-gradient(from 120deg, rgba(248, 113, 113, 0.15), rgba(40, 54, 120, 0.4), rgba(8, 11, 21, 0.95));
   mix-blend-mode: screen;
   opacity: 0.65;
-  animation: overlayDrift 9s ease-in-out infinite;
+  animation: overlayDrift var(--overlay-speed) ease-in-out infinite;
+  filter: hue-rotate(var(--overlay-hue)) saturate(var(--overlay-saturation));
 }
 
 @keyframes overlayDrift {
@@ -270,6 +441,19 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
   }
   100% {
     transform: scale(1) rotate(0deg);
+  }
+}
+
+@keyframes overlayTremor {
+  0%,
+  100% {
+    transform: scale(1.02) rotate(2deg);
+  }
+  40% {
+    transform: scale(1.06) rotate(-4deg);
+  }
+  70% {
+    transform: scale(1.08) rotate(3deg);
   }
 }
 
@@ -307,6 +491,23 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
   background: rgba(239, 68, 68, 0.45);
   box-shadow: 0 0 24px rgba(239, 68, 68, 0.55);
 }
+.environment-grid[data-fear="distorted"] span.is-active {
+  transform: scale(1.08) rotate(1deg);
+  box-shadow: 0 0 22px rgba(249, 115, 22, 0.45);
+}
+
+.environment-grid[data-fear="distorted"] span.is-threat {
+  box-shadow: 0 0 28px rgba(236, 72, 153, 0.55);
+}
+
+.environment-grid[data-fear="collapsing"] span {
+  animation: tilePulse 2.8s ease-in-out infinite;
+}
+
+.environment-grid[data-fear="collapsing"] span.is-threat {
+  animation: tilePulse 1.6s ease-in-out infinite, tileFracture 1.15s steps(2, end) infinite;
+  box-shadow: 0 0 30px rgba(239, 68, 68, 0.6);
+}
 .environment-grid::before,
 .environment-grid::after {
   content: "";
@@ -319,6 +520,43 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
 .environment-detail {
   color: rgba(226, 232, 240, 0.78);
   font-size: 0.95rem;
+}
+
+body[data-fear-state="distorted"] .environment-overlay {
+  --overlay-speed: 7.2s;
+  --overlay-hue: 14deg;
+  --overlay-saturation: 1.18;
+  animation: overlayDrift var(--overlay-speed) ease-in-out infinite, overlayTremor 8s ease-in-out infinite;
+}
+
+body[data-fear-state="collapsing"] .environment-overlay {
+  --overlay-speed: 5.2s;
+  --overlay-hue: -12deg;
+  --overlay-saturation: 1.28;
+  opacity: 0.78;
+  animation: overlayDrift var(--overlay-speed) ease-in-out infinite, overlayTremor 2.2s steps(2, end) infinite;
+}
+
+@keyframes tilePulse {
+  0%,
+  100% {
+    transform: scale(1);
+    filter: brightness(1);
+  }
+  48% {
+    transform: scale(1.05);
+    filter: brightness(1.18);
+  }
+}
+
+@keyframes tileFracture {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1.03);
+  }
+  50% {
+    transform: translate3d(2px, -3px, 0) scale(1.08);
+  }
 }
 
 .decision-options {

--- a/madia.new/public/secret/1989/freddys-dream-maze/index.html
+++ b/madia.new/public/secret/1989/freddys-dream-maze/index.html
@@ -11,6 +11,7 @@
   <body class="secret-annex-snes freddys-dream-maze" data-fear-state="lucid">
     <a class="skip-link" href="#main-content">Skip to game</a>
     <div class="scanlines" aria-hidden="true"></div>
+    <div class="dream-haze" id="nightmare-haze" aria-hidden="true"></div>
     <header class="page-header">
       <p class="eyebrow">Level 5 · 1989 Arcade</p>
       <h1>Freddy's Dream Maze</h1>


### PR DESCRIPTION
## Summary
- add a nightmare haze overlay element to Freddy's Dream Maze
- expand the level styling with fear-state driven haze, HUD, and grid animations
- refactor the level script with fear-state audio/particle control and make the shared particle helper support palette swaps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e16e5a10088328ad1d35eb7b4bf765