### PR TITLE
feat: unify arcade wrap-up dialogs

### DIFF
--- a/madia.new/public/secret/1989/bat-signal-scramble/bat-signal-scramble.js
+++ b/madia.new/public/secret/1989/bat-signal-scramble/bat-signal-scramble.js
@@ -2,6 +2,7 @@ import { mountParticleField } from "../particles.js";
 import { initHighScoreBanner, getHighScore } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { autoEnhanceFeedback, createLogChannel, createStatusChannel } from "../feedback.js";
+import { createWrapUpDialog } from "../wrap-up-dialog.js";
 
 const particleField = mountParticleField({
   density: 0.0002,
@@ -53,6 +54,8 @@ const routeSummaryEl = document.getElementById("route-summary");
 const routeMapList = document.getElementById("route-map");
 const replayButton = document.getElementById("replay-button");
 const closeWrapUpButton = document.getElementById("close-wrap-up");
+
+const wrapUpDialog = createWrapUpDialog(wrapUp);
 
 autoEnhanceFeedback();
 
@@ -686,7 +689,7 @@ function finishRun() {
     routeMapList.appendChild(item);
   });
 
-  wrapUp.hidden = false;
+  wrapUpDialog.open({ focus: replayButton });
   setStatus("Scramble complete. Review the route and reset when ready.", "success");
 }
 
@@ -738,22 +741,22 @@ function startRun() {
   animationFrame = window.requestAnimationFrame(step);
 }
 
-function closeWrapUp() {
-  wrapUp.hidden = true;
+function closeWrapUp(options = {}) {
+  wrapUpDialog.close(options);
 }
 
 startButton.addEventListener("click", () => {
-  closeWrapUp();
+  closeWrapUp({ restoreFocus: false });
   startRun();
 });
 
 resetButton.addEventListener("click", () => {
-  closeWrapUp();
+  closeWrapUp({ restoreFocus: false });
   resetRun();
 });
 
 replayButton.addEventListener("click", () => {
-  closeWrapUp();
+  closeWrapUp({ restoreFocus: false });
   startRun();
 });
 

--- a/madia.new/public/secret/1989/common.css
+++ b/madia.new/public/secret/1989/common.css
@@ -21,6 +21,14 @@ body {
   color: #e2e8f0;
 }
 
+body.wrap-up-open {
+  overflow: hidden;
+}
+
+.wrap-up[hidden] {
+  display: none !important;
+}
+
 a {
   color: #38bdf8;
 }

--- a/madia.new/public/secret/1989/family-flux/family-flux.css
+++ b/madia.new/public/secret/1989/family-flux/family-flux.css
@@ -351,11 +351,22 @@
 }
 
 .wrap-up {
-  margin-top: 2.5rem;
-  padding: 1.75rem;
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  background: rgba(2, 6, 23, 0.72);
+  backdrop-filter: blur(8px);
+  z-index: 70;
+}
+
+.wrap-up-card {
+  width: min(520px, 92%);
+  padding: 2.25rem 2.5rem;
   border-radius: 1.75rem;
   border: 1px solid rgba(226, 232, 240, 0.2);
-  background: rgba(15, 23, 42, 0.78);
+  background: rgba(15, 23, 42, 0.88);
   box-shadow: 0 1.35rem 3rem rgba(12, 18, 36, 0.7);
   display: grid;
   gap: 1.75rem;

--- a/madia.new/public/secret/1989/family-flux/family-flux.js
+++ b/madia.new/public/secret/1989/family-flux/family-flux.js
@@ -2,6 +2,7 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 import { autoEnhanceFeedback } from "../feedback.js";
+import { createWrapUpDialog } from "../wrap-up-dialog.js";
 
 const GAME_ID = "family-flux";
 const INITIAL_HARMONY = 520;
@@ -742,6 +743,9 @@ const wrapSummary = document.getElementById("wrap-summary");
 const wrapScore = document.getElementById("wrap-score");
 const decisionTree = document.getElementById("decision-tree");
 const replayButton = document.getElementById("replay-button");
+const wrapUpClose = document.getElementById("wrap-up-close");
+
+const wrapUpDialog = createWrapUpDialog(wrapUpSection);
 
 const scoreConfig = getScoreConfig(GAME_ID);
 const highScore = initHighScoreBanner({
@@ -796,7 +800,13 @@ nextButton?.addEventListener("click", () => {
 
 replayButton?.addEventListener("click", () => {
   ensureAudioContext();
+  wrapUpDialog.close({ restoreFocus: false });
   startRun();
+});
+
+wrapUpClose?.addEventListener("click", () => {
+  wrapUpDialog.close();
+  setStatus("Wrap-up dismissed. Queue your next crisis when ready.", "info");
 });
 
 autoEnhanceFeedback({
@@ -817,7 +827,7 @@ function startRun() {
   state.current = null;
   state.awaitingContinue = false;
   scenarioArticle.hidden = false;
-  wrapUpSection.hidden = true;
+  wrapUpDialog.close({ restoreFocus: false });
   resetButton.disabled = false;
   startButton.disabled = true;
   nextButton.disabled = true;
@@ -842,7 +852,7 @@ function resetRun() {
   nextButton.disabled = true;
   enableChoices(false);
   scenarioArticle.hidden = true;
-  wrapUpSection.hidden = true;
+  wrapUpDialog.close({ restoreFocus: false });
   progressReadout.textContent = "No dilemmas active.";
   setStatus("Session reset. Harmony recentered.", "info");
   updateHarmonyDisplay(0, "neutral", { immediate: true });
@@ -1205,7 +1215,7 @@ function concludeRun() {
   renderWrapUp();
 }
 function renderWrapUp() {
-  wrapUpSection.hidden = false;
+  wrapUpDialog.open({ focus: replayButton });
   const finalScore = Math.max(0, Math.round(state.harmony));
   const bestSwing = state.history.reduce((max, entry) => (Math.abs(entry.delta) > Math.abs(max) ? entry.delta : max), 0);
   wrapSummary.textContent = `You navigated ${state.history.length} dilemmas and finished with Harmony ${finalScore}.`;

--- a/madia.new/public/secret/1989/family-flux/index.html
+++ b/madia.new/public/secret/1989/family-flux/index.html
@@ -106,25 +106,36 @@
           <h3 id="log-title">Beat Log</h3>
           <ul id="event-log"></ul>
         </section>
-        <section class="wrap-up" id="wrap-up" hidden aria-live="polite">
-          <header class="wrap-header">
-            <h3>Session Wrap-Up</h3>
-            <p id="wrap-summary"></p>
-          </header>
-          <div class="wrap-score" id="wrap-score"></div>
-          <div class="wrap-tree">
-            <h4>Decision Tree</h4>
-            <ol class="decision-tree" id="decision-tree"></ol>
-          </div>
-          <div class="wrap-actions">
-            <button type="button" class="action-button" id="replay-button">Run It Again</button>
-          </div>
-        </section>
       </section>
     </main>
     <footer class="page-footer">
       <p>Tip: A daring win can unlock surprise scenes. Just be sure you have the Harmony padding to weather the fallout.</p>
     </footer>
+    <section
+      class="wrap-up"
+      id="wrap-up"
+      hidden
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="wrap-title"
+      aria-live="polite"
+    >
+      <div class="wrap-up-card">
+        <header class="wrap-header">
+          <h3 id="wrap-title">Session Wrap-Up</h3>
+          <p id="wrap-summary"></p>
+        </header>
+        <div class="wrap-score" id="wrap-score"></div>
+        <div class="wrap-tree">
+          <h4>Decision Tree</h4>
+          <ol class="decision-tree" id="decision-tree"></ol>
+        </div>
+        <div class="wrap-actions">
+          <button type="button" class="action-button" id="replay-button">Run It Again</button>
+          <button type="button" class="action-button" id="wrap-up-close">Close</button>
+        </div>
+      </div>
+    </section>
     <script type="module" src="family-flux.js"></script>
   </body>
 </html>

--- a/madia.new/public/secret/1989/frank-drebins-follies/frank-drebins-follies.css
+++ b/madia.new/public/secret/1989/frank-drebins-follies/frank-drebins-follies.css
@@ -482,6 +482,14 @@
   font-size: 0.9rem;
 }
 
+body.wrap-up-open {
+  overflow: hidden;
+}
+
+.wrap-up[hidden] {
+  display: none;
+}
+
 .wrap-up {
   position: fixed;
   inset: 0;

--- a/madia.new/public/secret/1989/hoverboard-pursuit/hoverboard-pursuit.js
+++ b/madia.new/public/secret/1989/hoverboard-pursuit/hoverboard-pursuit.js
@@ -2,6 +2,7 @@ import { mountParticleField } from "../particles.js";
 import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { autoEnhanceFeedback, createLogChannel, createStatusChannel } from "../feedback.js";
+import { createWrapUpDialog } from "../wrap-up-dialog.js";
 
 const particleSystem = mountParticleField({
   density: 0.00018,
@@ -122,6 +123,8 @@ const splitTunnelEl = document.getElementById("split-tunnel");
 const replayButton = document.getElementById("replay-button");
 const ghostButton = document.getElementById("ghost-button");
 const closeWrapUp = document.getElementById("close-wrap-up");
+
+const wrapUpDialog = createWrapUpDialog(wrapUp);
 const wrapUpNote = document.getElementById("wrap-up-note");
 
 const log = createLogChannel(eventLogList, { limit: 18 });
@@ -499,7 +502,7 @@ function resetRunState() {
 
 function startRun({ ghost = false } = {}) {
   resetRunState();
-  wrapUp.setAttribute("hidden", "true");
+  wrapUpDialog.close({ restoreFocus: false });
   useGhost = ghost && Boolean(storedGhost);
   runActive = true;
   totalTime = 0;
@@ -551,7 +554,7 @@ function finishRun() {
   };
   highScore.submit(scoreValue, meta);
 
-  wrapUp.removeAttribute("hidden");
+  wrapUpDialog.open({ focus: replayButton });
 
   const priorBest = storedGhost?.runTime;
   if (ghostRecording.length > 0 && (!Number.isFinite(priorBest) || finalTime < priorBest)) {
@@ -699,7 +702,7 @@ startButton.addEventListener("click", () => {
 resetButton.addEventListener("click", () => {
   resetRunState();
   spawnObstacles();
-  wrapUp.setAttribute("hidden", "true");
+  wrapUpDialog.close({ restoreFocus: false });
 });
 
 boostButton.addEventListener("mousedown", () => {
@@ -728,7 +731,7 @@ laneButtons.forEach((button) => {
 });
 
 replayButton.addEventListener("click", () => {
-  wrapUp.setAttribute("hidden", "true");
+  wrapUpDialog.close({ restoreFocus: false });
   startRun({ ghost: false });
 });
 
@@ -736,12 +739,12 @@ ghostButton.addEventListener("click", () => {
   if (!storedGhost) {
     return;
   }
-  wrapUp.setAttribute("hidden", "true");
+  wrapUpDialog.close({ restoreFocus: false });
   startRun({ ghost: true });
 });
 
 closeWrapUp.addEventListener("click", () => {
-  wrapUp.setAttribute("hidden", "true");
+  wrapUpDialog.close();
 });
 
 function handleKey(event) {

--- a/madia.new/public/secret/1989/lawnmower-labyrinth/index.html
+++ b/madia.new/public/secret/1989/lawnmower-labyrinth/index.html
@@ -129,17 +129,29 @@
           </div>
           <ol class="log-entries" id="event-log"></ol>
         </section>
-        <section class="wrap-up" id="wrap-up" hidden>
-          <h3>Run Summary</h3>
-          <p id="wrap-up-text"></p>
-          <p class="wrap-up-note">Replay to chase a faster time and log a better survival score.</p>
-          <button type="button" class="action-button" id="replay-button">Run Again</button>
-        </section>
       </section>
     </main>
     <footer class="page-footer">
       <p>Stay low, count the passes, and sprint only when the mower line clears. The leaderboard waits for your clean escape.</p>
     </footer>
+    <section
+      class="wrap-up"
+      id="wrap-up"
+      hidden
+      aria-labelledby="wrap-up-title"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div class="wrap-up-card">
+        <h2 id="wrap-up-title">Run Summary</h2>
+        <p class="wrap-up-text" id="wrap-up-text"></p>
+        <p class="wrap-up-note">Replay to chase a faster time and log a better survival score.</p>
+        <div class="wrap-up-actions">
+          <button type="button" class="action-button" id="replay-button">Run Again</button>
+          <button type="button" class="action-button" id="wrap-up-close">Close</button>
+        </div>
+      </div>
+    </section>
     <script type="module" src="lawnmower-labyrinth.js"></script>
   </body>
 </html>

--- a/madia.new/public/secret/1989/lawnmower-labyrinth/lawnmower-labyrinth.css
+++ b/madia.new/public/secret/1989/lawnmower-labyrinth/lawnmower-labyrinth.css
@@ -592,24 +592,51 @@
 }
 
 .wrap-up {
-  background: rgba(15, 23, 42, 0.7);
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  border-radius: 1rem;
-  padding: 1rem;
+  position: fixed;
+  inset: 0;
   display: grid;
-  gap: 0.75rem;
+  place-items: center;
+  padding: 1.5rem;
+  background: rgba(2, 6, 23, 0.72);
+  backdrop-filter: blur(8px);
+  z-index: 60;
 }
 
-.wrap-up h3 {
+.wrap-up-card {
+  width: min(420px, 90%);
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 1.2rem;
+  padding: 2rem 2.25rem;
+  display: grid;
+  gap: 1rem;
+  text-align: center;
+  box-shadow: 0 2.8rem 4.2rem rgba(2, 6, 23, 0.6);
+}
+
+.wrap-up-card h2 {
   margin: 0;
   text-transform: uppercase;
-  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  font-size: 1rem;
   color: rgba(148, 163, 184, 0.9);
 }
 
-.wrap-up p {
+.wrap-up-card p {
   margin: 0;
   color: rgba(226, 232, 240, 0.85);
+}
+
+.wrap-up-text {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.wrap-up-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
 }
 
 @keyframes cellStepPulse {

--- a/madia.new/public/secret/1989/lawnmower-labyrinth/lawnmower-labyrinth.js
+++ b/madia.new/public/secret/1989/lawnmower-labyrinth/lawnmower-labyrinth.js
@@ -2,6 +2,7 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 import { autoEnhanceFeedback } from "../feedback.js";
+import { createWrapUpDialog } from "../wrap-up-dialog.js";
 
 const particleField = mountParticleField({
   effects: {
@@ -82,6 +83,9 @@ const eventLog = document.getElementById("event-log");
 const wrapUp = document.getElementById("wrap-up");
 const wrapUpText = document.getElementById("wrap-up-text");
 const replayButton = document.getElementById("replay-button");
+const wrapUpClose = document.getElementById("wrap-up-close");
+
+const wrapUpDialog = createWrapUpDialog(wrapUp);
 
 boardEl.style.gridTemplateColumns = `repeat(${GRID_COLS}, 46px)`;
 
@@ -180,9 +184,17 @@ resetButton.addEventListener("click", () => {
 });
 
 replayButton.addEventListener("click", () => {
+  wrapUpDialog.close({ restoreFocus: false });
   resetRun();
   beginRun();
 });
+
+if (wrapUpClose) {
+  wrapUpClose.addEventListener("click", () => {
+    wrapUpDialog.close();
+    setSessionStatus("Wrap-up dismissed. Plot your next route when ready.", "info");
+  });
+}
 
 dashButton.addEventListener("click", () => {
   performDash();
@@ -256,7 +268,7 @@ function beginRun() {
   controlButtons.forEach((button) => {
     button.disabled = false;
   });
-  wrapUp.hidden = true;
+  wrapUpDialog.close({ restoreFocus: false });
   placeMower();
 }
 
@@ -300,7 +312,7 @@ function resetRun({ preserveLog = false } = {}) {
   controlButtons.forEach((button) => {
     button.disabled = true;
   });
-  wrapUp.hidden = true;
+  wrapUpDialog.close({ restoreFocus: false });
   placePlayer();
   placeMower();
   resetSprinklerCells(false);
@@ -586,7 +598,7 @@ function completeRun() {
     display: `${formatSeconds(finalTime)}s · crumbs ${state.collectedCrumbs.size}`,
   };
   highScore.submit(scoreValue, meta);
-  wrapUp.hidden = false;
+  wrapUpDialog.open({ focus: replayButton });
   wrapUpText.textContent = `Safe Zone reached in ${formatSeconds(finalTime)}s with ${state.collectedCrumbs.size} crumb${
     state.collectedCrumbs.size === 1 ? "" : "s"
   } banked.`;
@@ -617,7 +629,7 @@ function failRun(message) {
   controlButtons.forEach((button) => {
     button.disabled = true;
   });
-  wrapUp.hidden = false;
+  wrapUpDialog.open({ focus: replayButton });
   wrapUpText.textContent = `${message} Try again for a faster time.`;
   setSessionStatus(message, "danger");
   addLog(message, "danger");

--- a/madia.new/public/secret/1989/power-glove-prodigy/power-glove-prodigy.js
+++ b/madia.new/public/secret/1989/power-glove-prodigy/power-glove-prodigy.js
@@ -2,6 +2,7 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 import { autoEnhanceFeedback, createLogChannel, createStatusChannel } from "../feedback.js";
+import { createWrapUpDialog } from "../wrap-up-dialog.js";
 
 const particleField = mountParticleField({
   effects: {
@@ -44,6 +45,8 @@ const wrapUpMultiplier = document.getElementById("summary-multiplier");
 const wrapUpHype = document.getElementById("summary-hype");
 const wrapUpReplay = document.getElementById("wrap-up-replay");
 const wrapUpClose = document.getElementById("wrap-up-close");
+
+const wrapUpDialog = createWrapUpDialog(wrapUp);
 
 autoEnhanceFeedback(document.body);
 const statusChannel = createStatusChannel(statusLine);
@@ -633,13 +636,12 @@ function showSummary() {
   wrapUpStreak.textContent = state.bestStreak.toString();
   wrapUpMultiplier.textContent = `×${state.multiplierPeak.toFixed(1)}`;
   wrapUpHype.textContent = `${Math.round(state.hypePeak)}%`;
-  wrapUp.hidden = false;
+  wrapUpDialog.open({ focus: wrapUpReplay });
   state.summaryOpen = true;
-  wrapUp.focus({ preventScroll: true });
 }
 
-function hideSummary() {
-  wrapUp.hidden = true;
+function hideSummary({ restoreFocus = true } = {}) {
+  wrapUpDialog.close({ restoreFocus });
   state.summaryOpen = false;
 }
 
@@ -726,19 +728,13 @@ resetButton.addEventListener("click", () => {
 });
 
 wrapUpReplay.addEventListener("click", () => {
-  hideSummary();
+  hideSummary({ restoreFocus: false });
   startTournament();
 });
 
 wrapUpClose.addEventListener("click", () => {
   hideSummary();
   statusChannel("Results saved. Fire up another run when ready.", "info");
-});
-
-wrapUp.addEventListener("keydown", (event) => {
-  if (event.key === "Escape") {
-    hideSummary();
-  }
 });
 
 if (inspirationButton && inspirationText) {

--- a/madia.new/public/secret/1989/sugar-ray-hustle/index.html
+++ b/madia.new/public/secret/1989/sugar-ray-hustle/index.html
@@ -153,20 +153,6 @@
           <ul class="event-log" id="event-log"></ul>
         </section>
       </section>
-      <section class="wrap-up" id="wrap-up" hidden aria-live="polite">
-        <div class="wrap-up-card">
-          <p class="wrap-up-eyebrow">Nightfall Recap</p>
-          <h2 class="wrap-up-title" id="wrap-up-title">House Rules the Night</h2>
-          <p class="wrap-up-total">Final Take: <strong id="wrap-up-money">$0</strong></p>
-          <p class="wrap-up-streak">Longest Perfect Streak: <strong id="wrap-up-streak">0</strong></p>
-          <p class="wrap-up-foes">
-            Opponents Dusted: <strong id="wrap-up-opponents">0</strong> /
-            <span id="wrap-up-total-opponents">4</span>
-          </p>
-          <p class="wrap-up-note" id="wrap-up-note">Keep grinding for that marquee slot.</p>
-          <button type="button" class="action-button wrap-up-button" id="wrap-up-replay">Run It Back</button>
-        </div>
-      </section>
     </main>
     <footer class="page-footer">
       <p>
@@ -174,6 +160,31 @@
         impossible perfect into an effortless slam.
       </p>
     </footer>
+    <section
+      class="wrap-up"
+      id="wrap-up"
+      hidden
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="wrap-up-title"
+      aria-live="polite"
+    >
+      <div class="wrap-up-card">
+        <p class="wrap-up-eyebrow">Nightfall Recap</p>
+        <h2 class="wrap-up-title" id="wrap-up-title">House Rules the Night</h2>
+        <p class="wrap-up-total">Final Take: <strong id="wrap-up-money">$0</strong></p>
+        <p class="wrap-up-streak">Longest Perfect Streak: <strong id="wrap-up-streak">0</strong></p>
+        <p class="wrap-up-foes">
+          Opponents Dusted: <strong id="wrap-up-opponents">0</strong> /
+          <span id="wrap-up-total-opponents">4</span>
+        </p>
+        <p class="wrap-up-note" id="wrap-up-note">Keep grinding for that marquee slot.</p>
+        <div class="wrap-up-actions">
+          <button type="button" class="action-button" id="wrap-up-replay">Run It Back</button>
+          <button type="button" class="action-button" id="wrap-up-close">Close</button>
+        </div>
+      </div>
+    </section>
     <script type="module" src="sugar-ray-hustle.js"></script>
   </body>
 </html>

--- a/madia.new/public/secret/1989/sugar-ray-hustle/sugar-ray-hustle.css
+++ b/madia.new/public/secret/1989/sugar-ray-hustle/sugar-ray-hustle.css
@@ -596,24 +596,33 @@ body.sugar-ray-theme {
 }
 
 .wrap-up {
-  position: sticky;
-  top: 1.5rem;
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  background: rgba(2, 6, 23, 0.7);
+  backdrop-filter: blur(8px);
+  z-index: 60;
 }
 
 .wrap-up-card {
   background: linear-gradient(155deg, rgba(15, 23, 42, 0.9), rgba(2, 6, 17, 0.94));
   border-radius: 1.5rem;
-  padding: 2rem;
+  padding: 2.25rem 2.5rem;
   border: 1px solid rgba(250, 204, 21, 0.3);
   box-shadow: 0 32px 80px rgba(2, 6, 23, 0.65);
   text-align: center;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
+  width: min(420px, 92%);
 }
 
-.wrap-up[hidden] {
-  display: none;
+.wrap-up-actions {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
 }
 
 .wrap-up-eyebrow {

--- a/madia.new/public/secret/1989/sugar-ray-hustle/sugar-ray-hustle.js
+++ b/madia.new/public/secret/1989/sugar-ray-hustle/sugar-ray-hustle.js
@@ -2,6 +2,7 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 import { createStatusChannel, createLogChannel } from "../feedback.js";
+import { createWrapUpDialog } from "../wrap-up-dialog.js";
 
 const particleField = mountParticleField({
   effects: {
@@ -55,6 +56,9 @@ const wrapUpOpponents = document.getElementById("wrap-up-opponents");
 const wrapUpTotalOpponents = document.getElementById("wrap-up-total-opponents");
 const wrapUpNote = document.getElementById("wrap-up-note");
 const wrapUpReplay = document.getElementById("wrap-up-replay");
+const wrapUpClose = document.getElementById("wrap-up-close");
+
+const wrapUpDialog = createWrapUpDialog(wrapUp);
 
 const setStatus = createStatusChannel(statusBar);
 const logChannel = createLogChannel(eventLog, { limit: 12 });
@@ -245,8 +249,16 @@ function initialize() {
   });
 
   wrapUpReplay.addEventListener("click", () => {
+    wrapUpDialog.close({ restoreFocus: false });
     resetSession();
   });
+
+  if (wrapUpClose) {
+    wrapUpClose.addEventListener("click", () => {
+      wrapUpDialog.close();
+      setStatus("Recap closed. Stack your chips and relight the marquee when ready.", "info");
+    });
+  }
 }
 
 function primeRound() {
@@ -559,7 +571,7 @@ function endSession(victory) {
   wrapUpNote.textContent = victory
     ? "Hit the marquee and log the score upstairs."
     : "Keep grinding for that marquee slot.";
-  wrapUp.hidden = false;
+  wrapUpDialog.open({ focus: wrapUpReplay });
   const meta = {
     longestStreak: state.bestPerfectStreak,
     opponents: state.opponentsCleared,
@@ -572,6 +584,7 @@ function endSession(victory) {
 }
 
 function resetSession() {
+  wrapUpDialog.close({ restoreFocus: false });
   state.opponentIndex = 0;
   state.currentOpponent = opponents[0];
   state.playerMoney = 1200;
@@ -589,7 +602,7 @@ function resetSession() {
   state.sessionActive = true;
   state.opponentsCleared = 0;
   state.lastClaim = "";
-  wrapUp.hidden = true;
+  wrapUpDialog.close({ restoreFocus: false });
   wrapUpTotalOpponents.textContent = opponents.length.toString();
   wrapUpOpponents.textContent = "0";
   wrapUpStreak.textContent = "0";

--- a/madia.new/public/secret/1989/the-final-barrier/the-final-barrier.js
+++ b/madia.new/public/secret/1989/the-final-barrier/the-final-barrier.js
@@ -2,6 +2,7 @@ import { mountParticleField } from "../particles.js";
 import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { autoEnhanceFeedback, createLogChannel, createStatusChannel } from "../feedback.js";
+import { createWrapUpDialog } from "../wrap-up-dialog.js";
 
 const particleField = mountParticleField({
   container: document.getElementById("particle-anchor"),
@@ -40,6 +41,8 @@ const torpedoButton = document.getElementById("torpedo-button");
 const resetButton = document.getElementById("reset-button");
 const replayButton = document.getElementById("replay-button");
 const closeWrapButton = document.getElementById("close-wrap-button");
+
+const wrapUpDialog = createWrapUpDialog(wrapUp);
 const wrapUp = document.getElementById("wrap-up");
 const wrapSummary = document.getElementById("wrap-summary");
 const wrapScore = document.getElementById("wrap-score");
@@ -275,7 +278,7 @@ function resetState() {
   setPhaseIndicator("Awaiting launch clearance.");
   setStatus("Power routed to standby systems.");
   logChannel.push("Simulation reset. Shields nominal.", "info");
-  wrapUp.hidden = true;
+  wrapUpDialog.close({ restoreFocus: false });
   cinematic.hidden = true;
   cockpit.classList.remove("is-phase-2", "is-phase-3");
   updatePowerModeButtons(POWER_MODES.balanced);
@@ -599,7 +602,7 @@ function completeMission(victory) {
   wrapSummary.textContent = victory
     ? "Sentinel shattered. Course clear beyond the Barrier."
     : "Enterprise crippled. The Barrier repels all intruders.";
-  wrapUp.hidden = false;
+  wrapUpDialog.open({ focus: replayButton });
   const meta = {
     accuracy: Math.round(accuracy * 100),
     shields: shieldPercent,
@@ -908,12 +911,12 @@ resetButton.addEventListener("click", () => {
 });
 
 replayButton.addEventListener("click", () => {
-  wrapUp.hidden = true;
+  wrapUpDialog.close({ restoreFocus: false });
   startCinematic();
 });
 
 closeWrapButton.addEventListener("click", () => {
-  wrapUp.hidden = true;
+  wrapUpDialog.close();
 });
 
 modeButtons.forEach((button) => {

--- a/madia.new/public/secret/1989/truvys-salon-style/truvys-salon-style.js
+++ b/madia.new/public/secret/1989/truvys-salon-style/truvys-salon-style.js
@@ -259,7 +259,7 @@ gossipDecline.addEventListener("click", () => {
 });
 
 wrapReplay.addEventListener("click", () => {
-  hideWrapUp();
+  hideWrapUp({ restoreFocus: false });
   startShift();
 });
 
@@ -269,7 +269,7 @@ wrapClose.addEventListener("click", () => {
 });
 
 window.addEventListener("keydown", (event) => {
-  if (wrapUp.hidden === false) {
+  if (wrapUpDialog.isOpen()) {
     return;
   }
   if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
@@ -802,12 +802,11 @@ function showWrapUp() {
   } else {
     wrapNote.textContent = "A little hairspray and you can bounce back next shift.";
   }
-  wrapUp.hidden = false;
-  wrapUp.focus();
+  wrapUpDialog.open({ focus: wrapReplay });
 }
 
-function hideWrapUp() {
-  wrapUp.hidden = true;
+function hideWrapUp({ restoreFocus = true } = {}) {
+  wrapUpDialog.close({ restoreFocus });
 }
 
 function offerGossip() {

--- a/madia.new/public/secret/1989/wild-thing-wind-up/wild-thing-wind-up.js
+++ b/madia.new/public/secret/1989/wild-thing-wind-up/wild-thing-wind-up.js
@@ -2,6 +2,7 @@ import { initHighScoreBanner } from "../arcade-scores.js";
 import { getScoreConfig } from "../score-config.js";
 import { mountParticleField } from "../particles.js";
 import { autoEnhanceFeedback, createLogChannel, createStatusChannel } from "../feedback.js";
+import { createWrapUpDialog } from "../wrap-up-dialog.js";
 
 const GAME_ID = "wild-thing-wind-up";
 const RUN_LIMIT = 5;
@@ -79,6 +80,8 @@ const wrapUpWild = document.getElementById("wrap-up-wild");
 const wrapUpNote = document.getElementById("wrap-up-note");
 const wrapUpReplay = document.getElementById("wrap-up-replay");
 const wrapUpClose = document.getElementById("wrap-up-close");
+
+const wrapUpDialog = createWrapUpDialog(wrapUpRoot);
 
 const TARGET_ZONES = [
   { label: "High Inside", x: 0.32, y: 0.24 },
@@ -160,7 +163,7 @@ function setup() {
   });
 
   wrapUpReplay.addEventListener("click", () => {
-    hideWrapUp();
+    hideWrapUp({ restoreFocus: false });
     startGame();
   });
 
@@ -674,17 +677,14 @@ function concludeGame() {
   } else {
     wrapUpNote.textContent = "Punch out the order again to push your high score even higher.";
   }
-  wrapUpRoot.hidden = false;
-  window.setTimeout(() => {
-    wrapUpReplay.focus();
-  }, 90);
+  wrapUpDialog.open({ focus: wrapUpReplay });
   statusChannel("Skipper signals for the pen. Game over—check the box score.", "warning");
   particleField.emitBurst(1.25, { y: 0.32 });
   playPitchSound("game-over");
 }
 
-function hideWrapUp() {
-  wrapUpRoot.hidden = true;
+function hideWrapUp(options = {}) {
+  wrapUpDialog.close(options);
 }
 
 function callTime() {

--- a/madia.new/public/secret/1989/wrap-up-dialog.js
+++ b/madia.new/public/secret/1989/wrap-up-dialog.js
@@ -1,0 +1,238 @@
+const FOCUSABLE_SELECTORS = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+];
+
+function getFocusableElements(container) {
+  if (!(container instanceof HTMLElement)) {
+    return [];
+  }
+  const nodes = Array.from(container.querySelectorAll(FOCUSABLE_SELECTORS.join(",")));
+  return nodes.filter((element) => {
+    if (!(element instanceof HTMLElement)) {
+      return false;
+    }
+    if (element.getAttribute("aria-hidden") === "true") {
+      return false;
+    }
+    return element.offsetParent !== null || element === document.activeElement;
+  });
+}
+
+function resolveElements(targets = []) {
+  return targets
+    .flatMap((target) => {
+      if (!target) {
+        return [];
+      }
+      if (target instanceof HTMLElement) {
+        return [target];
+      }
+      if (typeof target === "string") {
+        return Array.from(document.querySelectorAll(target));
+      }
+      return [];
+    })
+    .filter((element) => element instanceof HTMLElement);
+}
+
+export function createWrapUpDialog(dialog, options = {}) {
+  if (!(dialog instanceof HTMLElement)) {
+    return {
+      element: null,
+      initialize() {},
+      open() {},
+      close() {},
+      isOpen() {
+        return false;
+      },
+    };
+  }
+
+  const {
+    inertTargets = null,
+    openClass = "wrap-up-open",
+    closeOnBackdrop = true,
+    role = dialog.getAttribute("role") || "dialog",
+    ariaModal = dialog.getAttribute("aria-modal") || "true",
+  } = options;
+
+  const attributeSnapshot = new Map();
+  let inertElements = [];
+  let lastFocused = null;
+
+  function resolveInertElements() {
+    if (Array.isArray(inertTargets) && inertTargets.length > 0) {
+      return resolveElements(inertTargets).filter((element) => !dialog.contains(element));
+    }
+    return Array.from(document.body.children).filter((element) => {
+      return element instanceof HTMLElement && element !== dialog && !element.contains(dialog);
+    });
+  }
+
+  function applyInertState(active) {
+    if (active) {
+      inertElements = resolveInertElements();
+      inertElements.forEach((element) => {
+        if (!attributeSnapshot.has(element)) {
+          attributeSnapshot.set(element, {
+            ariaHidden: element.getAttribute("aria-hidden"),
+            inert: "inert" in element ? element.inert : undefined,
+          });
+        }
+        element.setAttribute("aria-hidden", "true");
+        if ("inert" in element) {
+          element.inert = true;
+        }
+      });
+    } else {
+      inertElements.forEach((element) => {
+        const snapshot = attributeSnapshot.get(element);
+        if (snapshot) {
+          if (snapshot.ariaHidden === null) {
+            element.removeAttribute("aria-hidden");
+          } else {
+            element.setAttribute("aria-hidden", snapshot.ariaHidden);
+          }
+          if ("inert" in element) {
+            if (typeof snapshot.inert === "boolean") {
+              element.inert = snapshot.inert;
+            } else {
+              element.inert = false;
+            }
+          }
+          attributeSnapshot.delete(element);
+        } else {
+          element.removeAttribute("aria-hidden");
+          if ("inert" in element) {
+            element.inert = false;
+          }
+        }
+      });
+      inertElements = [];
+    }
+  }
+
+  function trapFocus(event) {
+    if (event.key !== "Tab") {
+      return;
+    }
+    const focusable = getFocusableElements(dialog);
+    if (focusable.length === 0) {
+      event.preventDefault();
+      dialog.focus({ preventScroll: true });
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+    if (event.shiftKey) {
+      if (active === first || !dialog.contains(active)) {
+        event.preventDefault();
+        last.focus({ preventScroll: true });
+      }
+    } else if (active === last) {
+      event.preventDefault();
+      first.focus({ preventScroll: true });
+    }
+  }
+
+  function handleKeydown(event) {
+    if (dialog.hidden) {
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      controller.close();
+      return;
+    }
+    trapFocus(event);
+  }
+
+  function ensureAccessibilityAttributes() {
+    if (!dialog.hasAttribute("tabindex")) {
+      dialog.setAttribute("tabindex", "-1");
+    }
+    if (role) {
+      dialog.setAttribute("role", role);
+    }
+    if (ariaModal != null) {
+      dialog.setAttribute("aria-modal", String(ariaModal));
+    }
+  }
+
+  function initialize() {
+    ensureAccessibilityAttributes();
+    if (dialog.hidden) {
+      dialog.setAttribute("aria-hidden", "true");
+      document.body.classList.remove(openClass);
+      applyInertState(false);
+    } else {
+      dialog.setAttribute("aria-hidden", "false");
+      document.body.classList.add(openClass);
+      applyInertState(true);
+    }
+  }
+
+  function open({ focus } = {}) {
+    const activeElement = document.activeElement;
+    if (activeElement instanceof HTMLElement && !dialog.contains(activeElement)) {
+      lastFocused = activeElement;
+    }
+    dialog.hidden = false;
+    dialog.setAttribute("aria-hidden", "false");
+    document.body.classList.add(openClass);
+    applyInertState(true);
+    const focusTargets = getFocusableElements(dialog);
+    const preferredTarget = focus instanceof HTMLElement ? focus : focusTargets[0] ?? dialog;
+    window.requestAnimationFrame(() => {
+      preferredTarget.focus({ preventScroll: true });
+    });
+  }
+
+  function close({ restoreFocus = true } = {}) {
+    const wasOpen = !dialog.hidden;
+    dialog.hidden = true;
+    dialog.setAttribute("aria-hidden", "true");
+    document.body.classList.remove(openClass);
+    applyInertState(false);
+    if (restoreFocus && wasOpen && lastFocused instanceof HTMLElement) {
+      window.requestAnimationFrame(() => {
+        lastFocused?.focus({ preventScroll: true });
+      });
+    }
+    lastFocused = null;
+  }
+
+  function isOpen() {
+    return !dialog.hidden;
+  }
+
+  const controller = { element: dialog, initialize, open, close, isOpen };
+
+  dialog.addEventListener("keydown", handleKeydown);
+  if (closeOnBackdrop) {
+    dialog.addEventListener("click", (event) => {
+      if (event.target === dialog) {
+        controller.close();
+      }
+    });
+  }
+
+  controller.initialize();
+
+  return controller;
+}
+
+export function hideWrapUpDialogs() {
+  document.querySelectorAll(".wrap-up").forEach((dialog) => {
+    if (dialog instanceof HTMLElement) {
+      dialog.hidden = true;
+      dialog.setAttribute("aria-hidden", "true");
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add a shared wrap-up dialog helper to handle focus trapping, aria state, and backdrop dismissal across the 1989 arcade games
- refit each cabinet with wrap-up overlays that use the helper, add missing close controls, and update styling so the modals load hidden and trap focus when opened
- move in-page wrap-up sections out of gameplay layouts and refresh CSS to ensure consistent full-screen overlays

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e1efe10b4c8328bf8fabcb852d6460