### PR TITLE
feat: add net operations arcade

### DIFF
--- a/madia.new/public/secret/net/AGENTS.md
+++ b/madia.new/public/secret/net/AGENTS.md
@@ -1,0 +1,9 @@
+# Net Operations Arcade Guidelines
+
+- Reference this project as "Net" when discussing it in future prompts.
+- Each minigame lives in its own directory under this folder and is registered in `net.js` so it shows up in the launcher grid.
+- Keep the fiction anchored in circa-1996 intranet/early-internet culture: modem tones, beige towers, ISPs, and sysadmin bulletin boards.
+- Favor neon-green on dark terminal palettes blended with midnight blues and amber indicator lights.
+- When posting completion status back to the launcher, use the message type `net:level-complete` and include a `{ score, status }` payload.
+- Keep HTML semantics accessible: labels for inputs, `aria-live` regions for status, and buttons for interactive actions.
+- CSS indentation is 2 spaces; JS indentation is 2 spaces; files should be UTF-8 encoded.

--- a/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.css
+++ b/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.css
@@ -1,0 +1,7 @@
+body {
+  background: radial-gradient(circle at top left, rgba(56, 248, 122, 0.12), transparent 55%), var(--net-bg);
+}
+
+.execute-button {
+  margin-top: 0.75rem;
+}

--- a/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.js
+++ b/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.js
@@ -1,0 +1,55 @@
+const form = document.getElementById("bgp-form");
+const board = document.getElementById("status-board");
+
+const expected = {
+  "local-pref": "raise",
+  "as-path": "double",
+  community: "blackhole",
+};
+
+const updateBoard = (message, state = "idle") => {
+  board.textContent = message;
+  board.dataset.state = state;
+};
+
+const evaluatePolicy = (formData) => {
+  const mismatches = Object.entries(expected)
+    .filter(([key, value]) => (formData.get(key) || "") !== value)
+    .map(([key]) => key);
+  return mismatches;
+};
+
+form?.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const formData = new FormData(form);
+  const mismatches = evaluatePolicy(formData);
+  if (mismatches.length) {
+    updateBoard(`Route map rejected: fix ${mismatches.join(", ")}.`, "error");
+    return;
+  }
+  updateBoard("Policies live. Backbone prefers fiber ring.", "success");
+  window.parent?.postMessage(
+    {
+      type: "net:level-complete",
+      game: "borderline-broadcast",
+      payload: {
+        status: "Routes clean",
+        score: 64512,
+      },
+    },
+    "*"
+  );
+});
+
+form?.addEventListener("input", () => {
+  if (board.dataset.state === "success") {
+    return;
+  }
+  const formData = new FormData(form);
+  const mismatches = evaluatePolicy(formData);
+  if (!mismatches.length) {
+    updateBoard("Policy ready. Deploy to routers.");
+  } else {
+    updateBoard("Session flapping. Apply damping plan…");
+  }
+});

--- a/madia.new/public/secret/net/borderline-broadcast/index.html
+++ b/madia.new/public/secret/net/borderline-broadcast/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Borderline Broadcast</title>
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="./borderline-broadcast.css" />
+  </head>
+  <body>
+    <header>
+      <p>Layer 03 · Routing Core</p>
+      <h1>Borderline Broadcast</h1>
+      <p>
+        The frame relay backup is leaking default routes into your backbone. Apply the routing memo so traffic prefers the fiber
+        ring and quarantines the noisy neighbor.
+      </p>
+    </header>
+    <main>
+      <section class="control-panel" aria-labelledby="bgp-brief">
+        <h2 id="bgp-brief">Policy console</h2>
+        <p>Choose the policy actions for each event.</p>
+        <form id="bgp-form" class="form-grid">
+          <label>
+            Backbone-1 local preference
+            <select name="local-pref">
+              <option value="">--</option>
+              <option value="keep">Leave at default 100</option>
+              <option value="raise">Raise to 150</option>
+              <option value="lower">Drop to 80</option>
+            </select>
+          </label>
+          <label>
+            Transit-backup AS path handling
+            <select name="as-path">
+              <option value="">--</option>
+              <option value="none">No prepending</option>
+              <option value="double">Prepend our ASN twice</option>
+              <option value="triple">Prepend our ASN three times</option>
+            </select>
+          </label>
+          <label>
+            Community 64512:90 (blackhole requests)
+            <select name="community">
+              <option value="">--</option>
+              <option value="propagate">Propagate normally</option>
+              <option value="blackhole">Discard route on import</option>
+              <option value="log">Accept but log only</option>
+            </select>
+          </label>
+          <button type="submit" class="execute-button">Deploy policies</button>
+        </form>
+        <div class="status-board" id="status-board" aria-live="polite">Session flapping. Apply damping plan…</div>
+      </section>
+    </main>
+    <footer>Peering etiquette keeps the network breathing.</footer>
+    <script type="module" src="./borderline-broadcast.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/net/build-info.json
+++ b/madia.new/public/secret/net/build-info.json
@@ -1,0 +1,3 @@
+{
+  "buildId": "net-ops-alpha"
+}

--- a/madia.new/public/secret/net/cache-cascade/cache-cascade.css
+++ b/madia.new/public/secret/net/cache-cascade/cache-cascade.css
@@ -1,0 +1,21 @@
+body {
+  background: radial-gradient(circle at center, rgba(56, 248, 122, 0.12), transparent 60%), var(--net-bg);
+}
+
+.stream-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.stream-grid label {
+  align-items: stretch;
+  gap: 0.5rem;
+}
+
+.stream-grid select {
+  width: 100%;
+}
+
+.execute-button {
+  margin-top: 0.75rem;
+}

--- a/madia.new/public/secret/net/cache-cascade/cache-cascade.js
+++ b/madia.new/public/secret/net/cache-cascade/cache-cascade.js
@@ -1,0 +1,60 @@
+const form = document.getElementById("cache-form");
+const board = document.getElementById("status-board");
+
+const expected = {
+  static: { route: "parent", ttl: "60" },
+  cms: { route: "direct", ttl: "5" },
+  mirror: { route: "sibling", ttl: "240" },
+};
+
+const updateBoard = (message, state = "idle") => {
+  board.textContent = message;
+  board.dataset.state = state;
+};
+
+const evaluateCache = (formData) => {
+  const mismatches = [];
+  Object.entries(expected).forEach(([prefix, config]) => {
+    const route = formData.get(prefix) || "";
+    const ttl = formData.get(`${prefix}-ttl`) || "";
+    if (route !== config.route || ttl !== config.ttl) {
+      mismatches.push(prefix);
+    }
+  });
+  return mismatches;
+};
+
+form?.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const formData = new FormData(form);
+  const mismatches = evaluateCache(formData);
+  if (mismatches.length) {
+    updateBoard(`Hierarchy rejected: adjust ${mismatches.join(", ")}.`, "error");
+    return;
+  }
+  updateBoard("Hit ratio climbing. Line holds steady.", "success");
+  window.parent?.postMessage(
+    {
+      type: "net:level-complete",
+      game: "cache-cascade",
+      payload: {
+        status: "Cache stable",
+        score: 120,
+      },
+    },
+    "*"
+  );
+});
+
+form?.addEventListener("input", () => {
+  if (board.dataset.state === "success") {
+    return;
+  }
+  const formData = new FormData(form);
+  const mismatches = evaluateCache(formData);
+  if (!mismatches.length) {
+    updateBoard("Hierarchy ready. Commit to squid.conf.");
+  } else {
+    updateBoard("Cache hit ratio falling…");
+  }
+});

--- a/madia.new/public/secret/net/cache-cascade/index.html
+++ b/madia.new/public/secret/net/cache-cascade/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Cache Cascade</title>
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="./cache-cascade.css" />
+  </head>
+  <body>
+    <header>
+      <p>Layer 02 · Proxy Works</p>
+      <h1>Cache Cascade</h1>
+      <p>
+        Squid 1.1 is choking on a late-night software launch. Route requests through the right parents and set TTLs so the dial-up
+        crowd stays fast while origin servers survive.
+      </p>
+    </header>
+    <main>
+      <section class="control-panel" aria-labelledby="cache-brief">
+        <h2 id="cache-brief">Hierarchy planner</h2>
+        <p>Assign the routing and TTL for each stream.</p>
+        <form id="cache-form" class="form-grid">
+          <fieldset>
+            <legend>Streams</legend>
+            <div class="stream-grid">
+              <label>
+                Static assets (cdn.partner.net)
+                <select name="static">
+                  <option value="">Routing</option>
+                  <option value="direct">Serve direct</option>
+                  <option value="parent">Send to parent cache</option>
+                  <option value="sibling">Share with sibling cache</option>
+                </select>
+                <select name="static-ttl">
+                  <option value="">TTL</option>
+                  <option value="15">15 minutes</option>
+                  <option value="60">60 minutes</option>
+                  <option value="120">120 minutes</option>
+                </select>
+              </label>
+              <label>
+                Newsroom CMS (cms.local)
+                <select name="cms">
+                  <option value="">Routing</option>
+                  <option value="direct">Serve direct</option>
+                  <option value="parent">Send to parent cache</option>
+                  <option value="sibling">Share with sibling cache</option>
+                </select>
+                <select name="cms-ttl">
+                  <option value="">TTL</option>
+                  <option value="5">5 minutes</option>
+                  <option value="15">15 minutes</option>
+                  <option value="60">60 minutes</option>
+                </select>
+              </label>
+              <label>
+                Software mirror (mirror.archive)
+                <select name="mirror">
+                  <option value="">Routing</option>
+                  <option value="direct">Serve direct</option>
+                  <option value="parent">Send to parent cache</option>
+                  <option value="sibling">Share with sibling cache</option>
+                </select>
+                <select name="mirror-ttl">
+                  <option value="">TTL</option>
+                  <option value="30">30 minutes</option>
+                  <option value="120">120 minutes</option>
+                  <option value="240">240 minutes</option>
+                </select>
+              </label>
+            </div>
+          </fieldset>
+          <button type="submit" class="execute-button">Commit hierarchy</button>
+        </form>
+        <div class="status-board" id="status-board" aria-live="polite">Cache hit ratio falling…
+        </div>
+      </section>
+    </main>
+    <footer>Remember: always warm the cache before the press release.</footer>
+    <script type="module" src="./cache-cascade.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/net/common.css
+++ b/madia.new/public/secret/net/common.css
@@ -1,0 +1,189 @@
+:root {
+  color-scheme: dark;
+  --net-bg: #050914;
+  --net-panel: #0b1224;
+  --net-grid: rgba(14, 116, 144, 0.3);
+  --net-accent: #38f87a;
+  --net-amber: #f4b400;
+  --net-text: #e2fbe2;
+  --net-muted: rgba(148, 197, 183, 0.78);
+  --net-danger: #ff5f6d;
+  font-family: "IBM Plex Mono", "Fira Code", "Menlo", monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(circle at top, rgba(56, 88, 120, 0.3) 0%, rgba(5, 9, 20, 0.95) 55%), var(--net-bg);
+  color: var(--net-text);
+}
+
+a {
+  color: var(--net-accent);
+}
+
+header {
+  padding: 1.5rem clamp(1rem, 4vw, 3rem) 1rem;
+  border-bottom: 1px solid rgba(56, 248, 122, 0.2);
+  background: linear-gradient(180deg, rgba(16, 24, 46, 0.9) 0%, rgba(7, 12, 26, 0.95) 100%);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+header h1 {
+  margin: 0.5rem 0 0;
+  font-size: clamp(1.75rem, 4vw, 2.75rem);
+}
+
+header p {
+  margin: 0.25rem 0 0;
+  font-size: clamp(0.85rem, 2.5vw, 1rem);
+  color: var(--net-muted);
+}
+
+main {
+  flex: 1;
+  padding: clamp(1rem, 4vw, 2.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.control-panel {
+  background: var(--net-panel);
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  border-radius: 12px;
+  padding: clamp(1rem, 3vw, 1.5rem);
+  box-shadow: 0 10px 28px rgba(2, 12, 24, 0.45);
+}
+
+.control-panel h2 {
+  margin: 0 0 1rem;
+  font-size: 1.1rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+  color: var(--net-muted);
+  gap: 0.4rem;
+}
+
+input,
+select,
+button,
+textarea {
+  font-family: inherit;
+  font-size: 1rem;
+  color: var(--net-text);
+  background: rgba(6, 16, 32, 0.9);
+  border: 1px solid rgba(56, 248, 122, 0.35);
+  border-radius: 6px;
+  padding: 0.55rem 0.75rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+button:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--net-accent);
+  box-shadow: 0 0 0 2px rgba(56, 248, 122, 0.25);
+}
+
+button {
+  cursor: pointer;
+  background: linear-gradient(135deg, rgba(56, 248, 122, 0.15), rgba(56, 248, 122, 0.35));
+  border: 1px solid rgba(56, 248, 122, 0.5);
+}
+
+button:hover {
+  border-color: var(--net-accent);
+}
+
+.status-board {
+  background: rgba(6, 14, 26, 0.9);
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  border-radius: 10px;
+  padding: 1rem;
+  font-size: 0.95rem;
+  color: var(--net-text);
+}
+
+.status-board strong {
+  color: var(--net-accent);
+}
+
+.status-board[data-state="success"] {
+  border-color: rgba(56, 248, 122, 0.6);
+  box-shadow: 0 0 22px rgba(56, 248, 122, 0.3);
+}
+
+.status-board[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.5);
+  box-shadow: 0 0 22px rgba(255, 95, 109, 0.25);
+  color: #ffd9e1;
+}
+
+fieldset {
+  border: 1px dashed rgba(56, 248, 122, 0.25);
+  border-radius: 8px;
+  padding: 0.75rem 1rem 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+legend {
+  padding: 0 0.5rem;
+  font-size: 0.9rem;
+  color: var(--net-accent);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.checkbox-grid,
+.radio-grid {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.checkbox-grid label,
+.radio-grid label {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(4, 12, 26, 0.7);
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  border-radius: 6px;
+}
+
+.checkbox-grid input,
+.radio-grid input {
+  width: auto;
+  margin-left: 0.75rem;
+}
+
+[aria-live] {
+  min-height: 1.5rem;
+}
+
+footer {
+  padding: 1.5rem clamp(1rem, 4vw, 3rem);
+  text-align: center;
+  font-size: 0.8rem;
+  color: rgba(148, 197, 183, 0.7);
+}

--- a/madia.new/public/secret/net/daemon-handshake/daemon-handshake.css
+++ b/madia.new/public/secret/net/daemon-handshake/daemon-handshake.css
@@ -1,0 +1,16 @@
+body {
+  background: radial-gradient(circle at left, rgba(56, 248, 122, 0.12), transparent 55%),
+    radial-gradient(circle at right, rgba(244, 180, 0, 0.12), transparent 60%), var(--net-bg);
+}
+
+.task-list {
+  margin: 0 0 1.25rem;
+  padding-left: 1rem;
+  color: var(--net-muted);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.execute-button {
+  margin-top: 0.5rem;
+}

--- a/madia.new/public/secret/net/daemon-handshake/daemon-handshake.js
+++ b/madia.new/public/secret/net/daemon-handshake/daemon-handshake.js
@@ -1,0 +1,74 @@
+const form = document.getElementById("daemon-form");
+const board = document.getElementById("status-board");
+
+const REQUIRED_PORT = 8080;
+const REQUIRED_ROOT = "/var/www/altroot";
+const REQUIRED_MODULES = ["mod_ssl", "mod_status"];
+const FORBIDDEN_MODULES = ["mod_userdir"];
+
+const updateBoard = (message, state = "idle") => {
+  board.textContent = message;
+  board.dataset.state = state;
+};
+
+const evaluateConfig = (formData) => {
+  const port = Number(formData.get("port"));
+  const docroot = (formData.get("docroot") || "").trim();
+  const modules = new Set(formData.getAll("modules"));
+  const issues = [];
+  if (port !== REQUIRED_PORT) {
+    issues.push("Port");
+  }
+  if (docroot !== REQUIRED_ROOT) {
+    issues.push("DocumentRoot");
+  }
+  REQUIRED_MODULES.forEach((module) => {
+    if (!modules.has(module)) {
+      issues.push(module);
+    }
+  });
+  FORBIDDEN_MODULES.forEach((module) => {
+    if (modules.has(module)) {
+      issues.push(`Remove ${module}`);
+    }
+  });
+  return issues;
+};
+
+const handleSubmit = (event) => {
+  event.preventDefault();
+  const formData = new FormData(form);
+  const issues = evaluateConfig(formData);
+  if (issues.length) {
+    updateBoard(`Daemon refused: ${issues.join(", ")}.`, "error");
+    return;
+  }
+  updateBoard("httpd ready. Access log streaming.", "success");
+  window.parent?.postMessage(
+    {
+      type: "net:level-complete",
+      game: "daemon-handshake",
+      payload: {
+        status: "Service green",
+        score: 8080,
+      },
+    },
+    "*"
+  );
+};
+
+const handleInput = () => {
+  if (board.dataset.state === "success") {
+    return;
+  }
+  const formData = new FormData(form);
+  const issues = evaluateConfig(formData);
+  if (!issues.length) {
+    updateBoard("Checklist satisfied. Ready to launch.");
+  } else {
+    updateBoard("Daemon halted. Awaiting config…");
+  }
+};
+
+form?.addEventListener("submit", handleSubmit);
+form?.addEventListener("input", handleInput);

--- a/madia.new/public/secret/net/daemon-handshake/index.html
+++ b/madia.new/public/secret/net/daemon-handshake/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Daemon Handshake</title>
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="./daemon-handshake.css" />
+  </head>
+  <body>
+    <header>
+      <p>Layer 06 · Web Stack</p>
+      <h1>Daemon Handshake</h1>
+      <p>
+        You're on-call for the student newspaper. Apache won't stay up, the server certificate is expiring, and traffic spikes at
+        dawn. Configure the daemon exactly as the ops checklist demands.
+      </p>
+    </header>
+    <main>
+      <section class="control-panel" aria-labelledby="httpd-brief">
+        <h2 id="httpd-brief">Ops checklist</h2>
+        <p>Ensure the following before you fire up <code>httpd</code>:</p>
+        <ul class="task-list">
+          <li>Listen on port <strong>8080</strong> while the proxy is in front.</li>
+          <li>Use <code>/var/www/altroot</code> as the document root.</li>
+          <li>Enable both <strong>mod_ssl</strong> and <strong>mod_status</strong>. Do not enable <strong>mod_userdir</strong>.</li>
+        </ul>
+        <form id="daemon-form" class="form-grid">
+          <label>
+            Listen Port
+            <input type="number" name="port" min="1" max="65535" value="80" />
+          </label>
+          <label>
+            Document Root
+            <input type="text" name="docroot" placeholder="/var/www/html" />
+          </label>
+          <fieldset>
+            <legend>Modules</legend>
+            <div class="checkbox-grid">
+              <label>
+                mod_ssl
+                <input type="checkbox" name="modules" value="mod_ssl" />
+              </label>
+              <label>
+                mod_status
+                <input type="checkbox" name="modules" value="mod_status" />
+              </label>
+              <label>
+                mod_userdir
+                <input type="checkbox" name="modules" value="mod_userdir" />
+              </label>
+              <label>
+                mod_rewrite
+                <input type="checkbox" name="modules" value="mod_rewrite" />
+              </label>
+            </div>
+          </fieldset>
+          <button type="submit" class="execute-button">Start daemon</button>
+        </form>
+        <div class="status-board" id="status-board" aria-live="polite">Daemon halted. Awaiting config…</div>
+      </section>
+    </main>
+    <footer>Keep alive ping courtesy of the campus NOC.</footer>
+    <script type="module" src="./daemon-handshake.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/net/index.html
+++ b/madia.new/public/secret/net/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Net Operations Arcade</title>
+    <link rel="stylesheet" href="net.css" id="net-style" />
+  </head>
+  <body>
+    <div class="scanlines" aria-hidden="true"></div>
+    <header class="net-header">
+      <div class="header-grid" aria-hidden="true"></div>
+      <p class="eyebrow">Secret Annex // Ops Lab</p>
+      <h1>Net Operations Arcade</h1>
+      <p class="tagline">Simulators from the deep web trenches of 1996.</p>
+    </header>
+    <main>
+      <section class="overview" aria-label="Arcade briefing">
+        <p>
+          Patch into the midnight backbone and rehearse the rituals every dial-up engineer swore by:
+          clean DNS zones, razor-sharp daemons, kernels stitched by hand. Each cabinet is a scenario pulled from late-night
+          message boards and pager alerts.
+        </p>
+        <button type="button" id="reset-progress" class="reset-button">Reset cabinet memory</button>
+      </section>
+      <section class="net-grid" id="node-grid" aria-label="Cabinet selection"></section>
+    </main>
+    <template id="node-card-template">
+      <article class="node-card">
+        <div class="node-thumb" aria-hidden="true"></div>
+        <div class="node-info">
+          <p class="node-layer"></p>
+          <h2 class="node-title"></h2>
+          <p class="node-description"></p>
+          <p class="node-status" data-status></p>
+        </div>
+        <div class="node-actions">
+          <button type="button" class="boot-button">
+            <span>Boot sequence</span>
+            <span aria-hidden="true">▶</span>
+          </button>
+        </div>
+      </article>
+    </template>
+    <div class="player-overlay" id="player-overlay" hidden>
+      <div class="overlay-backdrop" id="overlay-backdrop"></div>
+      <section class="overlay-frame" role="dialog" aria-modal="true" aria-labelledby="player-title" tabindex="-1">
+        <header class="overlay-header">
+          <div>
+            <p class="overlay-eyebrow">Now Jacked In</p>
+            <h2 id="player-title"></h2>
+            <p id="player-layer" class="overlay-layer"></p>
+            <p id="player-description" class="overlay-description"></p>
+          </div>
+          <div class="overlay-actions">
+            <button type="button" id="restart-cabinet" class="restart-button" aria-disabled="true" disabled>Restart</button>
+            <button type="button" id="close-overlay" class="close-button">Exit</button>
+          </div>
+        </header>
+        <iframe id="cabinet-frame" title="Net operations cabinet" loading="lazy"></iframe>
+      </section>
+    </div>
+    <script type="module">
+      const cacheBustUrl = (path, version) => `${path}?v=${encodeURIComponent(version)}`;
+
+      const getBuildId = async () => {
+        try {
+          const response = await fetch("./build-info.json", { cache: "no-store" });
+          if (!response.ok) {
+            throw new Error(`Failed to load build info: ${response.status}`);
+          }
+          const data = await response.json();
+          return data?.buildId || Date.now().toString();
+        } catch (error) {
+          console.warn("Falling back to timestamp cache buster", error);
+          return Date.now().toString();
+        }
+      };
+
+      const buildId = await getBuildId();
+      window.__NET_BUILD_ID__ = buildId;
+
+      const stylesheet = document.getElementById("net-style");
+      if (stylesheet) {
+        stylesheet.href = cacheBustUrl("net.css", buildId);
+      }
+
+      await import(cacheBustUrl("./net.js", buildId));
+    </script>
+  </body>
+</html>

--- a/madia.new/public/secret/net/kernel-forge-20/index.html
+++ b/madia.new/public/secret/net/kernel-forge-20/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Kernel Forge 2.0</title>
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="./kernel-forge-20.css" />
+  </head>
+  <body>
+    <header>
+      <p>Layer 05 · Kernel Lab</p>
+      <h1>Kernel Forge 2.0</h1>
+      <p>
+        The colo is rolling out dual-homed routers. Your kernel must be lean, route packets fast, and boot without SCSI baggage.
+        Toggle features to match the deployment memo.
+      </p>
+    </header>
+    <main>
+      <section class="control-panel" aria-labelledby="kernel-brief">
+        <h2 id="kernel-brief">Build directives</h2>
+        <p>Target kernel: 2.0.36 with SMP patch.</p>
+        <ul class="task-list">
+          <li>Enable <strong>IP forwarding</strong> and <strong>IP firewall</strong> support.</li>
+          <li>Compile <strong>3c59x</strong> NIC driver <em>into</em> the kernel.</li>
+          <li>Exclude <strong>SCSI</strong> and <strong>Sound</strong> subsystems to shrink the image.</li>
+        </ul>
+        <form id="kernel-form" class="form-grid">
+          <fieldset>
+            <legend>Networking</legend>
+            <div class="checkbox-grid">
+              <label>
+                IP forwarding
+                <input type="checkbox" name="network" value="forwarding" />
+              </label>
+              <label>
+                IP firewalling
+                <input type="checkbox" name="network" value="firewall" />
+              </label>
+              <label>
+                Experimental IPv6
+                <input type="checkbox" name="network" value="ipv6" />
+              </label>
+            </div>
+          </fieldset>
+          <fieldset>
+            <legend>Device Drivers</legend>
+            <label>
+              3c59x driver
+              <select name="nic-mode">
+                <option value="module">Build as module</option>
+                <option value="builtin">Compile into kernel</option>
+              </select>
+            </label>
+            <div class="checkbox-grid">
+              <label>
+                Include SCSI support
+                <input type="checkbox" name="drivers" value="scsi" />
+              </label>
+              <label>
+                Include Sound subsystem
+                <input type="checkbox" name="drivers" value="sound" />
+              </label>
+              <label>
+                Include PCMCIA
+                <input type="checkbox" name="drivers" value="pcmcia" />
+              </label>
+            </div>
+          </fieldset>
+          <button type="submit" class="execute-button">make bzImage</button>
+        </form>
+        <div class="status-board" id="status-board" aria-live="polite">Awaiting config for make menuconfig…</div>
+      </section>
+    </main>
+    <footer>Remember to copy System.map once it boots.</footer>
+    <script type="module" src="./kernel-forge-20.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.css
+++ b/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.css
@@ -1,0 +1,16 @@
+body {
+  background: radial-gradient(circle at top, rgba(56, 248, 122, 0.14), transparent 55%),
+    radial-gradient(circle at bottom, rgba(244, 180, 0, 0.12), transparent 60%), var(--net-bg);
+}
+
+.task-list {
+  margin: 0 0 1.25rem;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.4rem;
+  color: var(--net-muted);
+}
+
+.execute-button {
+  margin-top: 0.75rem;
+}

--- a/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.js
+++ b/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.js
@@ -1,0 +1,78 @@
+const form = document.getElementById("kernel-form");
+const board = document.getElementById("status-board");
+
+const REQUIRED_NETWORK = ["forwarding", "firewall"];
+const OPTIONAL_NETWORK = ["ipv6"];
+const REQUIRED_NIC_MODE = "builtin";
+const FORBIDDEN_DRIVERS = ["scsi", "sound"];
+
+const updateBoard = (message, state = "idle") => {
+  board.textContent = message;
+  board.dataset.state = state;
+};
+
+const evaluateKernel = (formData) => {
+  const network = new Set(formData.getAll("network"));
+  const drivers = new Set(formData.getAll("drivers"));
+  const nicMode = formData.get("nic-mode");
+  const issues = [];
+
+  REQUIRED_NETWORK.forEach((flag) => {
+    if (!network.has(flag)) {
+      issues.push(`Enable ${flag}`);
+    }
+  });
+
+  OPTIONAL_NETWORK.forEach((flag) => {
+    if (network.has(flag)) {
+      issues.push(`Disable ${flag}`);
+    }
+  });
+
+  if (nicMode !== REQUIRED_NIC_MODE) {
+    issues.push("3c59x mode");
+  }
+
+  FORBIDDEN_DRIVERS.forEach((flag) => {
+    if (drivers.has(flag)) {
+      issues.push(`Remove ${flag}`);
+    }
+  });
+
+  return issues;
+};
+
+form?.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const formData = new FormData(form);
+  const issues = evaluateKernel(formData);
+  if (issues.length) {
+    updateBoard(`Build failed: ${issues.join(", ")}.`, "error");
+    return;
+  }
+  updateBoard("Kernel linked. bzImage staged in /boot.", "success");
+  window.parent?.postMessage(
+    {
+      type: "net:level-complete",
+      game: "kernel-forge-20",
+      payload: {
+        status: "Router ready",
+        score: 20036,
+      },
+    },
+    "*"
+  );
+});
+
+form?.addEventListener("input", () => {
+  if (board.dataset.state === "success") {
+    return;
+  }
+  const formData = new FormData(form);
+  const issues = evaluateKernel(formData);
+  if (!issues.length) {
+    updateBoard("Config matches memo. make bzImage ready.");
+  } else {
+    updateBoard("Awaiting config for make menuconfig…");
+  }
+});

--- a/madia.new/public/secret/net/modem-skunkworks/index.html
+++ b/madia.new/public/secret/net/modem-skunkworks/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Modem Skunkworks</title>
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="./modem-skunkworks.css" />
+  </head>
+  <body>
+    <header>
+      <p>Layer 04 · Dial-Up Ops</p>
+      <h1>Modem Skunkworks</h1>
+      <p>
+        The overnight newsroom needs a clean PPP session. Sequence the handshake so their dialer script negotiates without redials
+        and the newsroom feed syncs on the first try.
+      </p>
+    </header>
+    <main>
+      <section class="control-panel" aria-labelledby="ppp-brief">
+        <h2 id="ppp-brief">Handshake console</h2>
+        <p>Assign the correct order to each PPP phase. No duplicates allowed.</p>
+        <form id="ppp-form" class="form-grid">
+          <fieldset>
+            <legend>Phase ordering</legend>
+            <div class="phase-grid">
+              <label>
+                Carrier detect
+                <select name="carrier">
+                  <option value="">--</option>
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                  <option value="4">4</option>
+                </select>
+              </label>
+              <label>
+                Link control negotiation (LCP)
+                <select name="lcp">
+                  <option value="">--</option>
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                  <option value="4">4</option>
+                </select>
+              </label>
+              <label>
+                Authentication (PAP/CHAP)
+                <select name="auth">
+                  <option value="">--</option>
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                  <option value="4">4</option>
+                </select>
+              </label>
+              <label>
+                Network control (IPCP)
+                <select name="ipcp">
+                  <option value="">--</option>
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                  <option value="4">4</option>
+                </select>
+              </label>
+            </div>
+          </fieldset>
+          <button type="submit" class="execute-button">Dial now</button>
+        </form>
+        <div class="status-board" id="status-board" aria-live="polite">Modem idle. Awaiting script…</div>
+      </section>
+    </main>
+    <footer>Pair your 56K with a clean copper line.</footer>
+    <script type="module" src="./modem-skunkworks.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.css
+++ b/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.css
@@ -1,0 +1,13 @@
+body {
+  background: radial-gradient(circle at center, rgba(56, 248, 122, 0.1), transparent 60%), var(--net-bg);
+}
+
+.phase-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+}
+
+.execute-button {
+  margin-top: 0.75rem;
+}

--- a/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.js
+++ b/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.js
@@ -1,0 +1,70 @@
+const form = document.getElementById("ppp-form");
+const board = document.getElementById("status-board");
+
+const expectedOrder = {
+  carrier: "1",
+  lcp: "2",
+  auth: "3",
+  ipcp: "4",
+};
+
+const updateBoard = (message, state = "idle") => {
+  board.textContent = message;
+  board.dataset.state = state;
+};
+
+const evaluateOrder = (formData) => {
+  const values = Object.fromEntries(Object.keys(expectedOrder).map((key) => [key, formData.get(key) || ""]));
+  const duplicates = new Set();
+  const seen = new Map();
+  Object.entries(values).forEach(([key, value]) => {
+    if (!value) {
+      return;
+    }
+    if (seen.has(value)) {
+      duplicates.add(value);
+    }
+    seen.set(value, key);
+  });
+  const mismatches = Object.entries(expectedOrder).filter(([key, value]) => values[key] !== value).map(([key]) => key);
+  return { duplicates, mismatches };
+};
+
+form?.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const formData = new FormData(form);
+  const { duplicates, mismatches } = evaluateOrder(formData);
+  if (duplicates.size) {
+    updateBoard(`Modem error: duplicate steps ${Array.from(duplicates).join(", ")}.`, "error");
+    return;
+  }
+  if (mismatches.length) {
+    updateBoard(`Negotiation failed: adjust ${mismatches.join(", ")}.`, "error");
+    return;
+  }
+  updateBoard("PPP link live. newsroom feed synchronized.", "success");
+  window.parent?.postMessage(
+    {
+      type: "net:level-complete",
+      game: "modem-skunkworks",
+      payload: {
+        status: "Link steady",
+        score: 56000,
+      },
+    },
+    "*"
+  );
+});
+
+form?.addEventListener("input", () => {
+  if (board.dataset.state === "success") {
+    return;
+  }
+  const formData = new FormData(form);
+  const { duplicates, mismatches } = evaluateOrder(formData);
+  if (!duplicates.size && !mismatches.length) {
+    updateBoard("Sequence locked. Dial when ready.");
+  } else {
+    updateBoard("Modem idle. Awaiting script…");
+  }
+});

--- a/madia.new/public/secret/net/net.css
+++ b/madia.new/public/secret/net/net.css
@@ -1,0 +1,316 @@
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&display=swap");
+
+:root {
+  color-scheme: dark;
+  --bg: #050914;
+  --grid-lines: rgba(56, 248, 122, 0.08);
+  --card-bg: rgba(7, 16, 30, 0.9);
+  --card-border: rgba(56, 248, 122, 0.28);
+  --accent: #38f87a;
+  --amber: #f4b400;
+  --text: #e7ffee;
+  --muted: rgba(148, 197, 183, 0.78);
+  font-family: "IBM Plex Mono", "Fira Code", "Menlo", monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(56, 88, 120, 0.35) 0%, rgba(5, 9, 20, 0.95) 55%), var(--bg);
+  color: var(--text);
+  overflow-x: hidden;
+}
+
+.scanlines::before,
+.scanlines::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+}
+
+.scanlines::before {
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(4, 8, 16, 0),
+    rgba(4, 8, 16, 0) 2px,
+    rgba(4, 8, 16, 0.15) 3px
+  );
+  mix-blend-mode: multiply;
+}
+
+.scanlines::after {
+  background: radial-gradient(circle at center, rgba(56, 248, 122, 0.08) 0%, rgba(5, 9, 20, 0.75) 60%);
+}
+
+.net-header {
+  position: relative;
+  padding: clamp(1.5rem, 4vw, 3rem) clamp(1.5rem, 4vw, 4rem) clamp(1rem, 3vw, 2rem);
+  overflow: hidden;
+}
+
+.header-grid {
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(var(--grid-lines) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid-lines) 1px, transparent 1px);
+  background-size: 40px 40px;
+  opacity: 0.6;
+  transform: skewY(-6deg) translateY(-12%);
+}
+
+.eyebrow {
+  position: relative;
+  margin: 0;
+  font-size: clamp(0.8rem, 2.4vw, 1rem);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--amber);
+}
+
+.net-header h1 {
+  position: relative;
+  margin: clamp(0.4rem, 1vw, 0.75rem) 0 0.25rem;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.tagline {
+  position: relative;
+  margin: 0;
+  max-width: 38ch;
+  font-size: clamp(0.95rem, 2.3vw, 1.1rem);
+  color: var(--muted);
+}
+
+main {
+  padding: 0 clamp(1.25rem, 4vw, 4rem) clamp(3rem, 6vw, 5rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.75rem);
+}
+
+.overview {
+  background: rgba(7, 16, 30, 0.85);
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  border-radius: 18px;
+  padding: clamp(1rem, 3vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  font-size: clamp(0.95rem, 2.4vw, 1.05rem);
+  color: var(--muted);
+}
+
+.reset-button {
+  align-self: flex-start;
+  padding: 0.6rem 1.2rem;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  background: linear-gradient(135deg, rgba(56, 248, 122, 0.15), rgba(56, 248, 122, 0.35));
+  border: 1px solid rgba(56, 248, 122, 0.45);
+  color: var(--text);
+  cursor: pointer;
+  border-radius: 999px;
+}
+
+.reset-button:hover {
+  border-color: var(--accent);
+}
+
+.net-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(1rem, 3vw, 2rem);
+}
+
+.node-card {
+  position: relative;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 18px;
+  padding: 1.25rem;
+  display: grid;
+  grid-template-columns: auto;
+  gap: 1.15rem;
+  min-height: 320px;
+  box-shadow: 0 18px 32px rgba(3, 10, 20, 0.45);
+}
+
+.node-thumb {
+  height: 120px;
+  border-radius: 12px;
+  background: radial-gradient(circle at 20% 20%, rgba(56, 248, 122, 0.3), rgba(5, 9, 20, 0.85));
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+  font-size: 0.85rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.node-info {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.node-layer {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--amber);
+}
+
+.node-title {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.node-description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.node-status {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(56, 248, 122, 0.75);
+}
+
+.node-status[data-offline="true"] {
+  color: rgba(255, 95, 109, 0.8);
+}
+
+.node-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.boot-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 1.35rem;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  font-size: 0.85rem;
+  background: linear-gradient(135deg, rgba(56, 248, 122, 0.2), rgba(56, 248, 122, 0.4));
+  border: 1px solid rgba(56, 248, 122, 0.5);
+  border-radius: 999px;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.boot-button:hover {
+  border-color: var(--accent);
+  box-shadow: 0 0 18px rgba(56, 248, 122, 0.35);
+}
+
+.player-overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: clamp(1rem, 4vw, 2rem);
+  background: rgba(2, 8, 16, 0.75);
+  backdrop-filter: blur(6px);
+  z-index: 20;
+}
+
+.overlay-backdrop {
+  position: absolute;
+  inset: 0;
+}
+
+.overlay-frame {
+  position: relative;
+  width: min(960px, 100%);
+  height: min(720px, 90vh);
+  background: rgba(4, 10, 20, 0.95);
+  border: 1px solid rgba(56, 248, 122, 0.35);
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 28px 48px rgba(2, 6, 12, 0.65);
+}
+
+.overlay-header {
+  padding: 1rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  border-bottom: 1px solid rgba(56, 248, 122, 0.25);
+}
+
+.overlay-eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: rgba(56, 248, 122, 0.8);
+}
+
+.overlay-layer,
+.overlay-description {
+  margin: 0.3rem 0 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.overlay-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.restart-button,
+.close-button {
+  padding: 0.55rem 1.2rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.8rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(56, 248, 122, 0.2), rgba(56, 248, 122, 0.4));
+  border: 1px solid rgba(56, 248, 122, 0.4);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.restart-button[aria-disabled="true"] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.close-button {
+  background: linear-gradient(135deg, rgba(244, 180, 0, 0.25), rgba(244, 180, 0, 0.35));
+  border: 1px solid rgba(244, 180, 0, 0.4);
+}
+
+#cabinet-frame {
+  flex: 1;
+  border: none;
+  background: #000;
+}
+
+@media (max-width: 720px) {
+  .node-card {
+    min-height: 0;
+  }
+
+  .overlay-frame {
+    height: 90vh;
+  }
+}

--- a/madia.new/public/secret/net/net.js
+++ b/madia.new/public/secret/net/net.js
@@ -1,0 +1,246 @@
+const STORAGE_KEY = "net-ops-progress";
+
+const nodes = [
+  {
+    id: "root-zone-relay",
+    layer: "Layer 07 · DNS Authority",
+    name: "Root Zone Relay",
+    description:
+      "Rebuild an ISP's DNS zone after a power blip. Map records to the right hosts before the modem bank times out.",
+    url: "./root-zone-relay/index.html",
+    thumbnail: "NS Lookup",
+  },
+  {
+    id: "daemon-handshake",
+    layer: "Layer 06 · Web Stack",
+    name: "Daemon Handshake",
+    description:
+      "Kick Apache 1.1 into motion on a beige tower. Enable the right modules and ride the green lights to 200 OK.",
+    url: "./daemon-handshake/index.html",
+    thumbnail: "httpd",
+  },
+  {
+    id: "kernel-forge-20",
+    layer: "Layer 05 · Kernel Lab",
+    name: "Kernel Forge 2.0",
+    description:
+      "Compile a lean 2.0.x kernel for dual NIC routing. Strip the bloat, keep the drivers, and beat the pager deadline.",
+    url: "./kernel-forge-20/index.html",
+    thumbnail: "make bzImage",
+  },
+  {
+    id: "modem-skunkworks",
+    layer: "Layer 04 · Dial-Up Ops",
+    name: "Modem Skunkworks",
+    description:
+      "Sequence the perfect PPP handshake so the remote newsroom can sync before sunrise.",
+    url: "./modem-skunkworks/index.html",
+    thumbnail: "PPP Sync",
+  },
+  {
+    id: "borderline-broadcast",
+    layer: "Layer 03 · Routing Core",
+    name: "Borderline Broadcast",
+    description:
+      "Tame a flapping BGP session and set policies so backbone traffic stops leaking over the backup frame relay.",
+    url: "./borderline-broadcast/index.html",
+    thumbnail: "BGP Map",
+  },
+  {
+    id: "cache-cascade",
+    layer: "Layer 02 · Proxy Works",
+    name: "Cache Cascade",
+    description:
+      "Tune your Squid cache hierarchy to absorb a surprise traffic storm without melting the leased line.",
+    url: "./cache-cascade/index.html",
+    thumbnail: "Proxy Flow",
+  },
+];
+
+const loadProgress = () => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return {};
+    }
+    const parsed = JSON.parse(stored);
+    return typeof parsed === "object" && parsed ? parsed : {};
+  } catch (error) {
+    console.warn("Failed to parse progress", error);
+    return {};
+  }
+};
+
+const saveProgress = (progress) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(progress));
+  } catch (error) {
+    console.warn("Failed to store progress", error);
+  }
+};
+
+const progress = loadProgress();
+
+const grid = document.getElementById("node-grid");
+const template = document.getElementById("node-card-template");
+const overlay = document.getElementById("player-overlay");
+const frame = document.getElementById("cabinet-frame");
+const closeButton = document.getElementById("close-overlay");
+const restartButton = document.getElementById("restart-cabinet");
+const titleEl = document.getElementById("player-title");
+const layerEl = document.getElementById("player-layer");
+const descriptionEl = document.getElementById("player-description");
+const overlayBackdrop = document.getElementById("overlay-backdrop");
+const resetProgressButton = document.getElementById("reset-progress");
+
+const cardIndex = new Map();
+let activeNode = null;
+
+const updateStatus = (nodeId, statusData = null) => {
+  const entry = cardIndex.get(nodeId);
+  if (!entry) {
+    return;
+  }
+  const statusElement = entry.querySelector("[data-status]");
+  if (!statusElement) {
+    return;
+  }
+  if (statusData) {
+    statusElement.textContent = statusData.status || "Online";
+    statusElement.dataset.offline = "false";
+    statusElement.setAttribute("data-completed", "true");
+  } else {
+    statusElement.textContent = "Offline";
+    statusElement.dataset.offline = "true";
+    statusElement.removeAttribute("data-completed");
+  }
+};
+
+const renderGrid = () => {
+  if (!grid || !template) {
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  nodes.forEach((node) => {
+    const card = template.content.firstElementChild.cloneNode(true);
+    card.dataset.nodeId = node.id;
+    const thumb = card.querySelector(".node-thumb");
+    const layer = card.querySelector(".node-layer");
+    const title = card.querySelector(".node-title");
+    const description = card.querySelector(".node-description");
+    const status = card.querySelector("[data-status]");
+    const button = card.querySelector(".boot-button");
+
+    if (thumb) {
+      thumb.textContent = node.thumbnail;
+    }
+    if (layer) {
+      layer.textContent = node.layer;
+    }
+    if (title) {
+      title.textContent = node.name;
+    }
+    if (description) {
+      description.textContent = node.description;
+    }
+    if (status) {
+      const stored = progress[node.id];
+      if (stored) {
+        status.textContent = stored.status || "Online";
+        status.dataset.offline = "false";
+        status.setAttribute("data-completed", "true");
+      } else {
+        status.textContent = "Offline";
+        status.dataset.offline = "true";
+      }
+    }
+    if (button) {
+      button.addEventListener("click", () => openNode(node));
+    }
+
+    cardIndex.set(node.id, card);
+    fragment.append(card);
+  });
+  grid.replaceChildren(fragment);
+};
+
+const openNode = (node) => {
+  if (!overlay || !frame) {
+    return;
+  }
+  activeNode = node;
+  titleEl.textContent = node.name;
+  layerEl.textContent = node.layer;
+  descriptionEl.textContent = node.description;
+  frame.src = node.url;
+  restartButton.setAttribute("aria-disabled", "true");
+  restartButton.disabled = true;
+  overlay.hidden = false;
+  overlay.dataset.open = "true";
+  requestAnimationFrame(() => {
+    overlay?.querySelector(".overlay-frame")?.focus({ preventScroll: true });
+  });
+};
+
+const closeOverlay = () => {
+  if (!overlay || !frame) {
+    return;
+  }
+  overlay.hidden = true;
+  overlay.removeAttribute("data-open");
+  frame.src = "about:blank";
+  activeNode = null;
+};
+
+const restartNode = () => {
+  if (!frame || !activeNode) {
+    return;
+  }
+  const currentSrc = frame.src;
+  frame.src = "about:blank";
+  setTimeout(() => {
+    frame.src = currentSrc || activeNode.url;
+  }, 20);
+};
+
+closeButton?.addEventListener("click", closeOverlay);
+overlayBackdrop?.addEventListener("click", closeOverlay);
+restartButton?.addEventListener("click", restartNode);
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape" && !overlay?.hidden) {
+    closeOverlay();
+  }
+});
+
+resetProgressButton?.addEventListener("click", () => {
+  Object.keys(progress).forEach((key) => delete progress[key]);
+  saveProgress(progress);
+  nodes.forEach((node) => updateStatus(node.id, null));
+});
+
+window.addEventListener("message", (event) => {
+  const data = event.data;
+  if (!data || typeof data !== "object") {
+    return;
+  }
+  if (data.type !== "net:level-complete") {
+    return;
+  }
+  const nodeId = data.game;
+  const payload = data.payload ?? {};
+  if (!nodeId || !nodes.some((node) => node.id === nodeId)) {
+    return;
+  }
+  progress[nodeId] = {
+    status: payload.status || "Stabilized",
+    score: payload.score ?? null,
+    timestamp: Date.now(),
+  };
+  saveProgress(progress);
+  updateStatus(nodeId, progress[nodeId]);
+  restartButton.removeAttribute("aria-disabled");
+  restartButton.disabled = false;
+});
+
+renderGrid();

--- a/madia.new/public/secret/net/root-zone-relay/index.html
+++ b/madia.new/public/secret/net/root-zone-relay/index.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Root Zone Relay</title>
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="./root-zone-relay.css" />
+  </head>
+  <body>
+    <header>
+      <p>Layer 07 · DNS Authority</p>
+      <h1>Root Zone Relay</h1>
+      <p>
+        A campus blackout scrambled your ISP's primary zone file. Patch the records before modem banks begin flapping and keep
+        the secondary servers in sync.
+      </p>
+    </header>
+    <main>
+      <section class="control-panel" aria-labelledby="zone-directive">
+        <h2 id="zone-directive">Directive</h2>
+        <p>
+          Align each record with the bulletin below. TTL values are strict. Use trailing dots where needed. Once every tile turns
+          green, push the zone live.
+        </p>
+        <ul class="task-list">
+          <li><strong>www</strong> should be an <abbr title="Address">A</abbr> record to <code>203.0.113.42</code> with TTL <code>3600</code>.</li>
+          <li><strong>mail</strong> should be an <abbr title="Mail Exchange">MX</abbr> record targeting <code>mail.isp.example.</code> with priority <code>10</code>.</li>
+          <li><strong>@</strong> needs an <abbr title="Name Server">NS</abbr> record pointing at <code>ns1.isp.example.</code>.</li>
+        </ul>
+        <form id="zone-form" class="form-grid">
+          <fieldset>
+            <legend>www</legend>
+            <label>
+              Record Type
+              <select name="www-type" required>
+                <option value="">Select</option>
+                <option value="A">A</option>
+                <option value="CNAME">CNAME</option>
+                <option value="MX">MX</option>
+              </select>
+            </label>
+            <label>
+              Value
+              <input type="text" name="www-value" placeholder="203.0.113.42" required />
+            </label>
+            <label>
+              TTL
+              <input type="number" name="www-ttl" placeholder="3600" required />
+            </label>
+          </fieldset>
+          <fieldset>
+            <legend>mail</legend>
+            <label>
+              Record Type
+              <select name="mail-type" required>
+                <option value="">Select</option>
+                <option value="MX">MX</option>
+                <option value="A">A</option>
+                <option value="CNAME">CNAME</option>
+              </select>
+            </label>
+            <label>
+              Target host
+              <input type="text" name="mail-value" placeholder="mail.isp.example." required />
+            </label>
+            <label>
+              Priority
+              <input type="number" name="mail-priority" placeholder="10" required />
+            </label>
+          </fieldset>
+          <fieldset>
+            <legend>Root (@)</legend>
+            <label>
+              Record Type
+              <select name="root-type" required>
+                <option value="">Select</option>
+                <option value="NS">NS</option>
+                <option value="SOA">SOA</option>
+                <option value="A">A</option>
+              </select>
+            </label>
+            <label>
+              Target host
+              <input type="text" name="root-value" placeholder="ns1.isp.example." required />
+            </label>
+          </fieldset>
+          <button type="submit" class="execute-button">Push zone live</button>
+        </form>
+        <div class="status-board" id="status-board" aria-live="polite">Awaiting alignment…</div>
+      </section>
+    </main>
+    <footer>Based on IETF RFCs that kept the '96 backbone humming.</footer>
+    <script type="module" src="./root-zone-relay.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/net/root-zone-relay/root-zone-relay.css
+++ b/madia.new/public/secret/net/root-zone-relay/root-zone-relay.css
@@ -1,0 +1,17 @@
+body {
+  background: radial-gradient(circle at top right, rgba(56, 248, 122, 0.1), transparent 55%),
+    radial-gradient(circle at bottom left, rgba(148, 197, 183, 0.15), transparent 60%), var(--net-bg);
+}
+
+.task-list {
+  margin: 0 0 1.25rem;
+  padding: 0 0 0 1rem;
+  color: var(--net-muted);
+  font-size: 0.95rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.execute-button {
+  margin-top: 0.25rem;
+}

--- a/madia.new/public/secret/net/root-zone-relay/root-zone-relay.js
+++ b/madia.new/public/secret/net/root-zone-relay/root-zone-relay.js
@@ -1,0 +1,81 @@
+const form = document.getElementById("zone-form");
+const board = document.getElementById("status-board");
+
+const expected = {
+  "www-type": "A",
+  "www-value": "203.0.113.42",
+  "www-ttl": "3600",
+  "mail-type": "MX",
+  "mail-value": "mail.isp.example.",
+  "mail-priority": "10",
+  "root-type": "NS",
+  "root-value": "ns1.isp.example.",
+};
+
+const normalize = (name, value) => {
+  if (value == null) {
+    return "";
+  }
+  if (name.endsWith("type")) {
+    return value.trim().toUpperCase();
+  }
+  if (name.endsWith("ttl") || name.endsWith("priority")) {
+    return String(Number(value));
+  }
+  return value.trim().toLowerCase();
+};
+
+const updateBoard = (message, state = "idle") => {
+  board.textContent = message;
+  board.dataset.state = state;
+};
+
+const evaluateZone = (formData) => {
+  const mismatches = [];
+  for (const [name, target] of Object.entries(expected)) {
+    const inputValue = normalize(name, formData.get(name));
+    const expectedValue = normalize(name, target);
+    if (inputValue !== expectedValue) {
+      mismatches.push(name);
+    }
+  }
+  return mismatches;
+};
+
+form?.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const formData = new FormData(form);
+  const mismatches = evaluateZone(formData);
+  if (mismatches.length) {
+    updateBoard(
+      `Zone reject: ${mismatches.length} field${mismatches.length === 1 ? "" : "s"} misaligned.`,
+      "error"
+    );
+    return;
+  }
+  updateBoard("Zone propagated. Secondary acknowledges serial bump.", "success");
+  window.parent?.postMessage(
+    {
+      type: "net:level-complete",
+      game: "root-zone-relay",
+      payload: {
+        status: "Zone steady",
+        score: 3600,
+      },
+    },
+    "*"
+  );
+});
+
+form?.addEventListener("input", () => {
+  if (board.dataset.state === "success") {
+    return;
+  }
+  const formData = new FormData(form);
+  const mismatches = evaluateZone(formData);
+  if (!mismatches.length) {
+    updateBoard("All records align. Ready to push.");
+  } else {
+    updateBoard("Awaiting alignment…");
+  }
+});


### PR DESCRIPTION
## Summary
- introduce a Net Operations arcade shell with 1996-era cabinet styling and persistent completion tracking
- add six hacker-themed configuration minigames covering DNS, Apache, kernel builds, PPP sequencing, BGP policy, and Squid caching
- document local guidelines for the Net anthology and seed a build id for cache busting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e455a5b8ac83288eb644088ab2aee9