### PR TITLE
Add Power Glove Prodigy level

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -2233,6 +2233,58 @@ const games = [
       </svg>
     `,
   }, // voice box swap
+  // Level 4
+  {
+    id: "power-glove-prodigy",
+    name: "Power Glove Prodigy",
+    description:
+      "Thread impossible controller strings, trigger Turbo Overflow, and bathe the championship in synthfire works.",
+    url: "./power-glove-prodigy/index.html",
+    thumbnail: `
+      <svg viewBox="0 0 160 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Power Glove Prodigy preview">
+        <defs>
+          <linearGradient id="pgpPanel" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="rgba(15,23,42,0.95)" />
+            <stop offset="100%" stop-color="rgba(6,12,32,0.92)" />
+          </linearGradient>
+          <linearGradient id="pgpGlow" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0%" stop-color="#22d3ee" />
+            <stop offset="50%" stop-color="#7c3aed" />
+            <stop offset="100%" stop-color="#f97316" />
+          </linearGradient>
+          <radialGradient id="pgpBurst" cx="50%" cy="50%" r="65%">
+            <stop offset="0%" stop-color="rgba(124,58,237,0.75)" />
+            <stop offset="100%" stop-color="rgba(124,58,237,0)" />
+          </radialGradient>
+        </defs>
+        <rect x="8" y="8" width="144" height="104" rx="20" fill="rgba(5,10,24,0.92)" stroke="rgba(148,163,184,0.35)" />
+        <rect x="18" y="18" width="124" height="84" rx="18" fill="url(#pgpPanel)" stroke="rgba(148,163,184,0.3)" />
+        <circle cx="80" cy="58" r="44" fill="url(#pgpBurst)" opacity="0.85" />
+        <g transform="translate(30 32)">
+          <rect x="0" y="0" width="72" height="52" rx="14" fill="rgba(15,23,42,0.88)" stroke="rgba(148,163,184,0.32)" />
+          <rect x="8" y="10" width="56" height="12" rx="6" fill="rgba(34,211,238,0.18)" />
+          <rect x="8" y="26" width="56" height="22" rx="9" fill="rgba(7,12,30,0.95)" stroke="rgba(34,211,238,0.45)" />
+          <text x="36" y="38" text-anchor="middle" font-size="10" fill="#22d3ee" font-family="'Press Start 2P', monospace">×5.6</text>
+        </g>
+        <g transform="translate(108 32)">
+          <rect x="-14" y="0" width="44" height="52" rx="16" fill="rgba(15,23,42,0.88)" stroke="rgba(148,163,184,0.35)" />
+          <circle cx="8" cy="18" r="12" fill="rgba(34,211,238,0.35)" stroke="rgba(148,163,184,0.4)" />
+          <circle cx="8" cy="18" r="6" fill="rgba(248,250,252,0.92)" />
+          <rect x="-2" y="32" width="20" height="8" rx="4" fill="#f97316" />
+          <rect x="14" y="32" width="20" height="8" rx="4" fill="#22d3ee" />
+          <rect x="6" y="42" width="16" height="6" rx="3" fill="#7c3aed" />
+        </g>
+        <g>
+          <path d="M26 86 C42 74 64 66 80 66 C96 66 118 74 134 86" stroke="url(#pgpGlow)" stroke-width="6" stroke-linecap="round" opacity="0.65" />
+          <circle cx="44" cy="86" r="7" fill="#22d3ee" stroke="rgba(248,250,252,0.6)" stroke-width="2" />
+          <circle cx="80" cy="86" r="7" fill="#7c3aed" stroke="rgba(248,250,252,0.6)" stroke-width="2" />
+          <circle cx="116" cy="86" r="7" fill="#f97316" stroke="rgba(248,250,252,0.6)" stroke-width="2" />
+        </g>
+        <path d="M30 24 L40 30 L30 36" stroke="rgba(34,211,238,0.55)" stroke-width="3" stroke-linecap="round" />
+        <path d="M130 24 L120 30 L130 36" stroke="rgba(249,115,22,0.55)" stroke-width="3" stroke-linecap="round" />
+      </svg>
+    `,
+  }, // Level 4
   // Level 5
   {
     id: "freddys-dream-maze",

--- a/madia.new/public/secret/1989/power-glove-prodigy/index.html
+++ b/madia.new/public/secret/1989/power-glove-prodigy/index.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Power Glove Prodigy</title>
+    <link rel="stylesheet" href="../../secret-annex-snes.css" />
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="power-glove-prodigy.css" />
+  </head>
+  <body class="secret-annex-snes power-glove-prodigy">
+    <a class="skip-link" href="#main-content">Skip to gameplay</a>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="page-header">
+      <p class="eyebrow">Level 4 · 1989 Arcade</p>
+      <h1>Power Glove Prodigy</h1>
+      <p class="subtitle">
+        Jack into the championship stage, thread impossible controller strings, and detonate hype for a lights-out finish.
+      </p>
+    </header>
+    <main id="main-content" class="page-layout">
+      <section class="briefing" aria-labelledby="briefing-title">
+        <h2 id="briefing-title">Tournament Briefing</h2>
+        <p>
+          Regional qualifiers are history—the neon finals demand frame-perfect strings. Read the play card, slam the inputs in
+          order, and keep the hype meter blazing to activate Turbo Overflow. Every crowd eruption spikes your multiplier and
+          slings confetti across the arena.
+        </p>
+        <ul class="callouts">
+          <li>
+            <strong>Phase ladder:</strong> Qualifiers warm you up, Semifinals twist the strings, and the Championship throws
+            split-second resets.
+          </li>
+          <li>
+            <strong>Hype meter:</strong> Every clean clear boosts hype; misfires drain it. Fill it to 80% to trigger a Turbo
+            Overflow surge.
+          </li>
+          <li>
+            <strong>Combo flow:</strong> Strings can chain up to five beats. Keep the streak alive to rocket the multiplier
+            before the spotlight fades.
+          </li>
+        </ul>
+        <section class="controls" aria-labelledby="controls-title">
+          <h3 id="controls-title">Controls</h3>
+          <dl>
+            <div>
+              <dt>Press face buttons</dt>
+              <dd>
+                Click or tap the glowing pads, or use <span class="key-label">Z</span>/<span class="key-label">X</span> for
+                <span class="key-label">A</span>/<span class="key-label">B</span>.
+              </dd>
+            </div>
+            <div>
+              <dt>Nudge the D-pad</dt>
+              <dd>
+                Use the <span class="key-label">↑</span> and <span class="key-label">↓</span> arrows (or
+                <span class="key-label">K</span>/<span class="key-label">J</span>) for directional cues.
+              </dd>
+            </div>
+            <div>
+              <dt>Start / Reset</dt>
+              <dd>
+                Hit <span class="key-label">Start Tournament</span> to launch the ladder or tap <span class="key-label">Reset</span>
+                for another run.
+              </dd>
+            </div>
+          </dl>
+        </section>
+      </section>
+      <section class="arena" aria-labelledby="arena-title">
+        <div class="arena-header">
+          <h2 id="arena-title">Championship Stage</h2>
+          <div class="arena-controls">
+            <button type="button" class="action-button" id="start-button">Start Tournament</button>
+            <button type="button" class="action-button" id="reset-button">Reset</button>
+          </div>
+        </div>
+        <p class="arena-help">
+          Watch the sequence, punch the pads in order, and keep hype rising. Miss a beat and the crowd chills, dragging the
+          multiplier down.
+        </p>
+        <div class="scoreboard" role="group" aria-label="Tournament status">
+          <div class="score-card">
+            <p class="score-label">Score</p>
+            <p class="score-value" id="score-value">0</p>
+            <p class="score-detail">Multiplier <span id="multiplier-value">×1.0</span></p>
+          </div>
+          <div class="score-card">
+            <p class="score-label">Streak</p>
+            <p class="score-value" id="streak-value">0</p>
+            <p class="score-detail">Best <span id="streak-best">0</span></p>
+          </div>
+          <div class="score-card hype-card" aria-live="polite">
+            <p class="score-label">Hype Meter</p>
+            <div class="hype-meter" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+              <div class="hype-fill" id="hype-fill"></div>
+            </div>
+            <p class="score-detail"><span id="hype-value">0%</span> charged</p>
+          </div>
+          <div class="score-card phase-card">
+            <p class="score-label">Phase Track</p>
+            <ol class="phase-track" id="phase-track">
+              <li data-phase="qualifiers">Qualifiers</li>
+              <li data-phase="semifinals">Semifinals</li>
+              <li data-phase="championship">Championship</li>
+            </ol>
+          </div>
+        </div>
+        <div class="challenge-area">
+          <article class="challenge-card" aria-live="polite">
+            <header class="challenge-header">
+              <h3 id="challenge-title">Awaiting start.</h3>
+              <div class="challenge-timer" id="challenge-timer" aria-hidden="true"></div>
+            </header>
+            <p class="challenge-text" id="challenge-text">Press Start Tournament to begin the hype run.</p>
+            <div class="pattern" aria-label="Input pattern" id="pattern-display"></div>
+          </article>
+          <div class="controller" role="group" aria-label="Input controller">
+            <button type="button" class="pad-button" data-input="A">
+              <span class="pad-label">A</span>
+              <span class="pad-help">Z</span>
+            </button>
+            <button type="button" class="pad-button" data-input="B">
+              <span class="pad-label">B</span>
+              <span class="pad-help">X</span>
+            </button>
+            <button type="button" class="pad-button" data-input="UP">
+              <span class="pad-label">↑</span>
+              <span class="pad-help">↑ / K</span>
+            </button>
+            <button type="button" class="pad-button" data-input="DOWN">
+              <span class="pad-label">↓</span>
+              <span class="pad-help">↓ / J</span>
+            </button>
+          </div>
+        </div>
+        <p class="status-line" id="status-line" role="status" aria-live="polite">Welcome to the championship.</p>
+        <section class="event-log" aria-labelledby="event-log-title">
+          <h3 id="event-log-title">Crowd Feed</h3>
+          <ul id="event-log"></ul>
+        </section>
+      </section>
+    </main>
+    <section class="wrap-up" id="wrap-up" hidden role="dialog" aria-modal="true" aria-labelledby="wrap-up-title" tabindex="-1">
+      <div class="wrap-up-card">
+        <header class="wrap-up-header">
+          <h2 id="wrap-up-title">Tournament Results</h2>
+          <p id="wrap-up-subtitle">Your run is in the books.</p>
+        </header>
+        <dl class="wrap-up-stats">
+          <div>
+            <dt>Final Score</dt>
+            <dd id="summary-score">0</dd>
+          </div>
+          <div>
+            <dt>Best Streak</dt>
+            <dd id="summary-streak">0</dd>
+          </div>
+          <div>
+            <dt>Peak Multiplier</dt>
+            <dd id="summary-multiplier">×1.0</dd>
+          </div>
+          <div>
+            <dt>Hype Peak</dt>
+            <dd id="summary-hype">0%</dd>
+          </div>
+        </dl>
+        <footer class="wrap-up-actions">
+          <button type="button" class="action-button" id="wrap-up-replay">Run It Back</button>
+          <button type="button" class="action-button" id="wrap-up-close">Close</button>
+        </footer>
+      </div>
+    </section>
+    <script type="module" src="power-glove-prodigy.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/1989/power-glove-prodigy/power-glove-prodigy.css
+++ b/madia.new/public/secret/1989/power-glove-prodigy/power-glove-prodigy.css
@@ -1,0 +1,537 @@
+:root {
+  color-scheme: dark;
+}
+
+.power-glove-prodigy {
+  --pgp-bg: radial-gradient(circle at 15% 20%, rgba(45, 212, 191, 0.12), transparent 55%),
+    radial-gradient(circle at 85% 15%, rgba(125, 211, 252, 0.18), transparent 50%),
+    radial-gradient(circle at 50% 80%, rgba(244, 114, 182, 0.16), transparent 55%),
+    #050a1c;
+  --pgp-panel: rgba(7, 12, 30, 0.85);
+  --pgp-panel-border: rgba(148, 163, 184, 0.35);
+  --pgp-highlight: #7c3aed;
+  --pgp-highlight-strong: #a855f7;
+  --pgp-cyan: #22d3ee;
+  --pgp-gold: #facc15;
+  background: var(--pgp-bg);
+  min-height: 100vh;
+}
+
+.power-glove-prodigy .page-layout {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  padding-bottom: 4rem;
+}
+
+@media (max-width: 1100px) {
+  .power-glove-prodigy .page-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.power-glove-prodigy .briefing,
+.power-glove-prodigy .arena {
+  background: var(--pgp-panel);
+  border: 1px solid var(--pgp-panel-border);
+  border-radius: 1.5rem;
+  box-shadow: 0 2rem 4rem rgba(5, 10, 28, 0.45);
+  padding: 2rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.power-glove-prodigy .briefing::before,
+.power-glove-prodigy .arena::before {
+  content: "";
+  position: absolute;
+  inset: -30% -20% auto;
+  height: 60%;
+  background: linear-gradient(120deg, rgba(124, 58, 237, 0.28), rgba(37, 99, 235, 0));
+  pointer-events: none;
+  transform: rotate(-3deg);
+}
+
+.power-glove-prodigy .briefing > *,
+.power-glove-prodigy .arena > * {
+  position: relative;
+  z-index: 1;
+}
+
+.power-glove-prodigy .callouts {
+  display: grid;
+  gap: 1rem;
+  margin: 1.5rem 0 2rem;
+  padding: 0;
+  list-style: none;
+}
+
+.power-glove-prodigy .callouts li {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  background: rgba(15, 23, 42, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(124, 58, 237, 0.12);
+}
+
+.power-glove-prodigy .controls dl {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.power-glove-prodigy .controls dt {
+  font-weight: 600;
+  color: rgba(244, 244, 255, 0.9);
+}
+
+.power-glove-prodigy .controls dd {
+  margin: 0.35rem 0 0;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.power-glove-prodigy .arena-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.power-glove-prodigy .arena-controls {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.power-glove-prodigy .arena-help {
+  margin: 1.5rem 0;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.power-glove-prodigy .scoreboard {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.power-glove-prodigy .score-card {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+  box-shadow: inset 0 0 0 1px rgba(124, 58, 237, 0.12);
+}
+
+.power-glove-prodigy .score-label {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.power-glove-prodigy .score-value {
+  margin: 0.5rem 0 0;
+  font-size: 2.35rem;
+  font-weight: 600;
+  color: var(--pgp-cyan);
+}
+
+.power-glove-prodigy .score-detail {
+  margin: 0.5rem 0 0;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.power-glove-prodigy .hype-card .score-value {
+  font-size: 1.9rem;
+}
+
+.hype-meter {
+  margin: 0.75rem 0 0;
+  height: 0.9rem;
+  border-radius: 999px;
+  background: rgba(30, 41, 59, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  overflow: hidden;
+  position: relative;
+}
+
+.hype-fill {
+  --progress: 0;
+  position: absolute;
+  inset: 0;
+  width: calc(var(--progress) * 1%);
+  background: linear-gradient(90deg, #22d3ee, #38bdf8, #f97316);
+  box-shadow: 0 0.8rem 1.8rem rgba(34, 211, 238, 0.35);
+  transition: width 200ms ease, box-shadow 200ms ease;
+}
+
+.power-glove-prodigy .phase-card {
+  grid-column: span 2;
+}
+
+.power-glove-prodigy .phase-track {
+  display: flex;
+  gap: 0.65rem;
+  margin: 0.75rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.power-glove-prodigy .phase-track li {
+  flex: 1;
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.9rem;
+  text-align: center;
+  font-weight: 600;
+  font-size: 0.95rem;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  color: rgba(226, 232, 240, 0.75);
+  position: relative;
+  overflow: hidden;
+}
+
+.power-glove-prodigy .phase-track li[data-complete="true"] {
+  color: rgba(250, 250, 255, 0.95);
+  border-color: rgba(250, 204, 21, 0.7);
+  box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.35);
+}
+
+.power-glove-prodigy .phase-track li[data-current="true"] {
+  color: rgba(34, 211, 238, 0.95);
+  border-color: rgba(34, 211, 238, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(34, 211, 238, 0.35);
+}
+
+.challenge-area {
+  display: grid;
+  gap: 1.5rem;
+  margin: 2.25rem 0 2rem;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+}
+
+@media (max-width: 980px) {
+  .challenge-area {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.challenge-card {
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  box-shadow: inset 0 0 0 1px rgba(124, 58, 237, 0.12);
+}
+
+.challenge-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.challenge-header h3 {
+  margin: 0;
+  font-size: 1.35rem;
+  color: rgba(248, 250, 252, 0.95);
+}
+
+.challenge-timer {
+  --progress: 0;
+  flex-shrink: 0;
+  width: 5rem;
+  height: 5rem;
+  border-radius: 999px;
+  background: conic-gradient(
+    from -90deg,
+    rgba(124, 58, 237, 0.75) calc(var(--progress) * 100%),
+    rgba(15, 23, 42, 0.85) calc(var(--progress) * 100%)
+  );
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  position: relative;
+}
+
+.challenge-timer::after {
+  content: "";
+  width: 3.35rem;
+  height: 3.35rem;
+  border-radius: 50%;
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.challenge-text {
+  margin: 1rem 0 1.25rem;
+  font-size: 1.05rem;
+  line-height: 1.5;
+  color: rgba(226, 232, 240, 0.88);
+}
+
+.pattern {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.pattern-step {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 1rem;
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: rgba(248, 250, 252, 0.92);
+  background: rgba(30, 41, 59, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(124, 58, 237, 0.18);
+  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.pattern-step[data-state="active"] {
+  transform: scale(1.08);
+  border-color: rgba(34, 211, 238, 0.65);
+  box-shadow: 0 1.2rem 2.4rem rgba(34, 211, 238, 0.25);
+}
+
+.pattern-step[data-state="complete"] {
+  background: rgba(124, 58, 237, 0.85);
+  border-color: rgba(250, 204, 21, 0.7);
+  box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.35), 0 1.2rem 2.6rem rgba(124, 58, 237, 0.35);
+}
+
+.pattern-step[data-state="failed"] {
+  background: rgba(239, 68, 68, 0.22);
+  border-color: rgba(239, 68, 68, 0.6);
+  color: rgba(254, 226, 226, 0.95);
+  box-shadow: inset 0 0 0 1px rgba(239, 68, 68, 0.35);
+}
+
+.controller {
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+}
+
+.pad-button {
+  position: relative;
+  display: grid;
+  place-items: center;
+  border-radius: 1.2rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.75), rgba(15, 23, 42, 0.95));
+  padding: 1.35rem 1rem;
+  font-weight: 700;
+  font-size: 1.4rem;
+  color: rgba(248, 250, 252, 0.95);
+  transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease;
+  box-shadow: 0 1.2rem 2.4rem rgba(37, 99, 235, 0.35);
+}
+
+.pad-button .pad-help {
+  margin-top: 0.35rem;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.pad-button[data-input="B"] {
+  background: linear-gradient(135deg, rgba(236, 72, 153, 0.8), rgba(15, 23, 42, 0.95));
+  box-shadow: 0 1.2rem 2.4rem rgba(236, 72, 153, 0.35);
+}
+
+.pad-button[data-input="UP"] {
+  background: linear-gradient(135deg, rgba(45, 212, 191, 0.8), rgba(15, 23, 42, 0.95));
+  box-shadow: 0 1.2rem 2.4rem rgba(45, 212, 191, 0.35);
+}
+
+.pad-button[data-input="DOWN"] {
+  background: linear-gradient(135deg, rgba(250, 204, 21, 0.85), rgba(15, 23, 42, 0.95));
+  color: rgba(15, 23, 42, 0.95);
+  box-shadow: 0 1.2rem 2.4rem rgba(250, 204, 21, 0.35);
+}
+
+.pad-button:is(:hover, :focus-visible) {
+  transform: translateY(-4px);
+  border-color: rgba(248, 250, 252, 0.65);
+  box-shadow: 0 1.6rem 2.8rem rgba(94, 234, 212, 0.35);
+}
+
+.pad-button.is-active {
+  transform: translateY(2px) scale(0.96);
+  box-shadow: 0 0.75rem 2.2rem rgba(34, 211, 238, 0.45);
+}
+
+.status-line {
+  margin: 1rem 0 1.5rem;
+  padding: 0.9rem 1.25rem;
+  border-radius: 0.95rem;
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  font-weight: 500;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.event-log {
+  margin-top: 1.5rem;
+}
+
+.event-log ul {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  max-height: 16rem;
+  overflow-y: auto;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.event-log li {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.85rem;
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.88);
+}
+
+.wrap-up {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(3, 6, 18, 0.72);
+  backdrop-filter: blur(9px);
+  z-index: 50;
+}
+
+.wrap-up-card {
+  background: rgba(7, 12, 30, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 1.75rem;
+  padding: 2rem;
+  width: min(480px, calc(100% - 2rem));
+  box-shadow: 0 2.5rem 4.5rem rgba(7, 12, 30, 0.55);
+}
+
+.wrap-up-header h2 {
+  margin: 0;
+  font-size: 1.9rem;
+  color: rgba(248, 250, 252, 0.95);
+}
+
+.wrap-up-header p {
+  margin: 0.35rem 0 0;
+  color: rgba(203, 213, 225, 0.85);
+}
+
+.wrap-up-stats {
+  display: grid;
+  gap: 1.2rem;
+  margin: 1.75rem 0;
+}
+
+.wrap-up-stats div {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 1.05rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.wrap-up-stats dd {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--pgp-cyan);
+}
+
+.wrap-up-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+}
+
+.power-glove-prodigy .action-button {
+  background: linear-gradient(135deg, rgba(34, 211, 238, 0.85), rgba(59, 130, 246, 0.85));
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.9rem;
+  padding: 0.75rem 1.4rem;
+  color: rgba(15, 23, 42, 0.95);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: transform 120ms ease, box-shadow 120ms ease, filter 120ms ease;
+}
+
+.power-glove-prodigy .action-button:is(:hover, :focus-visible) {
+  transform: translateY(-3px);
+  box-shadow: 0 1.2rem 2.4rem rgba(34, 211, 238, 0.35);
+}
+
+.power-glove-prodigy .arena.is-shake {
+  animation: pgp-shake 280ms ease;
+}
+
+.power-glove-prodigy .arena[data-mode="turbo"]::after {
+  content: "Turbo Overflow";
+  position: absolute;
+  top: 1.2rem;
+  right: 1.5rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(250, 204, 21, 0.9), rgba(249, 115, 22, 0.75));
+  color: rgba(15, 23, 42, 0.95);
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 1rem 2rem rgba(249, 115, 22, 0.35);
+  animation: pgp-burst 1.6s ease infinite;
+  z-index: 2;
+}
+
+@keyframes pgp-shake {
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  25% {
+    transform: translate3d(-6px, 4px, 0);
+  }
+  50% {
+    transform: translate3d(5px, -4px, 0);
+  }
+  75% {
+    transform: translate3d(-4px, 3px, 0);
+  }
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes pgp-burst {
+  0%,
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  50% {
+    opacity: 0.65;
+    transform: translateY(-4px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .power-glove-prodigy *,
+  .power-glove-prodigy *::before,
+  .power-glove-prodigy *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/madia.new/public/secret/1989/power-glove-prodigy/power-glove-prodigy.js
+++ b/madia.new/public/secret/1989/power-glove-prodigy/power-glove-prodigy.js
@@ -1,0 +1,741 @@
+import { initHighScoreBanner } from "../arcade-scores.js";
+import { getScoreConfig } from "../score-config.js";
+import { mountParticleField } from "../particles.js";
+import { autoEnhanceFeedback, createLogChannel, createStatusChannel } from "../feedback.js";
+
+const particleField = mountParticleField({
+  effects: {
+    palette: ["#22d3ee", "#7c3aed", "#f97316", "#facc15", "#a855f7"],
+    ambientDensity: 0.68,
+  },
+});
+
+const scoreConfig = getScoreConfig("power-glove-prodigy");
+const highScore = initHighScoreBanner({
+  gameId: "power-glove-prodigy",
+  label: scoreConfig.label,
+  format: scoreConfig.format,
+  emptyText: scoreConfig.empty,
+});
+
+const startButton = document.getElementById("start-button");
+const resetButton = document.getElementById("reset-button");
+const arena = document.querySelector(".arena");
+const scoreValue = document.getElementById("score-value");
+const multiplierValue = document.getElementById("multiplier-value");
+const streakValue = document.getElementById("streak-value");
+const streakBestValue = document.getElementById("streak-best");
+const hypeFill = document.getElementById("hype-fill");
+const hypeValue = document.getElementById("hype-value");
+const phaseTrack = document.getElementById("phase-track");
+const challengeTitle = document.getElementById("challenge-title");
+const challengeText = document.getElementById("challenge-text");
+const patternDisplay = document.getElementById("pattern-display");
+const challengeTimer = document.getElementById("challenge-timer");
+const statusLine = document.getElementById("status-line");
+const logList = document.getElementById("event-log");
+const wrapUp = document.getElementById("wrap-up");
+const wrapUpScore = document.getElementById("summary-score");
+const wrapUpStreak = document.getElementById("summary-streak");
+const wrapUpMultiplier = document.getElementById("summary-multiplier");
+const wrapUpHype = document.getElementById("summary-hype");
+const wrapUpReplay = document.getElementById("wrap-up-replay");
+const wrapUpClose = document.getElementById("wrap-up-close");
+
+autoEnhanceFeedback(document.body);
+const statusChannel = createStatusChannel(statusLine);
+const logChannel = createLogChannel(logList, { limit: 20, mode: "prepend" });
+
+const INPUTS = {
+  A: {
+    id: "A",
+    label: "A",
+    icon: "A",
+    keys: ["KeyZ", "KeyA", "Digit1", "Numpad1"],
+  },
+  B: {
+    id: "B",
+    label: "B",
+    icon: "B",
+    keys: ["KeyX", "KeyS", "Digit2", "Numpad2"],
+  },
+  UP: {
+    id: "UP",
+    label: "Up",
+    icon: "↑",
+    keys: ["ArrowUp", "KeyK", "Numpad8"],
+  },
+  DOWN: {
+    id: "DOWN",
+    label: "Down",
+    icon: "↓",
+    keys: ["ArrowDown", "KeyJ", "Numpad5"],
+  },
+};
+
+const TRACKS = [
+  {
+    id: "qualifiers",
+    name: "Qualifiers",
+    intro: "Qualifier lights glow. Keep the strings crisp to impress the scouts.",
+    outro: "Qualifiers conquered. The pit crew swaps carts for semifinals.",
+    basePoints: 280,
+    hypeBoost: 12,
+    challenges: [
+      {
+        id: "warp-zone",
+        title: "Warp Zone Warmup",
+        text: "Queue the warp whistle flourish and slide into the hidden lane before the camera swing.",
+        pattern: ["UP", "UP", "DOWN", "DOWN"],
+        window: 5200,
+        successLog: "Warp Zone slotted. Crowd warms up with a synth sweep.",
+        failureLog: "Warp string fumbled. Spotlight drifts to the rival station.",
+      },
+      {
+        id: "bonus-chain",
+        title: "Bonus Chain Mash",
+        text: "Snag the bonus coins with alternating taps—no dropped beats or the announcer yawns.",
+        pattern: ["A", "B", "A", "B"],
+        window: 5000,
+        successLog: "Bonus chain flawless. Multiplier display pulses neon.",
+        failureLog: "Bonus chain scuffed. Panel meter flickers in disappointment.",
+      },
+      {
+        id: "pipeline-drift",
+        title: "Pipeline Drift",
+        text: "Feather the d-pad to dodge the rotating drones and land back on the track with swagger.",
+        pattern: ["UP", "DOWN", "DOWN", "UP"],
+        window: 5400,
+        successLog: "Pipeline drift perfect. Hype meter hums louder.",
+        failureLog: "Drone collision. Crowd murmurs and the lights dim.",
+      },
+    ],
+  },
+  {
+    id: "semifinals",
+    name: "Semifinals",
+    intro: "Semifinal bracket begins. Commentary booth is tracking every flick.",
+    outro: "Semifinals secure. Championship board flips to your name.",
+    basePoints: 340,
+    hypeBoost: 16,
+    challenges: [
+      {
+        id: "cliff-side",
+        title: "Cliffside Boost",
+        text: "Turbo off the canyon edge, charge the glove, and land on the bonus pad.",
+        pattern: ["B", "B", "UP", "A", "UP"],
+        window: 5200,
+        successLog: "Cliffside boost landed. Crowd erupts in laser-white confetti.",
+        failureLog: "Turbo mistimed. Canyon echoes with a collective gasp.",
+      },
+      {
+        id: "mirror-match",
+        title: "Mirror Match Mindgame",
+        text: "Predict the mirrored opponent and reverse their rhythm without blinking.",
+        pattern: ["DOWN", "UP", "A", "DOWN", "B"],
+        window: 5600,
+        successLog: "Mirror broken. Rival glances over in disbelief.",
+        failureLog: "Mirror steals the round. Hype leaks through the floor grate.",
+      },
+      {
+        id: "combo-finale",
+        title: "Combo Finale",
+        text: "The judges cue a tricky five-piece. Hit every cue to keep your semifinal advantage.",
+        pattern: ["A", "UP", "B", "DOWN", "A"],
+        window: 5500,
+        successLog: "Combo finale perfect. The booth shouts about Turbo Overflow chances.",
+        failureLog: "Combo finale slips. The monitors flash a warning banner.",
+      },
+    ],
+  },
+  {
+    id: "championship",
+    name: "Championship",
+    intro: "Championship spotlight ignites. Every beat is a broadcast highlight.",
+    outro: "Champion crowned. The crowd chants your callsign.",
+    basePoints: 420,
+    hypeBoost: 22,
+    challenges: [
+      {
+        id: "tournament-glide",
+        title: "Tournament Glide",
+        text: "Float between obstacles, double-tap to hover, and spike the landing on the scoring pad.",
+        pattern: ["UP", "A", "UP", "B", "DOWN"],
+        window: 5600,
+        successLog: "Tournament glide nails it. Hype meter blazes near capacity.",
+        failureLog: "Hover misfire. Crowd dims and the announcer hesitates.",
+      },
+      {
+        id: "power-gauntlet",
+        title: "Power Gauntlet",
+        text: "The glove glows red-hot—chain alternating taps to deflect every incoming projectile.",
+        pattern: ["A", "B", "A", "B", "A"],
+        window: 5400,
+        successLog: "Power gauntlet cleared. Sparks spiral toward the rafters.",
+        failureLog: "Gauntlet overload. Sparks fizzle before the scoreboard.",
+      },
+      {
+        id: "turbo-overflow",
+        title: "Turbo Overflow",
+        text: "Crowd demands the secret macro. Cycle d-pad flicks before sealing with a face button blitz.",
+        pattern: ["DOWN", "DOWN", "UP", "UP", "B", "A"],
+        window: 5800,
+        successLog: "Turbo Overflow unleashed. Arena bathed in violet streaks.",
+        failureLog: "Overflow stalled. Pressure gauge falls back to zero.",
+      },
+      {
+        id: "victory-crescendo",
+        title: "Victory Crescendo",
+        text: "Final string—echo the theme, swap pads fast, and hold the last note to stop the clock.",
+        pattern: ["A", "UP", "B", "DOWN", "UP", "A"],
+        window: 6000,
+        successLog: "Victory Crescendo echoes. Championship trophy lifts into view.",
+        failureLog: "Crescendo clipped. Trophy hover falters before settling.",
+      },
+    ],
+  },
+];
+
+const padButtons = new Map();
+document.querySelectorAll(".pad-button").forEach((button) => {
+  const inputId = button.dataset.input;
+  if (inputId) {
+    padButtons.set(inputId, button);
+  }
+});
+
+const KEY_MAP = new Map();
+Object.values(INPUTS).forEach((input) => {
+  input.keys.forEach((key) => {
+    KEY_MAP.set(key, input.id);
+  });
+});
+
+const state = {
+  playing: false,
+  summaryOpen: false,
+  trackIndex: 0,
+  challengeIndex: 0,
+  stepIndex: 0,
+  score: 0,
+  hype: 0,
+  multiplier: 1,
+  streak: 0,
+  bestStreak: 0,
+  multiplierPeak: 1,
+  hypePeak: 0,
+  awaitingInput: false,
+  turboActive: false,
+  turboSteps: 0,
+};
+
+let timerId = null;
+let timerDeadline = 0;
+let timerDuration = 0;
+let audioContext = null;
+
+function ensureAudioContext() {
+  if (audioContext) {
+    if (audioContext.state === "suspended") {
+      audioContext.resume().catch(() => {
+        /* ignore */
+      });
+    }
+    return audioContext;
+  }
+  const Ctor = window.AudioContext || window.webkitAudioContext;
+  if (!Ctor) {
+    return null;
+  }
+  audioContext = new Ctor();
+  return audioContext;
+}
+
+function scheduleTone({ frequency, duration = 0.18, delay = 0, gain = 0.18, type = "square" }) {
+  const ctx = ensureAudioContext();
+  if (!ctx) {
+    return;
+  }
+  const osc = ctx.createOscillator();
+  const envelope = ctx.createGain();
+  osc.type = type;
+  osc.frequency.value = frequency;
+  envelope.gain.value = 0;
+  osc.connect(envelope);
+  envelope.connect(ctx.destination);
+  const start = ctx.currentTime + delay;
+  envelope.gain.setValueAtTime(0.0001, start);
+  envelope.gain.linearRampToValueAtTime(gain, start + 0.02);
+  envelope.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+  osc.start(start);
+  osc.stop(start + duration + 0.05);
+}
+
+const fx = {
+  pressPad(inputId) {
+    const button = padButtons.get(inputId);
+    if (!button) {
+      return;
+    }
+    button.classList.remove("is-active");
+    // eslint-disable-next-line no-unused-expressions
+    button.offsetWidth;
+    button.classList.add("is-active");
+    window.setTimeout(() => {
+      button.classList.remove("is-active");
+    }, 140);
+    scheduleTone({ frequency: inputId === "B" ? 392 : 330, duration: 0.1, gain: 0.15, type: "sawtooth" });
+  },
+  stepSuccess() {
+    scheduleTone({ frequency: 523.25, duration: 0.14, gain: 0.16, type: "square" });
+  },
+  successBurst() {
+    particleField.emitBurst(1.08);
+    scheduleTone({ frequency: 659.25, duration: 0.2, gain: 0.2, type: "square" });
+    scheduleTone({ frequency: 783.99, duration: 0.18, delay: 0.12, gain: 0.18, type: "triangle" });
+  },
+  phaseCelebrate() {
+    particleField.emitSparkle(1.16);
+    scheduleTone({ frequency: 880, duration: 0.3, gain: 0.24, type: "triangle" });
+    scheduleTone({ frequency: 1174.66, duration: 0.25, delay: 0.15, gain: 0.2, type: "sawtooth" });
+  },
+  failure() {
+    particleField.emitBurst(0.9);
+    scheduleTone({ frequency: 196, duration: 0.25, gain: 0.22, type: "sawtooth" });
+    scheduleTone({ frequency: 110, duration: 0.35, delay: 0.12, gain: 0.18, type: "triangle" });
+    animateArena("is-shake");
+  },
+  turboOn() {
+    particleField.emitSparkle(1.24);
+    scheduleTone({ frequency: 987.77, duration: 0.4, gain: 0.28, type: "square" });
+    scheduleTone({ frequency: 1318.51, duration: 0.35, delay: 0.18, gain: 0.22, type: "triangle" });
+  },
+};
+
+function animateArena(className) {
+  if (!arena) {
+    return;
+  }
+  arena.classList.remove(className);
+  // eslint-disable-next-line no-unused-expressions
+  arena.offsetWidth;
+  arena.classList.add(className);
+  window.setTimeout(() => {
+    arena.classList.remove(className);
+  }, 320);
+}
+
+function updatePhaseTrack() {
+  const items = phaseTrack.querySelectorAll("li");
+  items.forEach((item, index) => {
+    item.dataset.current = String(index === state.trackIndex);
+    item.dataset.complete = String(index < state.trackIndex);
+  });
+}
+
+function updateScoreboard() {
+  scoreValue.textContent = state.score.toLocaleString();
+  multiplierValue.textContent = `×${state.multiplier.toFixed(1)}`;
+  streakValue.textContent = state.streak.toString();
+  streakBestValue.textContent = state.bestStreak.toString();
+  const hypeRounded = Math.round(state.hype);
+  hypeFill.style.setProperty("--progress", hypeRounded.toString());
+  hypeFill.parentElement?.setAttribute("aria-valuenow", hypeRounded.toString());
+  hypeValue.textContent = `${hypeRounded}%`;
+  if (arena) {
+    if (state.turboActive) {
+      arena.dataset.mode = "turbo";
+    } else {
+      delete arena.dataset.mode;
+    }
+  }
+}
+
+function stopTimer() {
+  if (timerId !== null) {
+    window.cancelAnimationFrame(timerId);
+    timerId = null;
+  }
+}
+
+function startTimer(duration) {
+  stopTimer();
+  timerDuration = duration;
+  timerDeadline = performance.now() + duration;
+  challengeTimer.style.setProperty("--progress", "1");
+  const tick = () => {
+    if (!state.awaitingInput) {
+      timerId = null;
+      challengeTimer.style.setProperty("--progress", "0");
+      return;
+    }
+    const now = performance.now();
+    const remaining = timerDeadline - now;
+    if (remaining <= 0) {
+      timerId = null;
+      challengeTimer.style.setProperty("--progress", "0");
+      handleFailure("timeout");
+      return;
+    }
+    const progress = Math.max(0, remaining / timerDuration);
+    challengeTimer.style.setProperty("--progress", progress.toFixed(3));
+    timerId = window.requestAnimationFrame(tick);
+  };
+  timerId = window.requestAnimationFrame(tick);
+}
+
+function getCurrentTrack() {
+  return TRACKS[state.trackIndex];
+}
+
+function getCurrentChallenge() {
+  const track = getCurrentTrack();
+  if (!track) {
+    return null;
+  }
+  return track.challenges[state.challengeIndex] ?? null;
+}
+
+function renderChallenge(challenge) {
+  challengeTitle.textContent = challenge.title;
+  challengeText.textContent = challenge.text;
+  patternDisplay.innerHTML = "";
+  challenge.pattern.forEach((inputId, index) => {
+    const input = INPUTS[inputId];
+    const step = document.createElement("span");
+    step.className = "pattern-step";
+    step.dataset.input = inputId;
+    if (index === 0) {
+      step.dataset.state = "active";
+    } else {
+      step.dataset.state = "pending";
+    }
+    step.textContent = input?.icon ?? inputId;
+    patternDisplay.append(step);
+  });
+}
+
+function queueNext(callback, delay = 650) {
+  window.setTimeout(() => {
+    callback();
+  }, delay);
+}
+
+function activateTurbo() {
+  if (state.turboActive) {
+    state.turboSteps = Math.max(state.turboSteps, 3);
+    return;
+  }
+  state.turboActive = true;
+  state.turboSteps = 3;
+  fx.turboOn();
+  statusChannel("Turbo Overflow engaged! Multipliers surge for the next strings.", "success");
+  logChannel.push("Turbo Overflow lights the stage. Spectators chant your callsign.", "success");
+  updateScoreboard();
+}
+
+function deactivateTurbo() {
+  if (!state.turboActive) {
+    return;
+  }
+  state.turboActive = false;
+  state.turboSteps = 0;
+  statusChannel("Turbo Overflow winds down. Keep the hype alive to trigger it again.", "info");
+  updateScoreboard();
+}
+
+function handleChallengeClear(challenge) {
+  const track = getCurrentTrack();
+  if (!track) {
+    return;
+  }
+  state.awaitingInput = false;
+  stopTimer();
+  const patternBonus = challenge.pattern.length * 18;
+  const turboMultiplier = state.turboActive ? 1.25 : 1;
+  const baseScore = challenge.points ?? track.basePoints;
+  const streakBonus = state.streak * 24;
+  const increment = Math.round((baseScore + patternBonus + streakBonus) * state.multiplier * turboMultiplier);
+  state.score += increment;
+  state.streak += 1;
+  state.bestStreak = Math.max(state.bestStreak, state.streak);
+  state.multiplier = Math.min(8, state.multiplier + 0.35 + challenge.pattern.length * 0.08 + (state.turboActive ? 0.2 : 0));
+  state.multiplierPeak = Math.max(state.multiplierPeak, state.multiplier);
+  const hypeGain = (challenge.hype ?? track.hypeBoost) + state.streak * 1.5 + (state.turboActive ? 6 : 0);
+  state.hype = Math.min(100, state.hype + hypeGain);
+  state.hypePeak = Math.max(state.hypePeak, state.hype);
+  fx.successBurst();
+  updateScoreboard();
+  logChannel.push(`${track.name}: ${challenge.successLog}`, "success");
+  statusChannel(`${challenge.title} cleared! Multiplier now ×${state.multiplier.toFixed(1)}.`, "success");
+  const patternSteps = patternDisplay.querySelectorAll(".pattern-step");
+  patternSteps.forEach((step) => {
+    step.dataset.state = "complete";
+  });
+  if (!state.turboActive && state.hype >= 80) {
+    activateTurbo();
+  }
+  if (state.turboActive) {
+    state.turboSteps -= 1;
+    if (state.turboSteps <= 0) {
+      deactivateTurbo();
+    }
+  }
+  queueNext(() => {
+    advanceChallenge();
+  }, 800);
+}
+
+function handleFailure(reason) {
+  if (!state.playing || !state.awaitingInput) {
+    return;
+  }
+  const track = getCurrentTrack();
+  const challenge = getCurrentChallenge();
+  state.awaitingInput = false;
+  stopTimer();
+  fx.failure();
+  const isTimeout = reason === "timeout";
+  state.hype = Math.max(0, state.hype - (isTimeout ? 18 : 24));
+  state.multiplier = Math.max(1, state.multiplier - (isTimeout ? 0.6 : 0.8));
+  state.streak = 0;
+  deactivateTurbo();
+  updateScoreboard();
+  const message = challenge?.failureLog ?? "Sequence dropped.";
+  logChannel.push(`${track?.name ?? "Stage"}: ${message}`, "warning");
+  statusChannel(`${challenge?.title ?? "Challenge"} missed. Multiplier steadies at ×${state.multiplier.toFixed(1)}.`, "warning");
+  const patternSteps = patternDisplay.querySelectorAll(".pattern-step");
+  patternSteps.forEach((step) => {
+    if (step.dataset.state !== "complete") {
+      step.dataset.state = "failed";
+    }
+  });
+  queueNext(() => {
+    advanceChallenge();
+  }, 900);
+}
+
+function advanceChallenge() {
+  const track = getCurrentTrack();
+  if (!track) {
+    finishTournament();
+    return;
+  }
+  state.challengeIndex += 1;
+  if (state.challengeIndex >= track.challenges.length) {
+    completeTrack();
+    return;
+  }
+  state.stepIndex = 0;
+  state.awaitingInput = true;
+  const challenge = getCurrentChallenge();
+  renderChallenge(challenge);
+  statusChannel(`${challenge.title}: Execute ${challenge.pattern.length}-beat string.`, "info");
+  startTimer(challenge.window ?? 5200);
+}
+
+function completeTrack() {
+  const track = getCurrentTrack();
+  fx.phaseCelebrate();
+  logChannel.push(`${track.name} clear · ${track.outro}`, "success");
+  statusChannel(`${track.name} cleared. ${track.outro}`, "success");
+  state.trackIndex += 1;
+  state.challengeIndex = 0;
+  state.stepIndex = 0;
+  if (state.trackIndex >= TRACKS.length) {
+    finishTournament();
+    return;
+  }
+  updatePhaseTrack();
+  const nextTrack = getCurrentTrack();
+  queueNext(() => {
+    state.awaitingInput = true;
+    renderChallenge(nextTrack.challenges[0]);
+    statusChannel(`${nextTrack.name}: ${nextTrack.intro}`, "info");
+    startTimer(nextTrack.challenges[0].window ?? 5400);
+  }, 1000);
+}
+
+function finishTournament() {
+  stopTimer();
+  state.playing = false;
+  state.awaitingInput = false;
+  deactivateTurbo();
+  updatePhaseTrack();
+  updateScoreboard();
+  statusChannel("Tournament complete! Review the run and chase the leaderboard.", "success");
+  logChannel.push(
+    `Run complete · ${state.score.toLocaleString()} pts · Best streak ${state.bestStreak} · Peak hype ${Math.round(state.hypePeak)}%`,
+    "success",
+  );
+  showSummary();
+  highScore.submit(state.score, {
+    bestStreak: state.bestStreak,
+    peakMultiplier: Number(state.multiplierPeak.toFixed(1)),
+    hypePeak: Math.round(state.hypePeak),
+  });
+}
+
+function resetBoardState() {
+  challengeTitle.textContent = "Awaiting start.";
+  challengeText.textContent = "Press Start Tournament to begin the hype run.";
+  patternDisplay.innerHTML = "";
+  challengeTimer.style.setProperty("--progress", "0");
+}
+
+function resetTournament({ keepSummary = false } = {}) {
+  stopTimer();
+  state.playing = false;
+  state.summaryOpen = false;
+  state.trackIndex = 0;
+  state.challengeIndex = 0;
+  state.stepIndex = 0;
+  state.score = 0;
+  state.hype = 0;
+  state.multiplier = 1;
+  state.streak = 0;
+  state.bestStreak = 0;
+  state.multiplierPeak = 1;
+  state.hypePeak = 0;
+  state.awaitingInput = false;
+  deactivateTurbo();
+  updatePhaseTrack();
+  updateScoreboard();
+  resetBoardState();
+  if (!keepSummary) {
+    hideSummary();
+  }
+  statusChannel("Tournament reset. Hit Start when you're ready to perform.", "info");
+}
+
+function startTournament() {
+  if (state.playing) {
+    return;
+  }
+  ensureAudioContext();
+  resetTournament();
+  state.playing = true;
+  updatePhaseTrack();
+  const track = getCurrentTrack();
+  const challenge = getCurrentChallenge();
+  state.awaitingInput = true;
+  renderChallenge(challenge);
+  statusChannel(`${track.intro}`, "info");
+  logChannel.push(`Tournament start · ${track.name} lights up.`, "info");
+  startTimer(challenge.window ?? 5200);
+}
+
+function showSummary() {
+  wrapUpScore.textContent = state.score.toLocaleString();
+  wrapUpStreak.textContent = state.bestStreak.toString();
+  wrapUpMultiplier.textContent = `×${state.multiplierPeak.toFixed(1)}`;
+  wrapUpHype.textContent = `${Math.round(state.hypePeak)}%`;
+  wrapUp.hidden = false;
+  state.summaryOpen = true;
+  wrapUp.focus({ preventScroll: true });
+}
+
+function hideSummary() {
+  wrapUp.hidden = true;
+  state.summaryOpen = false;
+}
+
+function handlePadButtonClick(event) {
+  const button = event.currentTarget;
+  const inputId = button.dataset.input;
+  if (!inputId) {
+    return;
+  }
+  ensureAudioContext();
+  handleInput(inputId);
+}
+
+function handleInput(inputId) {
+  if (!state.playing || !state.awaitingInput) {
+    return;
+  }
+  fx.pressPad(inputId);
+  const challenge = getCurrentChallenge();
+  if (!challenge) {
+    return;
+  }
+  const expected = challenge.pattern[state.stepIndex];
+  if (inputId !== expected) {
+    handleFailure("mistake");
+    return;
+  }
+  const steps = patternDisplay.querySelectorAll(".pattern-step");
+  const currentStep = steps[state.stepIndex];
+  if (currentStep) {
+    currentStep.dataset.state = "complete";
+  }
+  state.stepIndex += 1;
+  if (state.stepIndex >= challenge.pattern.length) {
+    handleChallengeClear(challenge);
+    return;
+  }
+  const nextStep = steps[state.stepIndex];
+  if (nextStep) {
+    nextStep.dataset.state = "active";
+  }
+  fx.stepSuccess();
+}
+
+function handleKeyDown(event) {
+  if (state.summaryOpen) {
+    if (event.key === "Escape") {
+      hideSummary();
+    }
+    return;
+  }
+  if (event.repeat) {
+    return;
+  }
+  if (event.key === "Enter") {
+    if (!state.playing) {
+      startTournament();
+      event.preventDefault();
+    }
+    return;
+  }
+  const inputId = KEY_MAP.get(event.code);
+  if (!inputId) {
+    return;
+  }
+  if (event.code.startsWith("Arrow")) {
+    event.preventDefault();
+  }
+  handleInput(inputId);
+}
+
+document.addEventListener("keydown", handleKeyDown);
+
+padButtons.forEach((button) => {
+  button.addEventListener("click", handlePadButtonClick);
+});
+
+startButton.addEventListener("click", () => {
+  startTournament();
+});
+
+resetButton.addEventListener("click", () => {
+  resetTournament();
+});
+
+wrapUpReplay.addEventListener("click", () => {
+  hideSummary();
+  startTournament();
+});
+
+wrapUpClose.addEventListener("click", () => {
+  hideSummary();
+  statusChannel("Results saved. Fire up another run when ready.", "info");
+});
+
+wrapUp.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") {
+    hideSummary();
+  }
+});
+
+resetTournament({ keepSummary: true });

--- a/madia.new/public/secret/1989/score-config.js
+++ b/madia.new/public/secret/1989/score-config.js
@@ -154,6 +154,22 @@ export const scoreConfigs = {
       return `${value ?? 0} pts · ${crumbLabel}`;
     },
   }, // Level 15
+  // Level 4
+  "power-glove-prodigy": {
+    label: "Tournament Score",
+    empty: "No tournaments logged yet.",
+    format: ({ value, meta }) => {
+      const streak = Number(meta?.bestStreak ?? 0);
+      const multiplier = Number(meta?.peakMultiplier ?? meta?.multiplierPeak ?? 0);
+      const hype = Number(meta?.hypePeak ?? 0);
+      const streakLabel = streak === 1 ? "1 streak" : `${streak} streak`;
+      const multiplierLabel = Number.isFinite(multiplier) && multiplier > 0
+        ? `×${multiplier.toFixed(1)} peak`
+        : "×1.0 peak";
+      const hypeLabel = `${Math.round(hype)}% hype`;
+      return `${value ?? 0} pts · ${streakLabel} · ${multiplierLabel} · ${hypeLabel}`;
+    },
+  }, // Level 4
   "freddys-dream-maze": {
     label: "Sanity Retained",
     empty: "No dream escapes logged yet.",


### PR DESCRIPTION
## Summary
- add the Level 4 "Power Glove Prodigy" cabinet with turbo-focused gameplay and celebratory FX
- style the tournament stage with neon scoreboard treatments, hype meter, and turbo indicator
- register the new cabinet in the arcade roster and shared score formatter

## Testing
- not run (project has no automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68e16e90345c8328abf7b2cf12604e41