### PR TITLE
Add accuracy ladder scoring to K-Mart Countdown

### DIFF
--- a/madia.new/public/secret/1989/k-mart-countdown/index.html
+++ b/madia.new/public/secret/1989/k-mart-countdown/index.html
@@ -45,11 +45,16 @@
             <ul class="callouts">
               <li>
                 <strong>Accuracy:</strong> Nail the exact count for 10,000 points. Near-misses decay exponentially—being off by one still nets
-                8,000, while a ten-stick miss drops to 500.
+                8,000, while a ten-stick miss drops to 500. Every increment closer than your previous round stacks into an
+                accuracy ladder bonus.
               </li>
               <li>
                 <strong>Quick Guess:</strong> The multiplier begins at ×5 and ticks down the longer you hesitate. Fire fast for massive scores,
                 but reckless misses trigger penalty fees.
+              </li>
+              <li>
+                <strong>Accuracy Ladder:</strong> Chain sharper reads to elevate the ladder tier and amplify your payout. Slip ups reset the
+                ladder, so stabilize before the next spill.
               </li>
               <li>
                 <strong>Verification:</strong> Every submission rewinds the spill, counting each stick to confirm the real total against your guess.
@@ -128,6 +133,7 @@
                 <th scope="col">Actual</th>
                 <th scope="col">Δ</th>
                 <th scope="col">Multiplier</th>
+                <th scope="col">Ladder</th>
                 <th scope="col">Score</th>
               </tr>
             </thead>


### PR DESCRIPTION
## Summary
- add an accuracy ladder bonus that boosts scores when a guess is tighter than the previous round
- surface ladder progress in status messaging, the reveal recap, and the session summary table
- refresh the cabinet briefing to explain the new ladder mechanic

## Testing
- python -m http.server 5000


------
https://chatgpt.com/codex/tasks/task_e_68e1eb92eafc8328820341941b2be8bc