### PR TITLE
feat: amplify osaka dash fx

### DIFF
--- a/madia.new/public/secret/1989/osaka-motorcycle-dash/index.html
+++ b/madia.new/public/secret/1989/osaka-motorcycle-dash/index.html
@@ -118,11 +118,13 @@
         </div>
         <div class="chase-field" id="chase-field" aria-label="Top-down Osaka pursuit" role="presentation">
           <div class="city-grid" aria-hidden="true"></div>
+          <div class="speed-lines" id="speed-lines" aria-hidden="true"></div>
           <div class="witness" id="witness" aria-label="Witness vehicle">
             <div class="witness-glow" aria-hidden="true"></div>
           </div>
           <div class="proximity-ring" id="proximity-ring" aria-hidden="true"></div>
           <div class="player" id="player" aria-label="Player motorcycle"></div>
+          <div class="disabler-effects" id="disabler-effects" aria-hidden="true"></div>
           <div class="hazards" id="hazards" aria-hidden="true"></div>
         </div>
         <p class="status-bar" id="status-bar">Awaiting your signal. Stay sharp.</p>

--- a/madia.new/public/secret/1989/osaka-motorcycle-dash/osaka-motorcycle-dash.css
+++ b/madia.new/public/secret/1989/osaka-motorcycle-dash/osaka-motorcycle-dash.css
@@ -269,6 +269,16 @@
     radial-gradient(circle at 70% 90%, rgba(236, 72, 153, 0.16), transparent 60%),
     linear-gradient(180deg, rgba(2, 6, 23, 0.95), rgba(15, 23, 42, 0.85));
   box-shadow: inset 0 0 0 1px rgba(94, 234, 212, 0.08);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
+}
+
+.chase-field::before {
+  content: "";
+  position: absolute;
+  inset: -10%;
+  background: radial-gradient(circle at center, rgba(248, 113, 113, 0.25), transparent 70%);
+  opacity: 0;
+  pointer-events: none;
 }
 
 .chase-field::after {
@@ -280,6 +290,16 @@
   pointer-events: none;
 }
 
+.chase-field.is-speeding {
+  border-color: rgba(94, 234, 212, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(94, 234, 212, 0.18), 0 0 32px rgba(13, 148, 136, 0.35);
+  filter: saturate(1.12);
+}
+
+.chase-field.is-impact::before {
+  animation: impact-flash 0.6s ease;
+}
+
 .city-grid {
   position: absolute;
   inset: -200%;
@@ -288,6 +308,7 @@
   background-size: 120px 120px;
   animation: grid-scroll 18s linear infinite;
   opacity: 0.65;
+  z-index: 0;
 }
 
 @keyframes grid-scroll {
@@ -297,6 +318,101 @@
   100% {
     transform: translate3d(-120px, 160px, 0);
   }
+}
+
+@keyframes speed-lines-dash {
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  100% {
+    transform: translate3d(-80px, 120px, 0);
+  }
+}
+
+@keyframes halo-pulse {
+  0% {
+    opacity: 0.85;
+    transform: scale(0.6);
+  }
+  70% {
+    opacity: 0.4;
+    transform: scale(1.05);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.25);
+  }
+}
+
+@keyframes boost-thrust {
+  0% {
+    transform: translateX(-50%) scaleY(0.9);
+    opacity: 0.85;
+  }
+  50% {
+    transform: translateX(-50%) scaleY(1.2);
+    opacity: 0.6;
+  }
+  100% {
+    transform: translateX(-50%) scaleY(0.95);
+    opacity: 0.85;
+  }
+}
+
+@keyframes impact-flash {
+  0% {
+    opacity: 0.8;
+    transform: scale(1.05);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.2);
+  }
+}
+
+@keyframes disabler-ring {
+  0% {
+    opacity: 0.85;
+    transform: translate(-50%, -50%) scale(0.55);
+  }
+  60% {
+    opacity: 0.45;
+    transform: translate(-50%, -50%) scale(1.05);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(1.45);
+  }
+}
+
+.speed-lines {
+  position: absolute;
+  inset: -10% -40%;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba(56, 189, 248, 0) 0,
+      rgba(56, 189, 248, 0) 18px,
+      rgba(56, 189, 248, 0.32) 18px,
+      rgba(56, 189, 248, 0.32) 20px
+    ),
+    repeating-linear-gradient(
+      180deg,
+      rgba(236, 72, 153, 0) 0,
+      rgba(236, 72, 153, 0) 24px,
+      rgba(236, 72, 153, 0.25) 24px,
+      rgba(236, 72, 153, 0.25) 26px
+    );
+  opacity: 0;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  animation: speed-lines-dash 1.2s linear infinite;
+  transition: opacity 0.35s ease;
+  z-index: 1;
+}
+
+.chase-field.is-speeding .speed-lines {
+  opacity: 0.85;
 }
 
 .witness,
@@ -312,6 +428,7 @@
   background: linear-gradient(180deg, rgba(251, 191, 36, 0.9), rgba(249, 115, 22, 0.8));
   border-radius: 12px 12px 14px 14px;
   box-shadow: 0 0 18px rgba(250, 204, 21, 0.65);
+  z-index: 3;
 }
 
 .witness::after {
@@ -345,11 +462,31 @@
   box-shadow: 0 0 18px rgba(244, 114, 182, 0.4);
   transform: translate(-50%, -50%);
   transition: border-color 0.25s ease, box-shadow 0.25s ease;
+  z-index: 2;
+  pointer-events: none;
 }
 
 .proximity-ring[data-state="warning"] {
   border-color: rgba(248, 113, 113, 0.7);
   box-shadow: 0 0 24px rgba(248, 113, 113, 0.6);
+}
+
+.proximity-ring::after {
+  content: "";
+  position: absolute;
+  inset: -16px;
+  border-radius: 50%;
+  border: 2px dashed rgba(56, 189, 248, 0.35);
+  opacity: 0;
+  transform: scale(0.75);
+}
+
+.proximity-ring[data-state="warning"]::after {
+  border-color: rgba(248, 113, 113, 0.55);
+}
+
+.proximity-ring.is-pulsing::after {
+  animation: halo-pulse 0.9s ease-out;
 }
 
 .player {
@@ -358,6 +495,7 @@
   border-radius: 50% 50% 12px 12px;
   background: linear-gradient(180deg, rgba(59, 130, 246, 0.9), rgba(139, 92, 246, 0.85));
   box-shadow: 0 0 18px rgba(59, 130, 246, 0.65);
+  z-index: 4;
 }
 
 .player::before {
@@ -382,14 +520,51 @@
   border-radius: 999px;
   background: linear-gradient(180deg, rgba(56, 189, 248, 0.65), transparent);
   transform: translateX(-50%);
-  opacity: 0.6;
+  opacity: 0.55;
   pointer-events: none;
+}
+
+.player[data-boost="true"]::after {
+  animation: boost-thrust 0.45s linear infinite;
+  opacity: 0.9;
 }
 
 .hazards {
   position: absolute;
   inset: 0;
   pointer-events: none;
+  z-index: 4;
+}
+
+.disabler-effects {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.disabler-wave {
+  position: absolute;
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
+  border: 2px solid rgba(59, 130, 246, 0.45);
+  transform: translate(-50%, -50%) scale(0.55);
+  opacity: 0;
+  mix-blend-mode: screen;
+  box-shadow: 0 0 32px rgba(14, 165, 233, 0.4);
+}
+
+.disabler-wave::after {
+  content: "";
+  position: absolute;
+  inset: 16%;
+  border-radius: 50%;
+  border: 2px solid rgba(94, 234, 212, 0.5);
+}
+
+.disabler-wave.is-active {
+  animation: disabler-ring 0.6s ease-out forwards;
 }
 
 .hazard {
@@ -408,6 +583,7 @@
 
 .hazard.is-disabled {
   animation: hazard-fade 0.4s ease forwards;
+  box-shadow: 0 0 24px rgba(34, 211, 238, 0.45);
 }
 
 @keyframes hazard-fade {
@@ -418,6 +594,27 @@
   100% {
     opacity: 0;
     transform: translate(-50%, -50%) scale(0.6);
+  }
+}
+
+.hazard.is-disabled::after {
+  content: "";
+  position: absolute;
+  inset: -12px;
+  border-radius: 16px;
+  border: 1px solid rgba(94, 234, 212, 0.6);
+  opacity: 0;
+  animation: disable-flare 0.45s ease forwards;
+}
+
+@keyframes disable-flare {
+  0% {
+    opacity: 0.75;
+    transform: scale(0.9);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.2);
   }
 }
 
@@ -557,12 +754,44 @@
   opacity: 0;
   transform: translate(-50%, -50%) scale(0.8);
   transition: opacity 0.2s ease, transform 0.25s ease;
+  z-index: 6;
 }
 
 .spark-burst.is-active {
   opacity: 1;
   transform: translate(-50%, -50%) scale(1.8);
   box-shadow: 0 0 24px rgba(250, 204, 21, 0.55);
+}
+
+.spark-burst::before,
+.spark-burst::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 3px;
+  height: 26px;
+  background: linear-gradient(180deg, rgba(250, 204, 21, 0), rgba(250, 204, 21, 0.85), rgba(250, 204, 21, 0));
+  transform: translate(-50%, -50%) scaleY(0.5);
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.25s ease;
+}
+
+.spark-burst::after {
+  transform: translate(-50%, -50%) rotate(90deg) scaleY(0.5);
+}
+
+.spark-burst.is-active::before,
+.spark-burst.is-active::after {
+  opacity: 0.85;
+}
+
+.spark-burst.is-active::before {
+  transform: translate(-50%, -50%) scaleY(1);
+}
+
+.spark-burst.is-active::after {
+  transform: translate(-50%, -50%) rotate(90deg) scaleY(1);
 }
 
 .chase-field.is-shaking {


### PR DESCRIPTION
## Summary
- add a speed-line layer and disabler effect surface to Osaka Motorcycle Dash’s chase field
- expand level-specific CSS for boost thrust, halo pulses, spark bursts, and disabler visuals
- upgrade boost, disabler, and crash audio cues with Web Audio helpers and integrate the new FX hooks

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68e189b33e488328bfd896b32f443327