### PR TITLE
feat: amplify freddys dream maze spectacle

### DIFF
--- a/madia.new/public/secret/1989/freddys-dream-maze/freddys-dream-maze.css
+++ b/madia.new/public/secret/1989/freddys-dream-maze/freddys-dream-maze.css
@@ -44,6 +44,110 @@ body.freddys-dream-maze::before {
   }
 }
 
+@keyframes runStartBurst {
+  0% {
+    filter: saturate(1) brightness(1);
+    transform: translateZ(0);
+  }
+  28% {
+    filter: saturate(1.25) brightness(1.12);
+    transform: translateY(-2px);
+  }
+  56% {
+    filter: saturate(1.1) brightness(1.05);
+    transform: translateY(1px);
+  }
+  100% {
+    filter: saturate(1) brightness(1);
+    transform: translateZ(0);
+  }
+}
+
+@keyframes fearShift {
+  0% {
+    filter: hue-rotate(0deg) saturate(1);
+  }
+  40% {
+    filter: hue-rotate(-18deg) saturate(1.25);
+  }
+  100% {
+    filter: hue-rotate(0deg) saturate(1);
+  }
+}
+
+@keyframes manifestShock {
+  0% {
+    transform: translateY(0);
+    filter: saturate(1);
+  }
+  28% {
+    transform: translateY(-3px);
+    filter: hue-rotate(-12deg) saturate(1.3);
+  }
+  58% {
+    transform: translateY(3px);
+    filter: hue-rotate(16deg) saturate(1.18);
+  }
+  100% {
+    transform: translateY(0);
+    filter: saturate(1);
+  }
+}
+
+@keyframes chaseAlarm {
+  0% {
+    filter: brightness(1) saturate(1);
+  }
+  30% {
+    filter: brightness(1.2) saturate(1.25);
+  }
+  60% {
+    filter: brightness(0.9) saturate(0.85);
+  }
+  100% {
+    filter: brightness(1) saturate(1);
+  }
+}
+
+@keyframes shiverJolt {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-2px);
+  }
+  40% {
+    transform: translateX(2px);
+  }
+  60% {
+    transform: translateX(-1px);
+  }
+  80% {
+    transform: translateX(1px);
+  }
+}
+
+body.freddys-dream-maze.is-run-start {
+  animation: runStartBurst 0.9s ease;
+}
+
+body.freddys-dream-maze.is-fear-shift {
+  animation: fearShift 1s ease;
+}
+
+body.freddys-dream-maze.is-manifest {
+  animation: manifestShock 1.1s ease;
+}
+
+body.freddys-dream-maze.is-chase {
+  animation: chaseAlarm 0.85s ease;
+}
+
+body.freddys-dream-maze.is-shiver {
+  animation: shiverJolt 0.9s ease;
+}
+
 body[data-fear-state="lucid"].freddys-dream-maze {
   --maze-glow: rgba(56, 189, 248, 0.5);
   --maze-accent: #38bdf8;
@@ -60,6 +164,52 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
   background: radial-gradient(circle at 30% 30%, rgba(239, 68, 68, 0.22), transparent 60%),
     radial-gradient(circle at 70% 70%, rgba(88, 28, 135, 0.3), transparent 55%),
     linear-gradient(160deg, #05010a, #120309 45%, #05010a 90%);
+}
+
+body.freddys-dream-maze[data-manifestation] .simulator {
+  box-shadow: 0 24px 55px rgba(2, 6, 23, 0.8), 0 0 28px rgba(248, 113, 113, 0.32);
+}
+
+body.freddys-dream-maze[data-manifestation="claustrophobic"] .simulator {
+  box-shadow: 0 24px 55px rgba(2, 6, 23, 0.8), 0 0 28px rgba(251, 191, 36, 0.32);
+}
+
+body.freddys-dream-maze[data-manifestation="drowning"] .simulator {
+  box-shadow: 0 24px 55px rgba(2, 6, 23, 0.8), 0 0 32px rgba(56, 189, 248, 0.35);
+}
+
+body.freddys-dream-maze[data-manifestation="silence"] .simulator {
+  box-shadow: 0 24px 55px rgba(2, 6, 23, 0.8), 0 0 24px rgba(148, 163, 184, 0.32);
+}
+
+body.freddys-dream-maze[data-manifestation="arachnid"] .environment-visual {
+  box-shadow: 0 0 32px rgba(248, 113, 113, 0.35);
+}
+
+body.freddys-dream-maze[data-manifestation="claustrophobic"] .environment-visual {
+  box-shadow: 0 0 32px rgba(251, 191, 36, 0.35);
+}
+
+body.freddys-dream-maze[data-manifestation="drowning"] .environment-visual {
+  box-shadow: 0 0 36px rgba(56, 189, 248, 0.4);
+}
+
+body.freddys-dream-maze[data-manifestation="silence"] .environment-visual {
+  box-shadow: 0 0 30px rgba(148, 163, 184, 0.35);
+}
+
+body.freddys-dream-maze[data-chase="active"] .simulator {
+  animation: chaseBeacon 1s ease-in-out infinite;
+}
+
+@keyframes chaseBeacon {
+  0%,
+  100% {
+    box-shadow: 0 24px 55px rgba(2, 6, 23, 0.8), 0 0 0 rgba(239, 68, 68, 0);
+  }
+  50% {
+    box-shadow: 0 24px 55px rgba(2, 6, 23, 0.8), 0 0 26px rgba(239, 68, 68, 0.45);
+  }
 }
 
 .page-header {
@@ -197,6 +347,26 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
   color: rgba(226, 232, 240, 0.78);
 }
 
+.hud-value.is-flash,
+.hud-note.is-flash {
+  animation: valuePop 0.7s ease;
+}
+
+@keyframes valuePop {
+  0% {
+    transform: translateY(0) scale(1);
+  }
+  35% {
+    transform: translateY(-4px) scale(1.08);
+  }
+  70% {
+    transform: translateY(2px) scale(0.98);
+  }
+  100% {
+    transform: translateY(0) scale(1);
+  }
+}
+
 .hud-meter .meter {
   height: 0.75rem;
   border-radius: 999px;
@@ -212,6 +382,64 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
   box-shadow: 0 0 18px var(--maze-glow);
   transform-origin: left center;
   transition: width 220ms ease-out, background 320ms ease-in;
+}
+
+#sanity-fill.is-heal {
+  animation: sanityHeal 0.9s ease;
+}
+
+#sanity-fill.is-hit {
+  animation: sanityHit 0.85s ease;
+}
+
+#sanity-fill.is-crash {
+  animation: sanityCrash 1.1s ease;
+}
+
+@keyframes sanityHeal {
+  0% {
+    filter: saturate(1);
+  }
+  35% {
+    filter: saturate(1.3) brightness(1.1);
+  }
+  100% {
+    filter: saturate(1);
+  }
+}
+
+@keyframes sanityHit {
+  0% {
+    transform: scaleX(1);
+    filter: saturate(1);
+  }
+  20% {
+    transform: scaleX(0.98) translateY(1px);
+    filter: saturate(0.9) brightness(0.95);
+  }
+  100% {
+    transform: scaleX(1);
+    filter: saturate(1);
+  }
+}
+
+@keyframes sanityCrash {
+  0% {
+    transform: scaleX(1);
+    filter: saturate(1);
+  }
+  25% {
+    transform: scaleX(0.96) translateY(2px);
+    filter: saturate(0.75) brightness(0.9);
+  }
+  55% {
+    transform: scaleX(1.02) translateY(-1px);
+    filter: saturate(1.1) brightness(1.05);
+  }
+  100% {
+    transform: scaleX(1);
+    filter: saturate(1);
+  }
 }
 
 #sanity-meter[data-warning="true"] {
@@ -252,6 +480,22 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
   border: 1px solid rgba(148, 163, 184, 0.2);
 }
 
+.environment-visual.is-glow {
+  animation: envGlow 1s ease;
+}
+
+@keyframes envGlow {
+  0% {
+    box-shadow: 0 0 0 rgba(56, 189, 248, 0);
+  }
+  40% {
+    box-shadow: 0 0 32px rgba(56, 189, 248, 0.35);
+  }
+  100% {
+    box-shadow: 0 0 0 rgba(56, 189, 248, 0);
+  }
+}
+
 .environment-overlay {
   position: absolute;
   inset: 0;
@@ -259,6 +503,18 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
   mix-blend-mode: screen;
   opacity: 0.65;
   animation: overlayDrift 9s ease-in-out infinite;
+}
+
+.environment-overlay.is-pulse {
+  animation: overlayPulse 1s ease, overlayDrift 9s ease-in-out infinite;
+}
+
+.environment-overlay.is-threat {
+  animation: overlayThreat 1.2s ease, overlayDrift 9s ease-in-out infinite;
+}
+
+.environment-overlay.is-sigil {
+  animation: overlaySigil 1.2s ease, overlayDrift 9s ease-in-out infinite;
 }
 
 @keyframes overlayDrift {
@@ -270,6 +526,51 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
   }
   100% {
     transform: scale(1) rotate(0deg);
+  }
+}
+
+@keyframes overlayPulse {
+  0% {
+    opacity: 0.6;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.88;
+    transform: scale(1.06);
+  }
+  100% {
+    opacity: 0.6;
+    transform: scale(1);
+  }
+}
+
+@keyframes overlayThreat {
+  0% {
+    opacity: 0.6;
+    filter: hue-rotate(0deg) saturate(1);
+  }
+  45% {
+    opacity: 0.92;
+    filter: hue-rotate(-14deg) saturate(1.3);
+  }
+  100% {
+    opacity: 0.6;
+    filter: hue-rotate(0deg) saturate(1);
+  }
+}
+
+@keyframes overlaySigil {
+  0% {
+    opacity: 0.7;
+    filter: drop-shadow(0 0 0 rgba(56, 189, 248, 0));
+  }
+  40% {
+    opacity: 0.95;
+    filter: drop-shadow(0 0 28px rgba(56, 189, 248, 0.55));
+  }
+  100% {
+    opacity: 0.7;
+    filter: drop-shadow(0 0 0 rgba(56, 189, 248, 0));
   }
 }
 
@@ -290,6 +591,49 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
   border-radius: 6px;
   box-shadow: inset 0 0 10px rgba(15, 23, 42, 0.8);
   transition: transform 280ms ease, background 220ms ease;
+}
+
+.environment-grid.is-reshuffle span {
+  animation: gridRipple 0.9s ease;
+}
+
+.environment-grid.is-reshuffle span:nth-child(6n + 1) {
+  animation-delay: 0ms;
+}
+
+.environment-grid.is-reshuffle span:nth-child(6n + 2) {
+  animation-delay: 60ms;
+}
+
+.environment-grid.is-reshuffle span:nth-child(6n + 3) {
+  animation-delay: 120ms;
+}
+
+.environment-grid.is-reshuffle span:nth-child(6n + 4) {
+  animation-delay: 180ms;
+}
+
+.environment-grid.is-reshuffle span:nth-child(6n + 5) {
+  animation-delay: 240ms;
+}
+
+.environment-grid.is-reshuffle span:nth-child(6n + 6) {
+  animation-delay: 300ms;
+}
+
+@keyframes gridRipple {
+  0% {
+    transform: scale(1);
+    filter: saturate(1);
+  }
+  45% {
+    transform: scale(1.12);
+    filter: saturate(1.4);
+  }
+  100% {
+    transform: scale(1);
+    filter: saturate(1);
+  }
 }
 
 .environment-grid span.is-active {
@@ -325,6 +669,22 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.decision-options.is-flare {
+  animation: decisionFlare 1s ease;
+}
+
+@keyframes decisionFlare {
+  0% {
+    filter: saturate(1);
+  }
+  40% {
+    filter: saturate(1.3) brightness(1.08);
+  }
+  100% {
+    filter: saturate(1);
+  }
 }
 
 .decision-options button {
@@ -390,6 +750,9 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
 #dream-log li {
   font-size: 0.92rem;
   color: rgba(226, 232, 240, 0.82);
+  opacity: 0;
+  transform: translateY(6px);
+  animation: logRise 0.4s ease forwards;
 }
 
 #dream-log li.is-warning {
@@ -398,6 +761,17 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
 
 #dream-log li.is-danger {
   color: #f87171;
+}
+
+@keyframes logRise {
+  0% {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .wrapup {
@@ -411,6 +785,10 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
   backdrop-filter: blur(12px);
 }
 
+.wrapup.is-appear {
+  animation: wrapupOverlay 0.7s ease;
+}
+
 .wrapup-card {
   background: rgba(15, 23, 42, 0.92);
   border: 1px solid rgba(148, 163, 184, 0.3);
@@ -421,6 +799,32 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
   gap: 1.25rem;
   text-align: center;
   box-shadow: 0 28px 68px rgba(4, 5, 15, 0.75);
+}
+
+.wrapup-card.is-appear {
+  animation: wrapupRise 0.7s ease;
+}
+
+@keyframes wrapupOverlay {
+  0% {
+    opacity: 0;
+    backdrop-filter: blur(2px);
+  }
+  100% {
+    opacity: 1;
+    backdrop-filter: blur(12px);
+  }
+}
+
+@keyframes wrapupRise {
+  0% {
+    opacity: 0;
+    transform: translateY(16px) scale(0.95);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 .wrapup-score-value {
@@ -475,6 +879,21 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
 .manifestation-card {
   border-color: rgba(248, 113, 113, 0.4);
   box-shadow: 0 40px 90px rgba(120, 0, 45, 0.6);
+}
+
+#manifestation.is-open .manifestation-card {
+  animation: manifestRise 0.6s ease;
+}
+
+@keyframes manifestRise {
+  0% {
+    opacity: 0;
+    transform: translateY(18px) scale(0.94);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 .manifestation-warning {
@@ -546,6 +965,10 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
   text-align: center;
 }
 
+#chase-overlay.is-surge .chase-card {
+  animation: chasePulse 0.6s ease;
+}
+
 .chase-meter {
   position: relative;
   height: 16px;
@@ -562,6 +985,37 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
   background: linear-gradient(90deg, rgba(239, 68, 68, 0.4), rgba(239, 68, 68, 0.85));
   transition: width 120ms ease-out;
   box-shadow: 0 0 18px rgba(239, 68, 68, 0.6);
+}
+
+.chase-fill.is-progress {
+  animation: chaseFillBurst 0.7s ease;
+}
+
+@keyframes chasePulse {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 36px 96px rgba(120, 0, 25, 0.65);
+  }
+  45% {
+    transform: scale(1.04);
+    box-shadow: 0 42px 120px rgba(239, 68, 68, 0.5);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 36px 96px rgba(120, 0, 25, 0.65);
+  }
+}
+
+@keyframes chaseFillBurst {
+  0% {
+    box-shadow: 0 0 18px rgba(239, 68, 68, 0.6);
+  }
+  50% {
+    box-shadow: 0 0 28px rgba(239, 68, 68, 0.9);
+  }
+  100% {
+    box-shadow: 0 0 18px rgba(239, 68, 68, 0.6);
+  }
 }
 
 .chase-note {


### PR DESCRIPTION
## Summary
- add a richer audio engine with event-specific stingers and ambient control for Freddy's Dream Maze
- layer new CSS animations and particle flashes across fear states, manifestations, and chase interactions
- enhance HUD, safe zone, and exit feedback with animated pulses and decision flares

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e16e9a50108328b5778521c6535488