### PR TITLE
Add inspiration reveal for Power Glove Prodigy

### DIFF
--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -2606,6 +2606,7 @@ const filmByGameId = new Map([
   ["paper-trail-blaze", { type: "film", title: "Blaze" }],
   ["second-star-flight", { type: "film", title: "Peter Pan (1989 re-release)" }],
   ["voice-box-swap", { type: "film", title: "Look Who's Talking" }],
+  ["power-glove-prodigy", { type: "film", title: "The Wizard" }],
   ["freddys-dream-maze", { type: "film", title: "A Nightmare on Elm Street 5: The Dream Child" }],
   ["framed-breakout", { type: "film", title: "Tango & Cash" }],
   ["bat-signal-scramble", { type: "film", title: "Batman" }],

--- a/madia.new/public/secret/1989/power-glove-prodigy/index.html
+++ b/madia.new/public/secret/1989/power-glove-prodigy/index.html
@@ -66,6 +66,23 @@
             </div>
           </dl>
         </section>
+        <section class="inspiration" aria-labelledby="inspiration-title" data-revealed="false">
+          <div class="inspiration-copy">
+            <h3 id="inspiration-title">Cabinet Inspiration</h3>
+            <p id="inspiration-text" class="inspiration-text" hidden>
+              Based on the film <cite>The Wizard</cite> (1989).
+            </p>
+          </div>
+          <button
+            type="button"
+            class="inspiration-button"
+            id="inspiration-button"
+            aria-controls="inspiration-text"
+            aria-expanded="false"
+          >
+            Reveal inspiration
+          </button>
+        </section>
       </section>
       <section class="arena" aria-labelledby="arena-title">
         <div class="arena-header">

--- a/madia.new/public/secret/1989/power-glove-prodigy/power-glove-prodigy.css
+++ b/madia.new/public/secret/1989/power-glove-prodigy/power-glove-prodigy.css
@@ -89,6 +89,77 @@
   color: rgba(226, 232, 240, 0.85);
 }
 
+.power-glove-prodigy .inspiration {
+  margin-top: 2.25rem;
+  padding: 1.35rem 1.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 1.25rem;
+  background: rgba(15, 23, 42, 0.62);
+  box-shadow: inset 0 0 0 1px rgba(124, 58, 237, 0.12);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  transition: border-color 200ms ease, box-shadow 200ms ease;
+}
+
+.power-glove-prodigy .inspiration[data-revealed="true"] {
+  border-color: rgba(34, 211, 238, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(34, 211, 238, 0.28), 0 0 20px rgba(34, 211, 238, 0.15);
+}
+
+.power-glove-prodigy .inspiration-copy {
+  flex: 1 1 260px;
+  min-width: 0;
+}
+
+.power-glove-prodigy .inspiration h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(224, 231, 255, 0.9);
+}
+
+.power-glove-prodigy .inspiration-text {
+  margin: 0.6rem 0 0;
+  color: rgba(226, 232, 240, 0.82);
+  font-size: 0.95rem;
+}
+
+.power-glove-prodigy .inspiration-text cite {
+  font-style: normal;
+  color: var(--pgp-highlight-strong);
+}
+
+.power-glove-prodigy .inspiration-button {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.7rem 1.4rem;
+  background: linear-gradient(135deg, rgba(34, 211, 238, 0.95), rgba(124, 58, 237, 0.95));
+  color: rgba(10, 18, 38, 0.95);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.78rem;
+  box-shadow: 0 16px 32px -18px rgba(34, 211, 238, 0.55);
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+
+.power-glove-prodigy .inspiration-button:hover,
+.power-glove-prodigy .inspiration-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 36px -18px rgba(124, 58, 237, 0.55);
+  background: linear-gradient(135deg, rgba(56, 189, 248, 1), rgba(167, 139, 250, 1));
+}
+
+.power-glove-prodigy .inspiration-button:focus-visible {
+  outline: 3px solid rgba(94, 234, 212, 0.85);
+  outline-offset: 4px;
+}
+
 .power-glove-prodigy .arena-header {
   display: flex;
   align-items: center;

--- a/madia.new/public/secret/1989/power-glove-prodigy/power-glove-prodigy.js
+++ b/madia.new/public/secret/1989/power-glove-prodigy/power-glove-prodigy.js
@@ -35,6 +35,9 @@ const challengeTimer = document.getElementById("challenge-timer");
 const statusLine = document.getElementById("status-line");
 const logList = document.getElementById("event-log");
 const wrapUp = document.getElementById("wrap-up");
+const inspirationSection = document.querySelector(".inspiration");
+const inspirationButton = document.getElementById("inspiration-button");
+const inspirationText = document.getElementById("inspiration-text");
 const wrapUpScore = document.getElementById("summary-score");
 const wrapUpStreak = document.getElementById("summary-streak");
 const wrapUpMultiplier = document.getElementById("summary-multiplier");
@@ -737,5 +740,24 @@ wrapUp.addEventListener("keydown", (event) => {
     hideSummary();
   }
 });
+
+if (inspirationButton && inspirationText) {
+  inspirationButton.addEventListener("click", () => {
+    inspirationText.hidden = false;
+    inspirationButton.hidden = true;
+    inspirationButton.setAttribute("aria-expanded", "true");
+    if (inspirationSection) {
+      inspirationSection.dataset.revealed = "true";
+    }
+    const inspirationMessage = inspirationText.textContent?.trim();
+    if (inspirationMessage) {
+      statusChannel(`Inspiration reveal · ${inspirationMessage}`, "info");
+      logChannel.push(`Inspiration unlocked · ${inspirationMessage}`, "info");
+    } else {
+      statusChannel("Cabinet inspiration revealed.", "info");
+      logChannel.push("Cabinet inspiration revealed.", "info");
+    }
+  });
+}
 
 resetTournament({ keepSummary: true });


### PR DESCRIPTION
## Summary
- add an inspiration reveal panel to the Power Glove Prodigy cabinet with styling that matches the neon UI
- pipe the reveal into the status and log channels so the crowd feed reflects the discovery
- register The Wizard as the film inspiration so the arcade overlay button also unlocks for the cabinet

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e1b2f52cac83289e65417626cbf92e