### PR TITLE
Fix hoverboard pursuit lane geometry and polish visuals

### DIFF
--- a/madia.new/public/secret/1989/hoverboard-pursuit/hoverboard-pursuit.css
+++ b/madia.new/public/secret/1989/hoverboard-pursuit/hoverboard-pursuit.css
@@ -177,6 +177,34 @@
   opacity: 0.6;
 }
 
+.track::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 36%;
+  left: 32%;
+  border-radius: 12px;
+  background: linear-gradient(180deg, rgba(56, 189, 248, 0.22), rgba(129, 140, 248, 0.32));
+  mix-blend-mode: screen;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateX(0);
+  transition: transform 160ms ease-out, opacity 160ms ease-out;
+}
+
+.track[data-player-lane]::after {
+  opacity: 0.35;
+}
+
+.track[data-player-lane="0"]::after {
+  transform: translateX(-100%);
+}
+
+.track[data-player-lane="2"]::after {
+  transform: translateX(100%);
+}
+
 .track-holo {
   position: absolute;
   inset: 0;
@@ -256,7 +284,7 @@ body.is-boosting .hoverboard#player-board::after {
   width: 80px;
   height: 140px;
   transform-origin: center bottom;
-  transform: translate3d(calc(-50% + var(--lane-offset, 0px)), 0, var(--z, -240px));
+  transform: translate3d(calc(-50% + var(--lane-offset, 0px)), 0, var(--z, -240px)) scale(var(--scale, 1));
   pointer-events: none;
   display: flex;
   align-items: center;
@@ -266,6 +294,8 @@ body.is-boosting .hoverboard#player-board::after {
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: rgba(248, 250, 252, 0.8);
+  transition: opacity 160ms ease-out, transform 180ms ease-out;
+  will-change: transform, opacity;
 }
 
 .obstacle::before,
@@ -286,6 +316,16 @@ body.is-boosting .hoverboard#player-board::after {
   inset: 6px;
   border-radius: 14px;
   border: 2px solid rgba(248, 250, 252, 0.18);
+}
+
+.obstacle[data-active="true"] {
+  color: rgba(248, 250, 252, 0.95);
+  text-shadow: 0 0 12px rgba(248, 250, 252, 0.55);
+}
+
+.obstacle[data-active="true"]::after {
+  border-color: rgba(250, 204, 21, 0.55);
+  box-shadow: 0 0 24px rgba(250, 204, 21, 0.3);
 }
 
 .obstacle[data-type="traffic"] {


### PR DESCRIPTION
## Summary
- recalculate hoverboard lane offsets from the track width and keep ghost playback aligned after resizes
- highlight the current lane and active hazards so upcoming obstacles stay readable
- scale obstacle cards by depth for clearer perspective cues during runs

## Testing
- Manual - Loaded hoverboard pursuit in the local arcade build


------
https://chatgpt.com/codex/tasks/task_e_68e1edd4b2ac8328ac49493de5b8c96c