### PR TITLE
feat: amplify framed breakout spectacle

### DIFF
--- a/madia.new/public/secret/1989/framed-breakout/framed-breakout.css
+++ b/madia.new/public/secret/1989/framed-breakout/framed-breakout.css
@@ -100,6 +100,58 @@ body {
   transition: width 220ms ease, filter 220ms ease;
 }
 
+.heroism-meter::after {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: 999px;
+  background: radial-gradient(circle at 50% 50%, rgba(56, 189, 248, 0.4), rgba(56, 189, 248, 0));
+  opacity: 0;
+  transform: scaleX(0.95);
+  transition: opacity 220ms ease, transform 220ms ease;
+  pointer-events: none;
+}
+
+body[data-heroism-tier='steady'] .heroism-fill {
+  filter: brightness(1.08) saturate(1.1);
+}
+
+body[data-heroism-tier='steady'] .heroism-meter::after {
+  opacity: 0.35;
+  transform: scaleX(1);
+  animation: heroism-pulse 2.4s ease-in-out infinite;
+}
+
+body[data-heroism-tier='charged'] .heroism-fill {
+  filter: brightness(1.15) saturate(1.25);
+}
+
+body[data-heroism-tier='charged'] .heroism-meter::after {
+  opacity: 0.55;
+  transform: scaleX(1.02);
+  animation: heroism-pulse 1.8s ease-in-out infinite;
+  background: radial-gradient(circle at 50% 50%, rgba(244, 114, 182, 0.45), rgba(56, 189, 248, 0));
+}
+
+body[data-heroism-tier='surged'] .heroism-fill {
+  filter: brightness(1.25) saturate(1.4);
+}
+
+body[data-heroism-tier='surged'] .heroism-meter::after {
+  opacity: 0.85;
+  transform: scaleX(1.08);
+  animation: heroism-burst 1.8s ease-in-out infinite;
+  background: radial-gradient(circle at 50% 50%, rgba(251, 191, 36, 0.55), rgba(244, 114, 182, 0));
+}
+
+body[data-heroism-tier='charged'] .simulator {
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.45), 0 0 28px rgba(244, 114, 182, 0.25);
+}
+
+body[data-heroism-tier='surged'] .simulator {
+  box-shadow: 0 20px 44px rgba(15, 23, 42, 0.55), 0 0 36px rgba(251, 191, 36, 0.28), 0 0 64px rgba(56, 189, 248, 0.18);
+}
+
 .areas-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(18.5rem, 1fr));
@@ -314,6 +366,38 @@ body {
   }
 }
 
+.area-pulse {
+  position: absolute;
+  inset: -2px;
+  border-radius: 24px;
+  border: 2px solid transparent;
+  opacity: 0;
+  transform: scale(0.85);
+  pointer-events: none;
+  z-index: 0;
+  mix-blend-mode: screen;
+}
+
+.area-pulse.is-active {
+  animation: area-pulse-rise 540ms ease-out forwards;
+}
+
+.area-pulse--distraction {
+  border-color: rgba(56, 189, 248, 0.65);
+  background: radial-gradient(circle at 50% 50%, rgba(56, 189, 248, 0.25), rgba(56, 189, 248, 0));
+}
+
+.area-pulse--direct {
+  border-color: rgba(251, 191, 36, 0.65);
+  background: radial-gradient(circle at 50% 50%, rgba(248, 113, 113, 0.22), rgba(251, 191, 36, 0));
+}
+
+.area-pulse--alert {
+  border-color: rgba(248, 113, 113, 0.85);
+  background: radial-gradient(circle at 50% 50%, rgba(248, 113, 113, 0.28), rgba(248, 113, 113, 0));
+  animation: area-pulse-alert 480ms ease-out forwards;
+}
+
 .intel-panel {
   margin-top: 2rem;
   background: rgba(2, 6, 23, 0.8);
@@ -343,6 +427,8 @@ body {
   border-radius: 12px;
   font-size: 0.9rem;
   box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+  position: relative;
+  --pop-delay: 0ms;
 }
 
 .event-feed li[data-tone='warning'] {
@@ -351,6 +437,10 @@ body {
 
 .event-feed li[data-tone='success'] {
   border-left-color: rgba(34, 197, 94, 0.85);
+}
+
+.event-feed li.feed-pop {
+  animation: feed-pop 360ms var(--pop-delay) cubic-bezier(0.32, 0.82, 0.32, 1.05);
 }
 
 .wrapup,
@@ -564,6 +654,72 @@ body.caught-flash::after {
 
 body.heroism-drain .heroism-fill {
   filter: saturate(0.4) brightness(0.7);
+}
+
+@keyframes heroism-pulse {
+  0%,
+  100% {
+    transform: scaleX(1);
+  }
+  50% {
+    transform: scaleX(1.04);
+  }
+}
+
+@keyframes heroism-burst {
+  0% {
+    opacity: 0.85;
+    transform: scaleX(1.02);
+  }
+  45% {
+    opacity: 1;
+    transform: scaleX(1.1);
+  }
+  100% {
+    opacity: 0.85;
+    transform: scaleX(1.02);
+  }
+}
+
+@keyframes area-pulse-rise {
+  0% {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  60% {
+    opacity: 0.75;
+    transform: scale(1.05);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.12);
+  }
+}
+
+@keyframes area-pulse-alert {
+  0% {
+    opacity: 0;
+    transform: scale(0.75);
+  }
+  45% {
+    opacity: 0.9;
+    transform: scale(1.08);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.18);
+  }
+}
+
+@keyframes feed-pop {
+  0% {
+    opacity: 0;
+    transform: translateY(6px) scale(0.95);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 @media (max-width: 960px) {


### PR DESCRIPTION
## Summary
- add heroism tier tracking with reactive UI glows and celebratory audio cues in Framed Breakout
- introduce pulse overlays for guard cards plus animated event feed entries to heighten moment-to-moment feedback
- layer new sound design for distractions, direct hits, and heroism surges to sell the upgraded cabinet experience

## Testing
- Manual via local http://127.0.0.1:5000/secret/1989/framed-breakout/ run

------
https://chatgpt.com/codex/tasks/task_e_68e18916bde08328b2c292fc79f6f5c8