### PR TITLE
Improve Three Fugitives patrol flow and guidance

### DIFF
--- a/madia.new/public/secret/1989/three-fugitives/index.html
+++ b/madia.new/public/secret/1989/three-fugitives/index.html
@@ -37,14 +37,36 @@
             shape a fresh cutter when needed.
           </li>
           <li>
-            <strong>Police flow:</strong> Patrols chase the hostage’s square unless you body-block their lane. A Distraction
-            reroutes them into predictable loops for three turns.
+            <strong>Police flow:</strong> Until the cuffs are gone, patrols dog the Fugitive. Once both links are severed they
+            refocus on the hostage, so plan to trigger the Distraction during your escape push—it still traps them in loops for
+            three of your turns.
           </li>
           <li>
             <strong>Fragile hostage:</strong> The kid can’t cross walls or cops. Plan each shove so she never meets a moving
             patrol.
           </li>
         </ul>
+        <section class="strategy" aria-labelledby="strategy-title">
+          <h3 id="strategy-title">Opening Maneuver</h3>
+          <p>
+            The scenario eases up once you keep the cops orbiting you instead of the hostage. Use this loop to secure the
+            resources and slice the cuffs before they can tighten the net.
+          </p>
+          <ol>
+            <li>
+              Swing south first to grab the Gritrock cache, then hug the left wall to climb to the Sparkstone stash. The
+              patrols will tail the Fugitive, so keep moving and don’t let them pin you against the walls.
+            </li>
+            <li>
+              Lead them south, then cut north to the Filing Tray to forge and sever each link. Reforge immediately so both
+              cuffs are open before you reposition.
+            </li>
+            <li>
+              Fire the Distraction once the second link is cut, shove the hostage east into the open lane, then sprint around
+              to push her north three times into the safe balcony.
+            </li>
+          </ol>
+        </section>
         <section class="legend" aria-labelledby="legend-title">
           <h3 id="legend-title">Legend</h3>
           <dl>

--- a/madia.new/public/secret/1989/three-fugitives/three-fugitives.js
+++ b/madia.new/public/secret/1989/three-fugitives/three-fugitives.js
@@ -508,7 +508,9 @@ function resetGame() {
   resetResources();
   resetLinks();
   renderEventLog();
-  pushEvent("Briefing: Collect sparkstone and gritrock, then forge a Filing Stone to cut the first link.");
+  pushEvent(
+    "Briefing: Collect sparkstone and gritrock while the patrols hound the Fugitive, then forge a Filing Stone to cut the first link."
+  );
   refreshUI();
 }
 
@@ -652,6 +654,8 @@ function advanceAfterMove() {
 
 function movePolice() {
   const occupied = new Set(board.policeUnits.map((unit) => coordKey(unit.position.x, unit.position.y)));
+  const lockedLinks = countLockedLinks();
+  const pursuitTarget = lockedLinks > 0 ? state.fugitive : state.hostage;
 
   board.policeUnits.forEach((unit) => {
     const currentKey = coordKey(unit.position.x, unit.position.y);
@@ -665,7 +669,7 @@ function movePolice() {
         nextPosition = clonePoint(loop[unit.loopIndex]);
       }
     } else {
-      const pursuit = findPursuitStep(unit.position, state.hostage, unit);
+      const pursuit = findPursuitStep(unit.position, pursuitTarget, unit);
       if (pursuit) {
         nextPosition = pursuit;
       }


### PR DESCRIPTION
## Summary
- retarget the Three Fugitives patrol AI to pursue the fugitive until the cuffs are cut so the opening turn is survivable
- refresh the briefing copy to highlight the new chase rhythm
- add an "Opening Maneuver" walkthrough section that explains how to finish the first scenario

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e1e8c09c6c8328bc8e10ccb5f0f8ef