### PR TITLE
Enhance level 12 salon FX and audio

### DIFF
--- a/madia.new/public/secret/1989/truvys-salon-style/truvys-salon-style.css
+++ b/madia.new/public/secret/1989/truvys-salon-style/truvys-salon-style.css
@@ -42,6 +42,11 @@ body.truvys-salon-style {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  transition: transform 240ms ease;
+}
+
+.salon-floor.is-shaking {
+  animation: salon-shake 580ms cubic-bezier(0.36, 0.07, 0.19, 0.97);
 }
 
 .salon-header {
@@ -78,6 +83,8 @@ body.truvys-salon-style {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+  position: relative;
+  transition: transform 220ms ease, box-shadow 220ms ease;
 }
 
 .hud-card .hud-label {
@@ -91,11 +98,58 @@ body.truvys-salon-style {
   font-size: 1.75rem;
   font-weight: 700;
   color: #1f2937;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
 .hud-card .hud-note {
   font-size: 0.9rem;
   color: rgba(55, 65, 81, 0.85);
+}
+
+.hud-card .hud-value[data-delta]::after {
+  content: attr(data-delta);
+  position: absolute;
+  right: 0.6rem;
+  top: 0.45rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #047857;
+  background: rgba(16, 185, 129, 0.18);
+  border-radius: 999px;
+  padding: 0.1rem 0.45rem;
+  animation: tip-delta-rise 620ms ease forwards;
+}
+
+.hud-card .hud-value.is-tip-loss::after {
+  color: #b91c1c;
+  background: rgba(248, 113, 113, 0.2);
+}
+
+.hud-card.is-tip-boost {
+  animation: tip-card-bloom 540ms ease;
+}
+
+.hud-card.is-perfect-boost {
+  animation: tip-card-perfect 720ms ease;
+}
+
+.hud-card.is-tip-penalty {
+  animation: tip-card-penalty 640ms ease;
+}
+
+.hud-card .hud-value.is-tip-boost-value {
+  animation: tip-value-flip 520ms ease;
+}
+
+.hud-card .hud-value.is-tip-loss {
+  animation: tip-value-loss 520ms ease;
+}
+
+.hud-note.is-perfect-flash {
+  animation: perfect-flash 620ms ease;
 }
 
 .hud-card.hud-meter {
@@ -119,6 +173,22 @@ body.truvys-salon-style {
   border-radius: inherit;
   background: linear-gradient(90deg, #ec4899 0%, #6366f1 100%);
   transition: width 180ms ease;
+}
+
+#heat-fill.is-heat-flash {
+  animation: heat-flash 900ms ease;
+}
+
+#heat-fill.is-heat-surge {
+  animation: heat-surge 1s ease;
+}
+
+.hud-card.is-heat-label-shift {
+  animation: heat-label-shift 900ms ease;
+}
+
+.hud-card.is-heat-alert {
+  animation: heat-alert 1s ease;
 }
 
 .salon-grid {
@@ -349,6 +419,210 @@ body.truvys-salon-style {
   }
 }
 
+@keyframes tip-delta-rise {
+  0% {
+    opacity: 0;
+    transform: translateY(10px) scale(0.8);
+  }
+  40% {
+    opacity: 1;
+    transform: translateY(-4px) scale(1.05);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-12px) scale(0.95);
+  }
+}
+
+@keyframes tip-card-bloom {
+  0% {
+    transform: translateY(0) scale(1);
+    box-shadow: inset 0 0 0 1px rgba(236, 72, 153, 0.3), 0 18px 32px rgba(244, 114, 182, 0.28);
+  }
+  50% {
+    transform: translateY(-4px) scale(1.02);
+    box-shadow: inset 0 0 0 1px rgba(236, 72, 153, 0.4), 0 24px 38px rgba(244, 114, 182, 0.38);
+  }
+  100% {
+    transform: translateY(0) scale(1);
+    box-shadow: inset 0 0 0 1px rgba(236, 72, 153, 0.3), 0 18px 32px rgba(244, 114, 182, 0.28);
+  }
+}
+
+@keyframes tip-card-perfect {
+  0% {
+    transform: translateY(0) scale(1);
+    box-shadow: inset 0 0 0 1px rgba(124, 58, 237, 0.35), 0 22px 40px rgba(124, 58, 237, 0.34);
+  }
+  40% {
+    transform: translateY(-6px) scale(1.04);
+    box-shadow: inset 0 0 0 1px rgba(124, 58, 237, 0.45), 0 28px 46px rgba(124, 58, 237, 0.42);
+  }
+  100% {
+    transform: translateY(0) scale(1);
+    box-shadow: inset 0 0 0 1px rgba(236, 72, 153, 0.3), 0 18px 32px rgba(244, 114, 182, 0.28);
+  }
+}
+
+@keyframes tip-card-penalty {
+  0% {
+    transform: translateY(0) scale(1);
+  }
+  30% {
+    transform: translateX(-6px) scale(0.98);
+  }
+  60% {
+    transform: translateX(6px) scale(0.99);
+  }
+  100% {
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes tip-value-flip {
+  0% {
+    transform: rotateX(0deg);
+  }
+  50% {
+    transform: rotateX(24deg);
+  }
+  100% {
+    transform: rotateX(0deg);
+  }
+}
+
+@keyframes tip-value-loss {
+  0% {
+    transform: translateY(0);
+  }
+  30% {
+    transform: translateY(4px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@keyframes perfect-flash {
+  0% {
+    color: rgba(55, 65, 81, 0.85);
+  }
+  40% {
+    color: #7c3aed;
+  }
+  100% {
+    color: rgba(55, 65, 81, 0.85);
+  }
+}
+
+@keyframes salon-shake {
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  20% {
+    transform: translate3d(-4px, 2px, 0) rotate(-0.5deg);
+  }
+  40% {
+    transform: translate3d(5px, -3px, 0) rotate(0.6deg);
+  }
+  60% {
+    transform: translate3d(-3px, 2px, 0) rotate(-0.4deg);
+  }
+  80% {
+    transform: translate3d(2px, -1px, 0) rotate(0.2deg);
+  }
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes heat-flash {
+  0% {
+    box-shadow: inset 0 0 0 0 rgba(236, 72, 153, 0);
+  }
+  40% {
+    box-shadow: inset 0 0 0 6px rgba(236, 72, 153, 0.4);
+  }
+  100% {
+    box-shadow: inset 0 0 0 0 rgba(236, 72, 153, 0);
+  }
+}
+
+@keyframes heat-surge {
+  0% {
+    transform: scaleX(1);
+  }
+  40% {
+    transform: scaleX(1.03);
+  }
+  100% {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes heat-label-shift {
+  0% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-4px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@keyframes heat-alert {
+  0% {
+    box-shadow: inset 0 0 0 1px rgba(239, 68, 68, 0.2), 0 18px 32px rgba(239, 68, 68, 0.22);
+  }
+  50% {
+    box-shadow: inset 0 0 0 1px rgba(239, 68, 68, 0.45), 0 22px 36px rgba(239, 68, 68, 0.34);
+  }
+  100% {
+    box-shadow: inset 0 0 0 1px rgba(236, 72, 153, 0.3), 0 18px 32px rgba(244, 114, 182, 0.28);
+  }
+}
+
+@keyframes status-glow {
+  0% {
+    transform: translateY(0);
+    box-shadow: 0 0 0 rgba(124, 58, 237, 0);
+  }
+  50% {
+    transform: translateY(-3px);
+    box-shadow: 0 16px 28px rgba(124, 58, 237, 0.25);
+  }
+  100% {
+    transform: translateY(0);
+    box-shadow: 0 0 0 rgba(124, 58, 237, 0);
+  }
+}
+
+@keyframes gossip-offer {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.02);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes gossip-freeze {
+  0% {
+    box-shadow: inset 0 0 0 2px rgba(59, 130, 246, 0.15), 0 0 12px rgba(192, 132, 252, 0.2);
+  }
+  50% {
+    box-shadow: inset 0 0 0 2px rgba(59, 130, 246, 0.45), 0 0 26px rgba(192, 132, 252, 0.4);
+  }
+  100% {
+    box-shadow: inset 0 0 0 2px rgba(59, 130, 246, 0.15), 0 0 12px rgba(192, 132, 252, 0.2);
+  }
+}
+
 .ticket-panel {
   background: rgba(255, 255, 255, 0.7);
   border-radius: 18px;
@@ -493,6 +767,19 @@ body.truvys-salon-style {
   box-shadow: inset 0 0 0 1px rgba(124, 58, 237, 0.35);
 }
 
+.gossip-zone[hidden] {
+  display: none !important;
+}
+
+.gossip-zone.is-offered {
+  animation: gossip-offer 1.4s ease infinite;
+}
+
+.gossip-zone.is-frozen {
+  box-shadow: inset 0 0 0 2px rgba(59, 130, 246, 0.35), 0 0 25px rgba(192, 132, 252, 0.35);
+  animation: gossip-freeze 1.2s ease infinite;
+}
+
 .gossip-actions {
   display: flex;
   gap: 0.75rem;
@@ -509,12 +796,35 @@ body.truvys-salon-style {
   align-items: center;
   gap: 0.75rem;
   min-height: 54px;
+  --status-accent: rgba(124, 58, 237, 0.8);
+  transition: background 220ms ease, border-color 220ms ease, transform 220ms ease;
 }
 
 .status-strip::before {
   content: attr(data-feedback-icon);
   font-size: 1.4rem;
-  color: rgba(124, 58, 237, 0.8);
+  color: var(--status-accent);
+}
+
+.status-strip.is-gossip-freeze {
+  background: rgba(196, 181, 253, 0.35);
+  border-color: rgba(124, 58, 237, 0.45);
+  --status-accent: rgba(139, 92, 246, 0.9);
+  animation: status-glow 1.2s ease;
+}
+
+.status-strip.is-gossip-risk {
+  background: rgba(253, 230, 138, 0.35);
+  border-color: rgba(217, 119, 6, 0.4);
+  --status-accent: rgba(234, 88, 12, 0.85);
+  animation: status-glow 1.2s ease;
+}
+
+.status-strip.is-gossip-clear {
+  background: rgba(134, 239, 172, 0.32);
+  border-color: rgba(34, 197, 94, 0.45);
+  --status-accent: rgba(16, 185, 129, 0.85);
+  animation: status-glow 900ms ease;
 }
 
 .event-feed {


### PR DESCRIPTION
## Summary
- add a salon FX controller to trigger particle bursts, tip jar callouts, queue heat pulses, and gossip highlights
- expand the level 12 soundscape with dedicated celebration, storm-out, mistake, and gossip cues layered onto existing tool sounds
- refresh the HUD and cabinet styling with animated tip deltas, heat surges, salon shake, and gossip zone states for clearer feedback

## Testing
- python -m http.server 5000 (manual smoke-check while capturing screenshot)

## Screenshots
![Level 12 FX refresh](browser:/invocations/iwllsoxe/artifacts/artifacts/truvys-salon-style-level12.png)


------
https://chatgpt.com/codex/tasks/task_e_68e19b829e748328842b55ee53c9cf77