### PR TITLE
Randomize Family Flux decision reveals

### DIFF
--- a/madia.new/public/secret/1989/family-flux/family-flux.css
+++ b/madia.new/public/secret/1989/family-flux/family-flux.css
@@ -307,6 +307,18 @@
   color: rgba(244, 114, 182, 0.8);
 }
 
+.choice-button[data-revealed="false"] .choice-risk {
+  letter-spacing: 0.08em;
+}
+
+.choice-button[data-revealed="false"][data-variant="safe"] .choice-risk {
+  color: rgba(72, 187, 120, 0.55);
+}
+
+.choice-button[data-revealed="false"][data-variant="gamble"] .choice-risk {
+  color: rgba(244, 114, 182, 0.6);
+}
+
 .choice-button[data-variant="safe"] .choice-risk {
   color: rgba(72, 187, 120, 0.8);
 }


### PR DESCRIPTION
## Summary
- shuffle Family Flux scenario choices so either option can appear on the left or right
- conceal Harmony swing text until a player locks in a decision, then reveal the outcome details on the chosen button
- update button styling to telegraph hidden outcomes without exposing the actual effects

## Testing
- Not run (static frontend project)

------
https://chatgpt.com/codex/tasks/task_e_68e1ef0106b483289827ca81adeb4281