### PR TITLE
Enhance Level 6 cabinet feedback

### DIFF
--- a/madia.new/public/secret/1989/frank-drebins-follies/frank-drebins-follies.css
+++ b/madia.new/public/secret/1989/frank-drebins-follies/frank-drebins-follies.css
@@ -44,6 +44,66 @@
   position: relative;
   overflow: hidden;
   min-height: 108px;
+  transition: transform 180ms ease-out, box-shadow 180ms ease-out, border-color 180ms ease-out;
+}
+
+.status-tile::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  opacity: 0;
+  background: radial-gradient(circle at top, rgba(248, 250, 252, 0.22), transparent 65%);
+  transition: opacity 200ms ease-out;
+  pointer-events: none;
+}
+
+.status-tile.status-flare {
+  animation: status-flare 420ms ease-out;
+}
+
+.status-tile.status-flare::after {
+  animation: status-flare-glow 420ms ease-out;
+}
+
+.status-tile[data-tone="success"] {
+  border-color: rgba(16, 185, 129, 0.65);
+  box-shadow: 0 18px 42px rgba(16, 185, 129, 0.18);
+}
+
+.status-tile[data-tone="warning"] {
+  border-color: rgba(234, 179, 8, 0.6);
+  box-shadow: 0 18px 42px rgba(234, 179, 8, 0.16);
+}
+
+.status-tile[data-tone="danger"] {
+  border-color: rgba(248, 113, 113, 0.7);
+  box-shadow: 0 20px 48px rgba(248, 113, 113, 0.24);
+  transform: translateY(-2px);
+}
+
+@keyframes status-flare {
+  0% {
+    transform: translateY(0) scale(0.98);
+  }
+  60% {
+    transform: translateY(-4px) scale(1.02);
+  }
+  100% {
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes status-flare-glow {
+  0% {
+    opacity: 0.75;
+  }
+  55% {
+    opacity: 0.32;
+  }
+  100% {
+    opacity: 0;
+  }
 }
 
 .status-label {
@@ -140,10 +200,93 @@
   pointer-events: none;
 }
 
+.prompt-card::before {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  opacity: 0;
+  transform: scale(0.96);
+  filter: blur(0);
+  pointer-events: none;
+}
+
 .prompt-title {
   font-family: "Press Start 2P", monospace;
   font-size: 1.1rem;
   color: var(--follies-blue);
+}
+
+.prompt-card.is-armed {
+  box-shadow: 0 16px 38px rgba(56, 189, 248, 0.18);
+}
+
+.prompt-card.is-armed::before {
+  opacity: 0.25;
+  transform: scale(1);
+  background: radial-gradient(circle at 10% 10%, rgba(56, 189, 248, 0.32), transparent 70%);
+  transition: opacity 240ms ease-out, transform 240ms ease-out;
+}
+
+.prompt-card[data-fx-tone="success"] {
+  border-color: rgba(16, 185, 129, 0.6);
+  box-shadow: 0 16px 40px rgba(16, 185, 129, 0.18);
+}
+
+.prompt-card[data-fx-tone="warning"] {
+  border-color: rgba(234, 179, 8, 0.55);
+  box-shadow: 0 18px 44px rgba(234, 179, 8, 0.18);
+}
+
+.prompt-card[data-fx-tone="danger"] {
+  border-color: rgba(248, 113, 113, 0.7);
+  box-shadow: 0 22px 52px rgba(248, 113, 113, 0.2);
+}
+
+.prompt-card.fx-burst::before {
+  animation: prompt-burst 520ms ease-out;
+  background: radial-gradient(circle at center, rgba(248, 113, 113, 0.4), transparent 70%);
+}
+
+.prompt-card.fx-sparkle::before {
+  animation: prompt-sparkle 520ms ease-out;
+  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.38), transparent 70%);
+}
+
+@keyframes prompt-burst {
+  0% {
+    opacity: 0.65;
+    transform: scale(0.9);
+    filter: blur(0px);
+  }
+  55% {
+    opacity: 0.2;
+    transform: scale(1.15);
+    filter: blur(6px);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.08);
+    filter: blur(10px);
+  }
+}
+
+@keyframes prompt-sparkle {
+  0% {
+    opacity: 0.7;
+    transform: scale(0.94);
+    filter: blur(0px);
+  }
+  60% {
+    opacity: 0.24;
+    transform: scale(1.08);
+    filter: blur(4px);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.04);
+    filter: blur(6px);
+  }
 }
 
 .prompt-instruction {
@@ -173,6 +316,10 @@
   transition: transform 120ms ease-out, filter 120ms ease-out;
 }
 
+.prompt-button.is-primed {
+  animation: prompt-button-prime 900ms ease-in-out infinite;
+}
+
 .prompt-button[disabled] {
   opacity: 0.45;
   filter: grayscale(0.4);
@@ -183,6 +330,21 @@
 .prompt-button:not([disabled]):focus-visible {
   transform: translateY(-2px);
   filter: brightness(1.05);
+}
+
+@keyframes prompt-button-prime {
+  0% {
+    transform: translateY(0);
+    filter: brightness(1);
+  }
+  50% {
+    transform: translateY(-1px) scale(1.01);
+    filter: brightness(1.08);
+  }
+  100% {
+    transform: translateY(0);
+    filter: brightness(1);
+  }
 }
 
 .prompt-key {
@@ -217,6 +379,22 @@
   transform: scaleX(var(--time-progress, 0));
   background: linear-gradient(90deg, var(--follies-yellow), var(--follies-orange));
   transition: transform 90ms linear;
+}
+
+.status-value.score-pop {
+  animation: score-pop 360ms ease-out;
+}
+
+@keyframes score-pop {
+  0% {
+    transform: scale(1);
+  }
+  40% {
+    transform: scale(1.08);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 .intervention-callout {


### PR DESCRIPTION
## Summary
- Add tone-aware animations and button states to the Level 6 cabinet UI for clearer feedback on tone changes
- Introduce a dedicated audio board and hook it into prompts, interventions, reputation swings, and wrap-up events
- Normalize outcome tone handling to drive stronger particle bursts, HUD pulses, and highlight effects

## Testing
- Not run (static assets only)

------
https://chatgpt.com/codex/tasks/task_e_68e18906e5648328b8dabfe912623b02