### PR TITLE
Fix Freddy's Dream Maze instructions layout

### DIFF
--- a/madia.new/public/secret/1989/freddys-dream-maze/freddys-dream-maze.css
+++ b/madia.new/public/secret/1989/freddys-dream-maze/freddys-dream-maze.css
@@ -187,23 +187,37 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
 
 .dream-layout {
   display: grid;
-  gap: 2.5rem;
+  gap: 1.8rem;
   align-items: start;
+  grid-template-columns: minmax(300px, 420px) minmax(0, 1fr);
 }
 
 .briefing {
   background: rgba(15, 23, 42, 0.55);
   border: 1px solid rgba(148, 163, 184, 0.2);
   border-radius: 18px;
-  padding: 1.75rem;
+  padding: 1.35rem 1.5rem;
   box-shadow: 0 20px 45px rgba(2, 6, 23, 0.65);
   backdrop-filter: blur(6px);
+  display: grid;
+  gap: 1.3rem;
+}
+
+.briefing p {
+  margin: 0;
+  line-height: 1.55;
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.briefing p + p {
+  margin-top: 0.75rem;
 }
 
 .briefing .callouts {
-  margin: 1.25rem 0;
+  margin: 0;
   display: grid;
-  gap: 1rem;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
 .briefing .callouts li {
@@ -217,6 +231,7 @@ body[data-fear-state="collapsing"].freddys-dream-maze {
 .controls dl {
   display: grid;
   gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
 .controls dt {
@@ -649,6 +664,12 @@ body[data-fear-state="collapsing"] .environment-overlay {
   backdrop-filter: blur(12px);
 }
 
+.wrapup[hidden],
+.manifestation[hidden],
+.chase[hidden] {
+  display: none !important;
+}
+
 .wrapup-card {
   background: rgba(15, 23, 42, 0.92);
   border: 1px solid rgba(148, 163, 184, 0.3);
@@ -810,6 +831,12 @@ body[data-fear-state="collapsing"] .environment-overlay {
 @media (max-width: 960px) {
   .dream-layout {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 1320px) {
+  .dream-layout {
+    grid-template-columns: minmax(320px, 460px) minmax(0, 1fr);
   }
 }
 


### PR DESCRIPTION
## Summary
- tighten the Freddy's Dream Maze grid so the briefing column fits alongside the simulator without forcing scroll
- compress briefing content spacing and allow callouts/controls to flow into multiple columns on wide displays
- ensure hidden modal dialogs stay removed from layout until they are activated

## Testing
- n/a (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e1b512ccb4832885dccf63f0108bf7