### PR TITLE
feat: amplify level 3 surge feedback

### DIFF
--- a/madia.new/public/secret/1989/river-of-slime-escape/river-of-slime-escape.css
+++ b/madia.new/public/secret/1989/river-of-slime-escape/river-of-slime-escape.css
@@ -304,6 +304,96 @@ body.river-of-slime.is-shaking .stage-frame {
   animation: screen-shake 360ms ease;
 }
 
+body.river-of-slime.river-tier-three {
+  background: radial-gradient(circle at 20% 20%, rgba(255, 93, 200, 0.28), transparent 55%),
+    radial-gradient(circle at 80% 12%, rgba(128, 255, 234, 0.24), transparent 60%),
+    radial-gradient(circle at 52% 82%, rgba(250, 204, 21, 0.18), transparent 65%),
+    linear-gradient(160deg, rgba(5, 8, 18, 0.94), rgba(12, 16, 32, 0.98));
+  animation: river-tier-three-bg 14s linear infinite;
+}
+
+body.river-of-slime.river-tier-three .stage-frame {
+  box-shadow: 0 1.6rem 3.6rem rgba(5, 10, 22, 0.72), 0 0 1.2rem rgba(255, 93, 200, 0.28),
+    0 0 2rem rgba(128, 255, 234, 0.22);
+  border-color: rgba(255, 93, 200, 0.45);
+  overflow: hidden;
+}
+
+body.river-of-slime.river-tier-three .stage-frame::after {
+  content: "";
+  position: absolute;
+  inset: 0.35rem;
+  border-radius: 0.95rem;
+  background: radial-gradient(circle at 32% 28%, rgba(255, 93, 200, 0.38), transparent 58%),
+    radial-gradient(circle at 68% 72%, rgba(128, 255, 234, 0.32), transparent 62%);
+  opacity: 0.28;
+  mix-blend-mode: screen;
+  pointer-events: none;
+  animation: tier-three-ring 3.4s ease-in-out infinite;
+}
+
+body.river-of-slime.river-tier-three-flare .stage-frame::after {
+  animation: tier-three-flare 0.9s ease-out;
+}
+
+body.river-of-slime.river-tier-three .hud-tile {
+  border-color: rgba(128, 255, 234, 0.42);
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.88), rgba(45, 12, 38, 0.6));
+  box-shadow: 0 0 1.2rem rgba(255, 93, 200, 0.22);
+}
+
+body.river-of-slime.river-tier-three .hud-label {
+  color: rgba(244, 114, 182, 0.88);
+}
+
+body.river-of-slime.river-tier-three .hud-value {
+  color: #fdf2f8;
+  text-shadow: 0 0 0.75rem rgba(255, 93, 200, 0.35);
+}
+
+body.river-of-slime.river-tier-three .hud-subvalue {
+  color: rgba(226, 232, 240, 0.92);
+}
+
+body.river-of-slime.river-tier-three .meter {
+  border-color: rgba(255, 93, 200, 0.42);
+  background: rgba(15, 23, 42, 0.7);
+}
+
+body.river-of-slime.river-tier-three .meter-fill {
+  animation: tier-three-meter 1.6s ease-in-out infinite alternate;
+}
+
+body.river-of-slime.river-tier-three .slime-indicator {
+  border-color: rgba(255, 93, 200, 0.55);
+  box-shadow: 0 0 1.4rem rgba(255, 93, 200, 0.26);
+  animation: tier-three-pulse 2.2s ease-in-out infinite;
+}
+
+body.river-of-slime.river-tier-three .slime-indicator-bar {
+  background: rgba(30, 41, 59, 0.72);
+}
+
+body.river-of-slime.river-tier-three .slime-indicator-fill {
+  background: linear-gradient(90deg, rgba(255, 93, 200, 0.85), rgba(56, 189, 248, 0.9));
+  background-size: 200% 100%;
+  animation: tier-three-wave 1.2s linear infinite;
+}
+
+body.river-of-slime.river-tier-three .slime-indicator-text {
+  color: rgba(255, 240, 248, 0.96);
+  text-shadow: 0 0 0.6rem rgba(255, 93, 200, 0.35);
+}
+
+body.river-of-slime.river-tier-three .slime-indicator-label {
+  color: rgba(255, 177, 229, 0.9);
+}
+
+body.river-of-slime.river-tier-three .status-readout {
+  border-color: rgba(128, 255, 234, 0.35);
+  box-shadow: 0 0 1.1rem rgba(128, 255, 234, 0.2);
+}
+
 @keyframes screen-shake {
   0%,
   100% {
@@ -320,6 +410,76 @@ body.river-of-slime.is-shaking .stage-frame {
   }
   80% {
     transform: translate3d(3px, 4px, 0);
+  }
+}
+
+@keyframes river-tier-three-bg {
+  0% {
+    background-position: 0% 0%, 80% 12%, 52% 82%, 0 0;
+  }
+  50% {
+    background-position: 6% 6%, 74% 8%, 50% 78%, 0 0;
+  }
+  100% {
+    background-position: 0% 0%, 80% 12%, 52% 82%, 0 0;
+  }
+}
+
+@keyframes tier-three-ring {
+  0% {
+    opacity: 0.18;
+    transform: scale(0.94);
+  }
+  50% {
+    opacity: 0.4;
+    transform: scale(1.02);
+  }
+  100% {
+    opacity: 0.18;
+    transform: scale(0.94);
+  }
+}
+
+@keyframes tier-three-flare {
+  0% {
+    opacity: 0.8;
+    transform: scale(0.92);
+  }
+  60% {
+    opacity: 0.2;
+    transform: scale(1.04);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.12);
+  }
+}
+
+@keyframes tier-three-meter {
+  0% {
+    filter: saturate(1) brightness(1);
+  }
+  100% {
+    filter: saturate(1.45) brightness(1.18);
+  }
+}
+
+@keyframes tier-three-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 1.1rem rgba(255, 93, 200, 0.25);
+  }
+  50% {
+    box-shadow: 0 0 1.8rem rgba(128, 255, 234, 0.35);
+  }
+}
+
+@keyframes tier-three-wave {
+  0% {
+    background-position: 0% 0;
+  }
+  100% {
+    background-position: 160% 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a tier-three celebration trigger in River of Slime Escape that emits particle bursts and a new surge audio cue when difficulty escalates to level 3
- polish the level-three state with neon HUD pulses, animated slime indicator waves, and stage-frame glow treatments driven by new CSS classes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e16e6c4c048328841aaeb06c598ec1