### PR TITLE
Fix Dojo Duality stream lock timing

### DIFF
--- a/madia.new/public/secret/1989/dojo-duality/dojo-duality.js
+++ b/madia.new/public/secret/1989/dojo-duality/dojo-duality.js
@@ -226,9 +226,6 @@ function movePiece(dx, dy) {
     renderBoard();
     return true;
   }
-  if (dy === 1) {
-    lockPiece();
-  }
   return false;
 }
 


### PR DESCRIPTION
## Summary
- prevent movePiece from auto-locking streams so the next piece can spawn normally
- allow Dojo Duality sessions to continue past the first drop so players can build toward the Crane Kick

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1ec252ec883288a7c9fd3f516492d