### PR TITLE
Fix Flapjack Flip-Out overlay visibility

### DIFF
--- a/madia.new/public/secret/1989/common.css
+++ b/madia.new/public/secret/1989/common.css
@@ -13,6 +13,10 @@
   box-sizing: border-box;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 body {
   margin: 0;
   min-height: 100vh;


### PR DESCRIPTION
## Summary
- add a `[hidden]` rule to the shared 1989 cabinet stylesheet so dialog overlays stay hidden until activated

## Testing
- python -m http.server 5000 (manual verification of Flapjack Flip-Out load state)

## Screenshot
![Flapjack Flip-Out start screen](browser:/invocations/trwekxhp/artifacts/artifacts/flapjack-fixed.png)


------
https://chatgpt.com/codex/tasks/task_e_68e1ef510a588328a0926c7f59b92985