### PR TITLE
Enhance Wild Thing Wind-Up spectacle

### DIFF
--- a/madia.new/public/secret/1989/wild-thing-wind-up/wild-thing-wind-up.css
+++ b/madia.new/public/secret/1989/wild-thing-wind-up/wild-thing-wind-up.css
@@ -29,6 +29,33 @@
   border-radius: 1rem;
   padding: 1.5rem;
   box-shadow: 0 1rem 2.5rem rgba(6, 11, 25, 0.6);
+  position: relative;
+  overflow: hidden;
+}
+
+.mound-console::before {
+  content: "";
+  position: absolute;
+  inset: -40%;
+  background: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.18), transparent 62%),
+    radial-gradient(circle at 80% 10%, rgba(168, 85, 247, 0.12), transparent 70%),
+    radial-gradient(circle at 50% 85%, rgba(249, 115, 22, 0.1), transparent 68%);
+  opacity: 0.75;
+  filter: blur(0.5px);
+  animation: consoleGlow 11s linear infinite;
+  pointer-events: none;
+}
+
+@keyframes consoleGlow {
+  0% {
+    transform: rotate(0deg) scale(1.05);
+  }
+  50% {
+    transform: rotate(2deg) scale(1.08);
+  }
+  100% {
+    transform: rotate(0deg) scale(1.05);
+  }
 }
 
 .console-header {
@@ -61,6 +88,9 @@
   flex-direction: column;
   gap: 0.35rem;
   box-shadow: inset 0 0 0.75rem rgba(8, 12, 28, 0.7), 0 0.6rem 1.2rem rgba(6, 10, 22, 0.55);
+  position: relative;
+  overflow: hidden;
+  transition: transform 160ms ease, box-shadow 160ms ease;
 }
 
 .score-chip .chip-label,
@@ -76,6 +106,68 @@
   font-size: 1.5rem;
   font-weight: 700;
   color: #f8fafc;
+  transition: color 160ms ease, text-shadow 160ms ease;
+}
+
+.score-chip::after,
+.count-chip::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 0%, rgba(56, 189, 248, 0.15), transparent 55%);
+  opacity: 0;
+  transition: opacity 160ms ease;
+  pointer-events: none;
+}
+
+.score-chip.is-flash,
+.count-chip.is-flash {
+  animation: chipFlash 560ms ease-out;
+  box-shadow: inset 0 0 1.2rem rgba(8, 12, 28, 0.8), 0 0.9rem 1.6rem rgba(30, 58, 138, 0.6);
+}
+
+.score-chip.is-flash::after,
+.count-chip.is-flash::after {
+  opacity: 1;
+}
+
+.score-chip.is-flash-success .chip-value,
+.count-chip.is-flash-success .chip-value {
+  color: var(--wild-gold);
+  text-shadow: 0 0 0.4rem rgba(250, 204, 21, 0.9);
+}
+
+.score-chip.is-flash-warning .chip-value,
+.count-chip.is-flash-warning .chip-value {
+  color: var(--wild-blue);
+  text-shadow: 0 0 0.45rem rgba(56, 189, 248, 0.7);
+}
+
+.score-chip.is-flash-danger .chip-value,
+.count-chip.is-flash-danger .chip-value {
+  color: var(--wild-red);
+  text-shadow: 0 0 0.45rem rgba(249, 115, 22, 0.8);
+}
+
+.score-chip.is-flash-info .chip-value,
+.count-chip.is-flash-info .chip-value {
+  color: #c4b5fd;
+  text-shadow: 0 0 0.4rem rgba(196, 181, 253, 0.65);
+}
+
+@keyframes chipFlash {
+  0% {
+    transform: translateY(0) scale(1);
+  }
+  35% {
+    transform: translateY(-4px) scale(1.04);
+  }
+  65% {
+    transform: translateY(0) scale(0.99);
+  }
+  100% {
+    transform: translateY(0) scale(1);
+  }
 }
 
 .meter-grid {
@@ -102,6 +194,39 @@
   position: relative;
 }
 
+.accuracy-module::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid transparent;
+  background: radial-gradient(circle at 50% 20%, rgba(56, 189, 248, 0.08), transparent 70%);
+  opacity: 0;
+  transition: opacity 220ms ease;
+  pointer-events: none;
+}
+
+.accuracy-module.is-active::after {
+  opacity: 1;
+  animation: accuracyAura 1.2s ease-in-out infinite;
+}
+
+.accuracy-module.is-wild::after {
+  background: radial-gradient(circle at 50% 30%, rgba(249, 115, 22, 0.15), rgba(250, 204, 21, 0.08) 45%, transparent 100%);
+}
+
+@keyframes accuracyAura {
+  0% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 0.6;
+  }
+  100% {
+    opacity: 0.25;
+  }
+}
+
 .module-header {
   display: flex;
   flex-direction: column;
@@ -120,6 +245,7 @@
   border: 1px solid rgba(148, 163, 184, 0.45);
   background: linear-gradient(180deg, rgba(11, 15, 32, 0.9), rgba(15, 23, 42, 0.45));
   overflow: hidden;
+  box-shadow: inset 0 0 1.4rem rgba(15, 23, 42, 0.85);
 }
 
 .power-fill {
@@ -130,6 +256,73 @@
   height: 0%;
   background: linear-gradient(180deg, rgba(56, 189, 248, 0.25), rgba(56, 189, 248, 0.85));
   transition: height 80ms linear;
+}
+
+.power-track::before,
+.power-track::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+}
+
+.power-track::before {
+  background: linear-gradient(180deg, transparent 0%, rgba(56, 189, 248, 0.28) 45%, transparent 100%);
+  transform: translateY(100%);
+}
+
+.power-track::after {
+  background: radial-gradient(circle at 50% 85%, rgba(249, 115, 22, 0.24), transparent 70%);
+  filter: blur(0.6rem);
+}
+
+.power-track.is-charging::before {
+  opacity: 1;
+  animation: powerSweep 1.65s ease-in-out infinite;
+}
+
+.power-track.is-hot::after {
+  opacity: 1;
+  animation: powerHeat 620ms ease-in-out infinite;
+}
+
+.power-track.is-wild {
+  box-shadow: inset 0 0 1.6rem rgba(249, 115, 22, 0.45), 0 0.9rem 1.8rem rgba(249, 115, 22, 0.3);
+}
+
+.power-track.is-wild::after {
+  background: radial-gradient(circle at 50% 85%, rgba(249, 115, 22, 0.36), rgba(250, 204, 21, 0.18) 55%, transparent 100%);
+  filter: blur(0.4rem);
+}
+
+.power-track.is-locked {
+  border-color: rgba(250, 204, 21, 0.75);
+  box-shadow: inset 0 0 1.6rem rgba(250, 204, 21, 0.2), 0 0.5rem 1.2rem rgba(250, 204, 21, 0.25);
+}
+
+@keyframes powerSweep {
+  0% {
+    transform: translateY(100%);
+  }
+  100% {
+    transform: translateY(-100%);
+  }
+}
+
+@keyframes powerHeat {
+  0% {
+    opacity: 0.2;
+    transform: scaleY(0.9);
+  }
+  50% {
+    opacity: 0.6;
+    transform: scaleY(1.08);
+  }
+  100% {
+    opacity: 0.2;
+    transform: scaleY(0.95);
+  }
 }
 
 .wild-band {
@@ -170,6 +363,7 @@
   overflow: hidden;
   border: 1px solid rgba(148, 163, 184, 0.35);
   box-shadow: inset 0 1.2rem 2rem rgba(6, 10, 22, 0.5);
+  transition: box-shadow 220ms ease, transform 220ms ease;
 }
 
 .plate-lane::after {
@@ -183,6 +377,7 @@
 
 .plate-lane.is-shake {
   animation: mound-shake 320ms ease-in-out 0s 1;
+  box-shadow: inset 0 1.6rem 2.6rem rgba(6, 10, 22, 0.6), 0 0.9rem 1.8rem rgba(15, 23, 42, 0.35);
 }
 
 @keyframes mound-shake {
@@ -249,6 +444,7 @@
   transform: translate(-50%, -50%);
   top: 50%;
   left: 50%;
+  transition: box-shadow 160ms ease, border-color 160ms ease;
 }
 
 .accuracy-module.is-active .accuracy-sweep {
@@ -279,10 +475,26 @@
   background: var(--wild-blue);
   opacity: 0;
   transform: translate(-50%, 0) scale(0.5);
+  overflow: visible;
+}
+
+.ball-flight::after {
+  content: "";
+  position: absolute;
+  inset: -120% -20% 40% -20%;
+  background: linear-gradient(180deg, rgba(56, 189, 248, 0.75), transparent 70%);
+  opacity: 0;
+  transform: translateY(10px) scaleY(0.6);
+  filter: blur(2px);
+  pointer-events: none;
 }
 
 .ball-flight.is-standard {
   animation: pitch-standard 420ms ease-out forwards;
+}
+
+.ball-flight.is-standard::after {
+  animation: trail-standard 420ms ease-out forwards;
 }
 
 .ball-flight.is-wild {
@@ -291,9 +503,19 @@
   animation: pitch-wild 360ms cubic-bezier(0.2, 0, 0.32, 1.2) forwards;
 }
 
+.ball-flight.is-wild::after {
+  background: linear-gradient(180deg, rgba(249, 115, 22, 0.85), rgba(250, 204, 21, 0.1) 80%, transparent 100%);
+  animation: trail-wild 360ms ease-out forwards;
+}
+
 .ball-flight.is-chaos {
   background: #f472b6;
   animation: pitch-chaos 520ms ease-in forwards;
+}
+
+.ball-flight.is-chaos::after {
+  background: linear-gradient(180deg, rgba(244, 114, 182, 0.8), transparent 80%);
+  animation: trail-chaos 520ms ease-in forwards;
 }
 
 @keyframes pitch-standard {
@@ -340,6 +562,51 @@
   }
 }
 
+@keyframes trail-standard {
+  0% {
+    opacity: 0.2;
+    transform: translateY(6px) scaleY(0.5);
+  }
+  60% {
+    opacity: 0.7;
+    transform: translateY(-40px) scaleY(1.1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-68px) scaleY(0.9);
+  }
+}
+
+@keyframes trail-wild {
+  0% {
+    opacity: 0.6;
+    transform: translateY(8px) scaleY(0.6);
+  }
+  50% {
+    opacity: 1;
+    transform: translateY(-50px) scaleY(1.2);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-90px) scaleY(1.05);
+  }
+}
+
+@keyframes trail-chaos {
+  0% {
+    opacity: 0.45;
+    transform: translateY(12px) scaleY(0.7) rotate(-12deg);
+  }
+  70% {
+    opacity: 0.9;
+    transform: translate(-70px, -42px) scaleY(1.05) rotate(-22deg);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(60px, -18px) scaleY(0.8) rotate(10deg);
+  }
+}
+
 .status-readout {
   background: rgba(15, 23, 42, 0.7);
   border: 1px solid rgba(148, 163, 184, 0.35);
@@ -348,6 +615,40 @@
   font-size: 0.95rem;
   color: rgba(226, 232, 240, 0.92);
   font-family: "Share Tech Mono", "Segoe UI", sans-serif;
+  position: relative;
+  overflow: hidden;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.status-readout::before {
+  content: "";
+  position: absolute;
+  inset: -30% -50%;
+  background: radial-gradient(circle at 50% 0%, rgba(56, 189, 248, 0.15), transparent 65%);
+  opacity: 0;
+  transform: scale(0.85);
+  transition: opacity 180ms ease, transform 220ms ease;
+  pointer-events: none;
+}
+
+.status-readout.feedback-status-pulse::before {
+  opacity: 1;
+  transform: scale(1.05);
+}
+
+.status-readout[data-feedback-tone="success"] {
+  border-color: rgba(250, 204, 21, 0.55);
+  box-shadow: 0 0.45rem 1rem rgba(250, 204, 21, 0.25);
+}
+
+.status-readout[data-feedback-tone="warning"] {
+  border-color: rgba(56, 189, 248, 0.55);
+  box-shadow: 0 0.45rem 1rem rgba(56, 189, 248, 0.2);
+}
+
+.status-readout[data-feedback-tone="danger"] {
+  border-color: rgba(249, 115, 22, 0.65);
+  box-shadow: 0 0.45rem 1rem rgba(249, 115, 22, 0.3);
 }
 
 .log-panel {
@@ -374,6 +675,18 @@
   background: rgba(8, 12, 28, 0.75);
   color: rgba(226, 232, 240, 0.92);
   font-size: 0.9rem;
+  animation: logSlide 360ms ease-out;
+}
+
+@keyframes logSlide {
+  0% {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .wrap-up {

--- a/madia.new/public/secret/1989/wild-thing-wind-up/wild-thing-wind-up.js
+++ b/madia.new/public/secret/1989/wild-thing-wind-up/wild-thing-wind-up.js
@@ -53,8 +53,23 @@ const accuracySweep = document.getElementById("accuracy-sweep");
 const ballFlight = document.getElementById("ball-flight");
 const accuracyModule = document.querySelector(".accuracy-module");
 
-const statusChannel = createStatusChannel(document.getElementById("status-bar"));
+const inningChip = inningValue.closest(".score-chip");
+const strikeoutsChip = strikeoutsValue.closest(".score-chip");
+const runsChip = runsValue.closest(".score-chip");
+const wildChip = wildSuccessValue.closest(".score-chip");
+const ballsChip = ballsValue.closest(".count-chip");
+const strikesChip = strikesValue.closest(".count-chip");
+const outsChip = outsValue.closest(".count-chip");
+
+const statusElement = document.getElementById("status-bar");
+const statusChannel = createStatusChannel(statusElement);
 const logChannel = createLogChannel(document.getElementById("event-log"), { limit: 16 });
+
+const CHIP_FLASH_VARIANTS = new Set(["success", "warning", "danger", "info"]);
+const chipFlashTimers = new WeakMap();
+
+const AudioContextClass = window.AudioContext || window.webkitAudioContext || null;
+const audioState = { context: null, master: null };
 
 const wrapUpRoot = document.getElementById("wrap-up");
 const wrapUpStrikeouts = document.getElementById("wrap-up-strikeouts");
@@ -115,6 +130,7 @@ const state = {
   lastAccuracyTimestamp: 0,
   isWildAttempt: false,
   powerLocked: 0,
+  wildCueTriggered: false,
   difficulty: getDifficulty(1),
 };
 
@@ -188,6 +204,11 @@ function startGame() {
   timeButton.disabled = false;
   logChannel.push("Bullpen door opens. The Wild Thing stalks to the hill.", "info");
   statusChannel("Wind up to fire the first pitch.", "info");
+  playMeterCue("warmup");
+  flashChip(inningChip, "info");
+  flashChip(ballsChip, "info");
+  flashChip(strikesChip, "info");
+  flashChip(outsChip, "info");
 }
 
 function resetState() {
@@ -211,6 +232,7 @@ function resetState() {
   state.lastAccuracyTimestamp = 0;
   state.isWildAttempt = false;
   state.powerLocked = 0;
+  state.wildCueTriggered = false;
   state.difficulty = getDifficulty(1);
   updateScoreboard();
   updateCounts();
@@ -241,12 +263,16 @@ function startPowerPhase() {
   state.powerLevel = 0;
   state.powerDirection = 1;
   state.lastPowerTimestamp = performance.now();
+  state.powerLocked = 0;
+  state.isWildAttempt = false;
+  state.wildCueTriggered = false;
   updatePowerDisplay();
   setPowerState("Building Heat", "charging");
   pitchButton.textContent = "Lock Power";
   pitchButton.setAttribute("aria-label", "Lock the power level");
   logChannel.push("Power meter live. Ride the surge.", "info");
   statusChannel("Ride the power meter and lock it near the peak.", "info");
+  playMeterCue("start");
   cancelPowerAnimation();
   powerAnimation = window.requestAnimationFrame(stepPowerMeter);
 }
@@ -265,6 +291,12 @@ function stepPowerMeter(timestamp) {
     state.powerLevel = 0;
     state.powerDirection = 1;
   }
+  if (state.powerLevel >= WILD_THRESHOLD && !state.wildCueTriggered) {
+    state.wildCueTriggered = true;
+    playMeterCue("wild-ready");
+  } else if (state.powerLevel < WILD_THRESHOLD * 0.78) {
+    state.wildCueTriggered = false;
+  }
   updatePowerDisplay();
   powerAnimation = window.requestAnimationFrame(stepPowerMeter);
 }
@@ -280,6 +312,7 @@ function lockPowerLevel() {
   pitchButton.textContent = "Snap Release";
   pitchButton.setAttribute("aria-label", "Snap the release for accuracy");
   statusChannel(state.isWildAttempt ? "Wild Thing attempt! The accuracy sweep is about to go berserk." : "Power locked. Track the glove and snap the release.", state.isWildAttempt ? "warning" : "info");
+  playMeterCue(state.isWildAttempt ? "lock-wild" : "lock");
   startAccuracyPhase();
 }
 
@@ -291,6 +324,7 @@ function startAccuracyPhase() {
   state.lastAccuracyTimestamp = performance.now();
   accuracyModule.classList.add("is-active");
   accuracyModule.classList.toggle("is-wild", state.isWildAttempt);
+  playMeterCue(state.isWildAttempt ? "accuracy-wild" : "accuracy");
   cancelAccuracyAnimation();
   accuracyAnimation = window.requestAnimationFrame(stepAccuracyMeter);
 }
@@ -347,6 +381,7 @@ function resolvePitch() {
     triggerBallFlight("wild");
     particleField.emitBurst(1.45);
     shakePlate();
+    playPitchSound("wild-strike");
     const result = registerStrike({ forceStrikeout: true, wildBonus: true });
     logChannel.push("Wild Thing detonates the mitt! Automatic punch-out.", "success");
     statusChannel(randomChoice(CROWD_ROARS), "success");
@@ -357,6 +392,7 @@ function resolvePitch() {
   if (diff <= perfectCutoff) {
     triggerBallFlight(state.isWildAttempt ? "wild" : "standard");
     particleField.emitSparkle(state.isWildAttempt ? 1.1 : 0.8);
+    playPitchSound("strike");
     const message = velocity >= 0.9
       ? "Heater paints the letters. Batter frozen."
       : "Painted the black. Ump rings him up.";
@@ -377,9 +413,11 @@ function resolvePitch() {
       if (foul) {
         logChannel.push("Foul tip keeps the at-bat alive.", "info");
         statusChannel(`Foul tip. Count ${state.balls}-${state.strikes}.`, "info");
+        playPitchSound("foul");
       } else {
         logChannel.push("Batter chases the breaker out of the zone.", "success");
         statusChannel(`Swing and miss! Count ${state.balls}-${state.strikes}.`, "success");
+        playPitchSound(state.isWildAttempt ? "wild-strike" : "strike");
       }
       afterPitch(result);
     } else {
@@ -387,6 +425,7 @@ function resolvePitch() {
       const outcome = registerBall({ addRun: false });
       logChannel.push("Just off the plate. The batter watches it sail by.", "warning");
       statusChannel(`Ball. Count ${state.balls}-${state.strikes}.`, "warning");
+      playPitchSound("ball");
       afterPitch(outcome);
     }
     return;
@@ -399,6 +438,7 @@ function resolvePitch() {
       const result = registerStrike({ foul: true });
       logChannel.push("Foul into the third deck netting.", "info");
       statusChannel(`Foul. Count ${state.balls}-${state.strikes}.`, "info");
+      playPitchSound("foul");
       afterPitch(result);
       return;
     }
@@ -408,12 +448,14 @@ function resolvePitch() {
       const result = registerContact({ type: "out" });
       logChannel.push("Weak dribbler to short. Easy toss for the out.", "success");
       statusChannel(`Out recorded. ${state.outs} ${state.outs === 1 ? "out" : "outs"}.`, "success");
+      playPitchSound("out");
       afterPitch(result);
     } else {
       triggerBallFlight("standard");
       const result = registerContact({ type: "run" });
       logChannel.push("Shot through the gap! Run crosses the plate.", "danger");
       statusChannel(`Run scores. Total runs ${state.runs}.`, "danger");
+      playPitchSound("run");
       afterPitch(result);
     }
     return;
@@ -425,6 +467,7 @@ function resolvePitch() {
       const outcome = registerBall({ addRun: false });
       logChannel.push("Off-speed tumbles out of the zone.", "warning");
       statusChannel(`Ball. Count ${state.balls}-${state.strikes}.`, "warning");
+      playPitchSound("ball");
       afterPitch(outcome);
     } else {
       const result = registerContact({ type: "run" });
@@ -432,6 +475,7 @@ function resolvePitch() {
       statusChannel(`Run scores. Total runs ${state.runs}.`, "danger");
       triggerBallFlight("chaos");
       shakePlate();
+      playPitchSound("chaos");
       afterPitch(result);
     }
     return;
@@ -443,12 +487,16 @@ function resolvePitch() {
   const result = registerBall({ addRun: true });
   logChannel.push(state.isWildAttempt ? chaosOutcome : "Plunked him. The dugout is jawing.", "danger");
   statusChannel(`Wild miss. Run scores. Total runs ${state.runs}.`, "danger");
+  playPitchSound("chaos");
   afterPitch(result);
 }
 
 function afterPitch(result) {
   updatePowerDisplay();
   if (!state.gameOver) {
+    state.isWildAttempt = false;
+    state.powerLocked = 0;
+    state.wildCueTriggered = false;
     setPowerState("Idle", "idle");
     pitchButton.textContent = "Start Wind-Up";
     pitchButton.setAttribute("aria-label", "Start the next wind-up");
@@ -470,6 +518,11 @@ function registerStrike({ foul = false, forceStrikeout = false, wildBonus = fals
     }
     updateCounts();
     updateScoreboard();
+    flashChip(strikeoutsChip, "success");
+    flashChip(outsChip, "success");
+    if (wildBonus) {
+      flashChip(wildChip, "success");
+    }
     const inningResult = checkInningProgress();
     return inningResult;
   }
@@ -479,6 +532,7 @@ function registerStrike({ foul = false, forceStrikeout = false, wildBonus = fals
       state.strikes += 1;
     }
     updateCounts();
+    flashChip(strikesChip, "warning");
     return "foul";
   }
 
@@ -493,14 +547,21 @@ function registerStrike({ foul = false, forceStrikeout = false, wildBonus = fals
     }
     updateCounts();
     updateScoreboard();
+    flashChip(strikeoutsChip, "success");
+    flashChip(outsChip, "success");
+    if (wildBonus) {
+      flashChip(wildChip, "success");
+    }
     const inningResult = checkInningProgress();
     return inningResult;
   }
   if (wildBonus) {
     state.wildSuccesses += 1;
     updateScoreboard();
+    flashChip(wildChip, "success");
   }
   updateCounts();
+  flashChip(strikesChip, "success");
   return "strike";
 }
 
@@ -511,6 +572,8 @@ function registerBall({ addRun }) {
     state.strikes = 0;
     updateCounts();
     updateScoreboard();
+    flashChip(runsChip, "danger");
+    flashChip(ballsChip, "warning");
     if (state.runs >= RUN_LIMIT) {
       state.gameOver = true;
       return "game-over";
@@ -524,6 +587,8 @@ function registerBall({ addRun }) {
     state.strikes = 0;
     updateCounts();
     updateScoreboard();
+    flashChip(runsChip, "danger");
+    flashChip(ballsChip, "warning");
     if (state.runs >= RUN_LIMIT) {
       state.gameOver = true;
       return "game-over";
@@ -531,6 +596,7 @@ function registerBall({ addRun }) {
     return "walk";
   }
   updateCounts();
+  flashChip(ballsChip, "warning");
   return "ball";
 }
 
@@ -540,6 +606,7 @@ function registerContact({ type }) {
   if (type === "out") {
     state.outs += 1;
     updateCounts();
+    flashChip(outsChip, "success");
     const inningResult = checkInningProgress();
     return inningResult;
   }
@@ -547,6 +614,7 @@ function registerContact({ type }) {
     state.runs += 1;
     updateCounts();
     updateScoreboard();
+    flashChip(runsChip, "danger");
     if (state.runs >= RUN_LIMIT) {
       state.gameOver = true;
       return "game-over";
@@ -554,6 +622,7 @@ function registerContact({ type }) {
     return "run";
   }
   updateCounts();
+  flashChip(ballsChip, "warning");
   return "ball";
 }
 
@@ -569,6 +638,12 @@ function checkInningProgress() {
     updateScoreboard();
     logChannel.push(`Inning ${state.inning - 1} closed. The lineup sharpens for the next frame.`, "info");
     statusChannel(`Frame complete. Welcome to inning ${state.inning}. Target window tightens.`, "info");
+    flashChip(inningChip, "info");
+    flashChip(outsChip, "info");
+    flashChip(ballsChip, "info");
+    flashChip(strikesChip, "info");
+    playMeterCue("inning");
+    particleField.emitBurst(0.9, { y: 0.18 });
     setNewTarget();
     return "inning";
   }
@@ -604,6 +679,8 @@ function concludeGame() {
     wrapUpReplay.focus();
   }, 90);
   statusChannel("Skipper signals for the pen. Game over—check the box score.", "warning");
+  particleField.emitBurst(1.25, { y: 0.32 });
+  playPitchSound("game-over");
 }
 
 function hideWrapUp() {
@@ -621,6 +698,7 @@ function callTime() {
   pitchButton.textContent = "Start Wind-Up";
   pitchButton.setAttribute("aria-label", "Start the wind-up phase");
   statusChannel("Time is called. Reset the sign and breathe.", "info");
+  playPitchSound("time");
 }
 
 function cancelPowerAnimation() {
@@ -650,12 +728,35 @@ function updateCounts() {
   outsValue.textContent = String(state.outs);
 }
 
+function flashChip(chip, tone = "info") {
+  if (!chip) {
+    return;
+  }
+  const variant = CHIP_FLASH_VARIANTS.has(tone) ? tone : "info";
+  const baseClass = "is-flash";
+  const variantClass = `is-flash-${variant}`;
+  chip.classList.remove(baseClass, "is-flash-success", "is-flash-warning", "is-flash-danger", "is-flash-info");
+  // eslint-disable-next-line no-unused-expressions
+  chip.offsetWidth;
+  chip.classList.add(baseClass, variantClass);
+  const existing = chipFlashTimers.get(chip);
+  if (typeof existing === "number") {
+    window.clearTimeout(existing);
+  }
+  const timer = window.setTimeout(() => {
+    chip.classList.remove(baseClass, variantClass);
+    chipFlashTimers.delete(chip);
+  }, 560);
+  chipFlashTimers.set(chip, timer);
+}
+
 function updatePowerDisplay() {
   const clamped = Math.max(0, Math.min(POWER_MAX, state.powerLevel));
   const percent = Math.round((clamped / POWER_MAX) * 115);
   powerFill.style.height = `${(clamped / POWER_MAX) * 100}%`;
   powerReadout.textContent = `${percent}%`;
   powerTrack.setAttribute("aria-valuenow", String(Math.round((clamped / POWER_MAX) * 115)));
+  powerTrack.classList.toggle("is-hot", state.phase === "power" && clamped >= WILD_THRESHOLD);
   if (state.phase === "idle" && !state.isWildAttempt) {
     setPowerState("Idle", "idle");
   } else if (state.phase === "power") {
@@ -670,6 +771,14 @@ function updatePowerDisplay() {
 function setPowerState(label, stateName) {
   powerState.textContent = label;
   powerState.dataset.state = stateName;
+  applyPowerTrackState(stateName);
+}
+
+function applyPowerTrackState(stateName) {
+  powerTrack.classList.remove("is-idle", "is-charging", "is-wild", "is-locked");
+  if (stateName) {
+    powerTrack.classList.add(`is-${stateName}`);
+  }
 }
 
 function setNewTarget() {
@@ -707,6 +816,158 @@ function shakePlate() {
   window.setTimeout(() => {
     plateLane.classList.remove("is-shake");
   }, 360);
+}
+
+function ensureAudioContext() {
+  if (!AudioContextClass) {
+    return null;
+  }
+  if (!audioState.context) {
+    const context = new AudioContextClass();
+    const master = context.createGain();
+    master.gain.value = 0.28;
+    master.connect(context.destination);
+    audioState.context = context;
+    audioState.master = master;
+  }
+  if (audioState.context.state === "suspended") {
+    audioState.context.resume();
+  }
+  return audioState.context;
+}
+
+function connectToMaster(node) {
+  if (audioState.master) {
+    node.connect(audioState.master);
+  }
+}
+
+function playTone(context, { type = "sine", start = 440, end = start, duration = 0.3, peak = 0.2, curve = "linear" } = {}) {
+  const oscillator = context.createOscillator();
+  const gain = context.createGain();
+  const now = context.currentTime;
+  oscillator.type = type;
+  oscillator.frequency.setValueAtTime(start, now);
+  if (curve === "exponential") {
+    oscillator.frequency.exponentialRampToValueAtTime(Math.max(end, 1), now + duration);
+  } else if (end !== start) {
+    oscillator.frequency.linearRampToValueAtTime(end, now + duration);
+  }
+  gain.gain.setValueAtTime(0.0001, now);
+  gain.gain.exponentialRampToValueAtTime(peak, now + 0.03);
+  gain.gain.exponentialRampToValueAtTime(0.001, now + duration);
+  oscillator.connect(gain);
+  connectToMaster(gain);
+  oscillator.start(now);
+  oscillator.stop(now + duration + 0.08);
+}
+
+function playNoiseBurst(
+  context,
+  { duration = 0.32, gain = 0.24, frequency = 520, q = 0.9, type = "bandpass", intensity = 1 } = {},
+) {
+  const now = context.currentTime;
+  const frameCount = Math.max(1, Math.floor(context.sampleRate * duration));
+  const buffer = context.createBuffer(1, frameCount, context.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < frameCount; i += 1) {
+    const progress = i / frameCount;
+    data[i] = (Math.random() * 2 - 1) * (1 - progress) ** 2 * intensity;
+  }
+  const source = context.createBufferSource();
+  source.buffer = buffer;
+  const filter = context.createBiquadFilter();
+  filter.type = type;
+  filter.frequency.value = frequency;
+  filter.Q.value = q;
+  const gainNode = context.createGain();
+  gainNode.gain.setValueAtTime(gain, now);
+  gainNode.gain.exponentialRampToValueAtTime(0.001, now + duration);
+  source.connect(filter);
+  filter.connect(gainNode);
+  connectToMaster(gainNode);
+  source.start(now);
+  source.stop(now + duration);
+}
+
+function playMeterCue(mode) {
+  const context = ensureAudioContext();
+  if (!context) {
+    return;
+  }
+  switch (mode) {
+    case "warmup":
+      playTone(context, { type: "triangle", start: 220, end: 360, duration: 0.4, peak: 0.18 });
+      break;
+    case "start":
+      playTone(context, { type: "sawtooth", start: 160, end: 320, duration: 0.4, peak: 0.2 });
+      break;
+    case "wild-ready":
+      playTone(context, { type: "square", start: 420, end: 640, duration: 0.28, peak: 0.22, curve: "exponential" });
+      break;
+    case "lock":
+      playTone(context, { type: "triangle", start: 340, end: 240, duration: 0.3, peak: 0.18 });
+      break;
+    case "lock-wild":
+      playTone(context, { type: "sawtooth", start: 360, end: 520, duration: 0.34, peak: 0.24 });
+      break;
+    case "accuracy":
+      playTone(context, { type: "triangle", start: 260, end: 340, duration: 0.3, peak: 0.18 });
+      break;
+    case "accuracy-wild":
+      playTone(context, { type: "square", start: 380, end: 520, duration: 0.3, peak: 0.22 });
+      break;
+    case "inning":
+      playTone(context, { type: "triangle", start: 300, end: 480, duration: 0.42, peak: 0.2 });
+      break;
+    default:
+      break;
+  }
+}
+
+function playPitchSound(outcome) {
+  const context = ensureAudioContext();
+  if (!context) {
+    return;
+  }
+  switch (outcome) {
+    case "wild-strike":
+      playNoiseBurst(context, { duration: 0.4, gain: 0.32, frequency: 840, q: 0.6, intensity: 1.4 });
+      playTone(context, { type: "sawtooth", start: 420, end: 860, duration: 0.36, peak: 0.28, curve: "exponential" });
+      break;
+    case "strike":
+      playNoiseBurst(context, { duration: 0.28, gain: 0.24, frequency: 520, q: 0.9, intensity: 0.85 });
+      playTone(context, { type: "triangle", start: 360, end: 520, duration: 0.26, peak: 0.18 });
+      break;
+    case "foul":
+      playNoiseBurst(context, { duration: 0.32, gain: 0.2, frequency: 640, q: 0.7, intensity: 0.7 });
+      playTone(context, { type: "square", start: 420, end: 320, duration: 0.24, peak: 0.14 });
+      break;
+    case "ball":
+      playTone(context, { type: "sine", start: 260, end: 180, duration: 0.35, peak: 0.12 });
+      break;
+    case "out":
+      playNoiseBurst(context, { duration: 0.3, gain: 0.22, frequency: 460, q: 0.8, intensity: 0.9 });
+      playTone(context, { type: "triangle", start: 320, end: 460, duration: 0.28, peak: 0.16 });
+      break;
+    case "run":
+      playNoiseBurst(context, { duration: 0.5, gain: 0.26, frequency: 300, q: 0.7, intensity: 1.1 });
+      playTone(context, { type: "sawtooth", start: 320, end: 190, duration: 0.46, peak: 0.18 });
+      break;
+    case "chaos":
+      playNoiseBurst(context, { duration: 0.55, gain: 0.28, frequency: 260, q: 0.55, type: "lowpass", intensity: 1.2 });
+      playTone(context, { type: "sawtooth", start: 340, end: 140, duration: 0.5, peak: 0.22 });
+      break;
+    case "time":
+      playTone(context, { type: "sine", start: 300, end: 240, duration: 0.32, peak: 0.1 });
+      break;
+    case "game-over":
+      playNoiseBurst(context, { duration: 0.7, gain: 0.3, frequency: 220, q: 0.6, type: "lowpass", intensity: 1.1 });
+      playTone(context, { type: "triangle", start: 260, end: 120, duration: 0.65, peak: 0.24 });
+      break;
+    default:
+      break;
+  }
 }
 
 function formatInningsPitched() {


### PR DESCRIPTION
## Summary
- Amplify the Level 11 cabinet with neon console glow, animated score chips, enhanced power meter, lane shake and pitch trails
- Add scoreboard flash logic, inning celebrations, and wrap-up burst effects driven by new helper utilities
- Layer Web Audio cues for meter phases and pitch outcomes to reinforce crowd feedback and risk/reward swings

## Testing
- Not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68e19b7d6b608328887b61608b0c2d98