### PR TITLE
Fix arcade overlay scrolling during gameplay

### DIFF
--- a/madia.new/public/secret/1989/1989.css
+++ b/madia.new/public/secret/1989/1989.css
@@ -43,6 +43,10 @@ body {
   padding-bottom: 4rem;
 }
 
+body.arcade-scroll-lock {
+  overflow: hidden;
+}
+
 .scanlines {
   position: fixed;
   inset: 0;

--- a/madia.new/public/secret/1989/1989.js
+++ b/madia.new/public/secret/1989/1989.js
@@ -1,6 +1,22 @@
 import { getHighScore, onHighScoreChange } from "./arcade-scores.js";
 import { getScoreConfig } from "./score-config.js";
 
+const BODY_SCROLL_LOCK_CLASS = "arcade-scroll-lock";
+
+function lockBodyScroll() {
+  if (!document.body) {
+    return;
+  }
+  document.body.classList.add(BODY_SCROLL_LOCK_CLASS);
+}
+
+function unlockBodyScroll() {
+  if (!document.body) {
+    return;
+  }
+  document.body.classList.remove(BODY_SCROLL_LOCK_CLASS);
+}
+
 /**
  * Register launchable cabinets here. You can also import { registerGame }
  * elsewhere and call it at runtime for dynamic catalogs.
@@ -2931,6 +2947,7 @@ function openGame(game) {
   frame.dataset.baseUrl = game.url;
   setRestartButtonEnabled(false);
   frame.src = game.url;
+  lockBodyScroll();
   overlay.hidden = false;
   overlay.dataset.activeGame = game.id;
   setFullscreenButtonState(isOverlayFullscreen());
@@ -2947,6 +2964,7 @@ function closeGame() {
   }
   overlay.hidden = true;
   overlay.dataset.activeGame = "";
+  unlockBodyScroll();
   try {
     pendingRestart?.();
   } catch (error) {


### PR DESCRIPTION
## Summary
- add a body scroll lock class while a 1989 cabinet is open
- release the scroll lock when closing the overlay so navigation returns to normal

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1f0b8b72c832886b4bc8dd62ead2c