### PR TITLE
Add new Net minigames covering routing, parsing, gopher, and FTP workflows

### DIFF
--- a/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.css
+++ b/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.css
@@ -1,0 +1,38 @@
+main {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.spec-list {
+  margin: 0;
+  padding-left: 1.5rem;
+  color: var(--text-muted);
+}
+
+.command-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+label {
+  display: grid;
+  gap: 0.4rem;
+  font-weight: 500;
+}
+
+select {
+  background: rgba(0, 14, 26, 0.95);
+  border: 1px solid rgba(110, 255, 210, 0.4);
+  color: var(--text-primary);
+  padding: 0.4rem 0.6rem;
+}
+
+.status-board[data-state="success"] {
+  color: var(--status-success);
+  border-color: var(--status-success);
+}
+
+.status-board[data-state="error"] {
+  color: var(--status-error);
+  border-color: var(--status-error);
+}

--- a/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.js
+++ b/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.js
@@ -1,0 +1,64 @@
+const form = document.getElementById("ftp-form");
+const board = document.getElementById("status-board");
+
+const expectedOrder = {
+  open: "1",
+  user: "2",
+  passive: "3",
+  cd: "4",
+  put: "5",
+  quit: "6",
+};
+
+const updateBoard = (message, state = "idle") => {
+  board.textContent = message;
+  board.dataset.state = state;
+};
+
+const hasDuplicates = (values) => {
+  const used = new Set();
+  for (const value of Object.values(values)) {
+    if (!value) {
+      continue;
+    }
+    if (used.has(value)) {
+      return true;
+    }
+    used.add(value);
+  }
+  return false;
+};
+
+form?.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const data = new FormData(form);
+  const values = Object.fromEntries(Object.keys(expectedOrder).map((key) => [key, data.get(key) || ""]));
+  if (hasDuplicates(values)) {
+    updateBoard("Sequence conflict detected. Remove duplicate slots.", "error");
+    return;
+  }
+  const mismatches = Object.entries(expectedOrder).filter(([key, value]) => values[key] !== value);
+  if (mismatches.length) {
+    updateBoard("Transfer aborted. Adjust command ordering.", "error");
+    return;
+  }
+  updateBoard("Payload delivered. QA has their bits.", "success");
+  window.parent?.postMessage(
+    {
+      type: "net:level-complete",
+      game: "ftp-flightdeck",
+      payload: {
+        status: "Build docked",
+        score: 36000,
+      },
+    },
+    "*"
+  );
+});
+
+form?.addEventListener("input", () => {
+  if (board.dataset.state === "success") {
+    return;
+  }
+  updateBoard("Transfer queue idle.");
+});

--- a/madia.new/public/secret/net/ftp-flightdeck/index.html
+++ b/madia.new/public/secret/net/ftp-flightdeck/index.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>FTP Flightdeck</title>
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="./ftp-flightdeck.css" />
+  </head>
+  <body>
+    <header>
+      <p>Layer 01 · Transfer Bay</p>
+      <h1>FTP Flightdeck</h1>
+      <p>
+        Your overnight build has to land on the staging server before QA clocks in. Queue the FTP commands in the right
+        order so the upload script doesn't bail.
+      </p>
+    </header>
+    <main>
+      <section class="control-panel" aria-labelledby="manifest-heading">
+        <h2 id="manifest-heading">Mission manifest</h2>
+        <ul class="spec-list">
+          <li>Connect to <code>staging.wired.lan</code> via user <code>deploy</code>.</li>
+          <li>Switch to passive mode before transferring.</li>
+          <li>Upload <code>build.tar.gz</code> into <code>/var/www/releases</code>.</li>
+        </ul>
+      </section>
+      <section class="control-panel" aria-labelledby="command-heading">
+        <h2 id="command-heading">Command queue</h2>
+        <p>Assign an execution order to each command. No duplicates.</p>
+        <form id="ftp-form" class="form-grid">
+          <fieldset>
+            <legend>Sequencing</legend>
+            <div class="command-grid">
+              <label>
+                <code>open staging.wired.lan</code>
+                <select name="open">
+                  <option value="">--</option>
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                  <option value="4">4</option>
+                  <option value="5">5</option>
+                  <option value="6">6</option>
+                </select>
+              </label>
+              <label>
+                <code>user deploy</code>
+                <select name="user">
+                  <option value="">--</option>
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                  <option value="4">4</option>
+                  <option value="5">5</option>
+                  <option value="6">6</option>
+                </select>
+              </label>
+              <label>
+                <code>passive</code>
+                <select name="passive">
+                  <option value="">--</option>
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                  <option value="4">4</option>
+                  <option value="5">5</option>
+                  <option value="6">6</option>
+                </select>
+              </label>
+              <label>
+                <code>cd /var/www/releases</code>
+                <select name="cd">
+                  <option value="">--</option>
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                  <option value="4">4</option>
+                  <option value="5">5</option>
+                  <option value="6">6</option>
+                </select>
+              </label>
+              <label>
+                <code>put build.tar.gz</code>
+                <select name="put">
+                  <option value="">--</option>
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                  <option value="4">4</option>
+                  <option value="5">5</option>
+                  <option value="6">6</option>
+                </select>
+              </label>
+              <label>
+                <code>quit</code>
+                <select name="quit">
+                  <option value="">--</option>
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                  <option value="3">3</option>
+                  <option value="4">4</option>
+                  <option value="5">5</option>
+                  <option value="6">6</option>
+                </select>
+              </label>
+            </div>
+          </fieldset>
+          <button type="submit" class="execute-button">Initiate transfer</button>
+        </form>
+        <div id="status-board" class="status-board" aria-live="polite">Transfer queue idle.</div>
+      </section>
+    </main>
+    <footer>Keep the channel clear and the payload intact.</footer>
+    <script type="module" src="./ftp-flightdeck.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.css
+++ b/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.css
@@ -1,0 +1,45 @@
+main {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.spec-list {
+  margin: 0;
+  padding-left: 1.5rem;
+  color: var(--text-muted);
+}
+
+.gopher-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.row {
+  border: 1px solid rgba(120, 255, 205, 0.35);
+  padding: 1rem;
+  background: rgba(3, 18, 24, 0.8);
+  display: grid;
+  gap: 0.75rem;
+}
+
+label {
+  display: grid;
+  gap: 0.35rem;
+}
+
+input[type="text"] {
+  background: rgba(0, 18, 24, 0.9);
+  border: 1px solid rgba(120, 255, 205, 0.4);
+  color: var(--text-primary);
+  padding: 0.4rem 0.6rem;
+}
+
+.status-board[data-state="success"] {
+  color: var(--status-success);
+  border-color: var(--status-success);
+}
+
+.status-board[data-state="error"] {
+  color: var(--status-error);
+  border-color: var(--status-error);
+}

--- a/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.js
+++ b/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.js
@@ -1,0 +1,51 @@
+const form = document.getElementById("gopher-form");
+const board = document.getElementById("status-board");
+
+const expected = {
+  "banner-text": "Library Net Welcome",
+  "banner-selector": "/motd.txt",
+  "banner-host": "gopher.library.lan",
+  "banner-type": "i",
+  "catalog-text": "Catalog Search Terminal",
+  "catalog-selector": "/query",
+  "catalog-host": "catalog.library.lan",
+  "catalog-type": "7",
+  "zine-text": "Weekly Sparks",
+  "zine-selector": "/zines/weeklysparks.txt",
+  "zine-host": "198.51.100.77",
+  "zine-type": "0",
+};
+
+const updateBoard = (message, state = "idle") => {
+  board.textContent = message;
+  board.dataset.state = state;
+};
+
+form?.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const data = new FormData(form);
+  const errors = Object.entries(expected).filter(([name, value]) => (data.get(name) || "").trim() !== value);
+  if (errors.length) {
+    updateBoard("Menu mismatch. Check selector, type, and host fields.", "error");
+    return;
+  }
+  updateBoard("Gophermap saved. Terminals update in sync.", "success");
+  window.parent?.postMessage(
+    {
+      type: "net:level-complete",
+      game: "gopher-groundskeeper",
+      payload: {
+        status: "Burrows indexed",
+        score: 38000,
+      },
+    },
+    "*"
+  );
+});
+
+form?.addEventListener("input", () => {
+  if (board.dataset.state === "success") {
+    return;
+  }
+  updateBoard("Awaiting menu entries.");
+});

--- a/madia.new/public/secret/net/gopher-groundskeeper/index.html
+++ b/madia.new/public/secret/net/gopher-groundskeeper/index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Gopher Groundskeeper</title>
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="./gopher-groundskeeper.css" />
+  </head>
+  <body>
+    <header>
+      <p>Layer 02 · Campus Content</p>
+      <h1>Gopher Groundskeeper</h1>
+      <p>
+        Library staff wants a menu that matches their printed index. Fill in the gophermap entries so selectors, types,
+        and hosts match the spec sheet.
+      </p>
+    </header>
+    <main>
+      <section class="control-panel" aria-labelledby="spec-heading">
+        <h2 id="spec-heading">Spec sheet</h2>
+        <ul class="spec-list">
+          <li>
+            Welcome banner text <strong>"Library Net Welcome"</strong> (type <code>i</code>) pointing to
+            <code>/motd.txt</code> on this server at host <code>gopher.library.lan</code>.
+          </li>
+          <li>
+            Catalog search text <strong>"Catalog Search Terminal"</strong> (type <code>7</code>) proxied through
+            <code>catalog.library.lan</code> selector <code>/query</code>.
+          </li>
+          <li>
+            Weekly zine text <strong>"Weekly Sparks"</strong> (type <code>0</code>) hosted remotely at
+            <code>198.51.100.77</code> selector <code>/zines/weeklysparks.txt</code> on port <code>70</code>.
+          </li>
+        </ul>
+      </section>
+      <section class="control-panel" aria-labelledby="gopher-heading">
+        <h2 id="gopher-heading">Gophermap composer</h2>
+        <p>Complete each row. Leave port blank to default to 70.</p>
+        <form id="gopher-form" class="form-grid">
+          <fieldset>
+            <legend>Menu rows</legend>
+            <div class="gopher-grid">
+              <div class="row" data-row="banner">
+                <h3>Welcome banner</h3>
+                <label>
+                  Display text
+                  <input type="text" name="banner-text" />
+                </label>
+                <label>
+                  Selector
+                  <input type="text" name="banner-selector" />
+                </label>
+                <label>
+                  Host
+                  <input type="text" name="banner-host" />
+                </label>
+                <label>
+                  Type
+                  <input type="text" name="banner-type" maxlength="1" />
+                </label>
+              </div>
+              <div class="row" data-row="catalog">
+                <h3>Catalog search</h3>
+                <label>
+                  Display text
+                  <input type="text" name="catalog-text" />
+                </label>
+                <label>
+                  Selector
+                  <input type="text" name="catalog-selector" />
+                </label>
+                <label>
+                  Host
+                  <input type="text" name="catalog-host" />
+                </label>
+                <label>
+                  Type
+                  <input type="text" name="catalog-type" maxlength="1" />
+                </label>
+              </div>
+              <div class="row" data-row="zine">
+                <h3>Weekly zine</h3>
+                <label>
+                  Display text
+                  <input type="text" name="zine-text" />
+                </label>
+                <label>
+                  Selector
+                  <input type="text" name="zine-selector" />
+                </label>
+                <label>
+                  Host
+                  <input type="text" name="zine-host" />
+                </label>
+                <label>
+                  Type
+                  <input type="text" name="zine-type" maxlength="1" />
+                </label>
+              </div>
+            </div>
+          </fieldset>
+          <button type="submit" class="execute-button">Save gophermap</button>
+        </form>
+        <div id="status-board" class="status-board" aria-live="polite">Awaiting menu entries.</div>
+      </section>
+    </main>
+    <footer>Keep the burrows tidy and the menu crisp.</footer>
+    <script type="module" src="./gopher-groundskeeper.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/net/hopline-diagnostics/hopline-diagnostics.css
+++ b/madia.new/public/secret/net/hopline-diagnostics/hopline-diagnostics.css
@@ -1,0 +1,52 @@
+main {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.diagnostic {
+  border: 1px solid var(--console-glow);
+  padding: 1rem;
+  background: rgba(4, 20, 28, 0.7);
+  box-shadow: inset 0 0 0 1px rgba(80, 255, 200, 0.1);
+}
+
+.log-panel {
+  max-height: 16rem;
+  overflow: auto;
+  background: rgba(0, 20, 30, 0.85);
+  padding: 1rem;
+  border: 1px solid rgba(80, 255, 200, 0.2);
+}
+
+.log-panel pre {
+  margin: 0;
+  color: var(--neon-green);
+}
+
+.route-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+label {
+  display: grid;
+  gap: 0.4rem;
+  font-weight: 500;
+}
+
+select {
+  background: rgba(0, 16, 24, 0.95);
+  border: 1px solid rgba(80, 255, 200, 0.35);
+  color: var(--text-primary);
+  padding: 0.4rem 0.6rem;
+}
+
+.status-board[data-state="success"] {
+  border-color: var(--status-success);
+  color: var(--status-success);
+}
+
+.status-board[data-state="error"] {
+  border-color: var(--status-error);
+  color: var(--status-error);
+}

--- a/madia.new/public/secret/net/hopline-diagnostics/hopline-diagnostics.js
+++ b/madia.new/public/secret/net/hopline-diagnostics/hopline-diagnostics.js
@@ -1,0 +1,42 @@
+const form = document.getElementById("route-form");
+const board = document.getElementById("status-board");
+
+const expected = {
+  lab: "edge-hub",
+  studio: "studio-loop",
+  isp: "metro-border",
+};
+
+const updateBoard = (message, state = "idle") => {
+  board.textContent = message;
+  board.dataset.state = state;
+};
+
+form?.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const data = new FormData(form);
+  const mismatches = Object.entries(expected).filter(([key, value]) => data.get(key) !== value);
+  if (mismatches.length) {
+    updateBoard("Traceroute still breaks. Check the mismatched prefixes.", "error");
+    return;
+  }
+  updateBoard("Routes propagated. Ping echoes clean.", "success");
+  window.parent?.postMessage(
+    {
+      type: "net:level-complete",
+      game: "hopline-diagnostics",
+      payload: {
+        status: "Latency shaved",
+        score: 64000,
+      },
+    },
+    "*"
+  );
+});
+
+form?.addEventListener("input", () => {
+  if (board.dataset.state === "success") {
+    return;
+  }
+  updateBoard("Routing daemon idle.");
+});

--- a/madia.new/public/secret/net/hopline-diagnostics/index.html
+++ b/madia.new/public/secret/net/hopline-diagnostics/index.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Hopline Diagnostics</title>
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="./hopline-diagnostics.css" />
+  </head>
+  <body>
+    <header>
+      <p>Layer 08 · Backbone Pulse</p>
+      <h1>Hopline Diagnostics</h1>
+      <p>
+        A campus office says uploads are timing out. You already ran ping and traceroute from the NOC.
+        Match each network to the router that should advertise it so the packets stay on-net.
+      </p>
+    </header>
+    <main>
+      <section class="diagnostic" aria-labelledby="diag-heading">
+        <h2 id="diag-heading">Trace brief</h2>
+        <div class="log-panel" role="log" aria-live="polite">
+          <pre>
+$ ping -c 4 studio.lan
+Reply from 10.20.3.12: time=9 ms
+Reply from 10.20.3.12: time=9 ms
+Request timed out.
+Request timed out.
+
+$ traceroute studio.lan
+ 1  gateway (10.0.0.1)
+ 2  edge-hub (10.1.4.1)
+ 3  ???
+ 4  metro-border (198.51.100.9)
+ 5  * * *
+          </pre>
+        </div>
+      </section>
+      <section class="control-panel" aria-labelledby="route-heading">
+        <h2 id="route-heading">Route remap console</h2>
+        <p>Select the router that should announce each prefix.</p>
+        <form id="route-form" class="form-grid">
+          <fieldset>
+            <legend>Prefix to router mapping</legend>
+            <div class="route-grid">
+              <label>
+                10.20.0.0/16 data lab
+                <select name="lab">
+                  <option value="">--</option>
+                  <option value="edge-hub">edge-hub</option>
+                  <option value="metro-border">metro-border</option>
+                  <option value="studio-loop">studio-loop</option>
+                </select>
+              </label>
+              <label>
+                172.22.40.0/21 studio wing
+                <select name="studio">
+                  <option value="">--</option>
+                  <option value="edge-hub">edge-hub</option>
+                  <option value="metro-border">metro-border</option>
+                  <option value="studio-loop">studio-loop</option>
+                </select>
+              </label>
+              <label>
+                198.51.100.0/28 ISP handoff
+                <select name="isp">
+                  <option value="">--</option>
+                  <option value="edge-hub">edge-hub</option>
+                  <option value="metro-border">metro-border</option>
+                  <option value="studio-loop">studio-loop</option>
+                </select>
+              </label>
+            </div>
+          </fieldset>
+          <button type="submit" class="execute-button">Deploy routes</button>
+        </form>
+        <div id="status-board" class="status-board" aria-live="polite">Routing daemon idle.</div>
+      </section>
+    </main>
+    <footer>Keep the traceroute green and the pager silent.</footer>
+    <script type="module" src="./hopline-diagnostics.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/net/net.js
+++ b/madia.new/public/secret/net/net.js
@@ -2,6 +2,15 @@ const STORAGE_KEY = "net-ops-progress";
 
 const nodes = [
   {
+    id: "hopline-diagnostics",
+    layer: "Layer 08 · Backbone Pulse",
+    name: "Hopline Diagnostics",
+    description:
+      "Trace the stubborn uplink with ping and traceroute, then pin prefixes to the right routers before users notice.",
+    url: "./hopline-diagnostics/index.html",
+    thumbnail: "Trace Ops",
+  },
+  {
     id: "root-zone-relay",
     layer: "Layer 07 · DNS Authority",
     name: "Root Zone Relay",
@@ -47,6 +56,15 @@ const nodes = [
     thumbnail: "BGP Map",
   },
   {
+    id: "stream-parser-depot",
+    layer: "Layer 03 · Log Sieve",
+    name: "Stream Parser Depot",
+    description:
+      "Chain the right awk and sed snippets to squeeze a clean incident summary out of the radius logs.",
+    url: "./stream-parser-depot/index.html",
+    thumbnail: "awk|sed",
+  },
+  {
     id: "cache-cascade",
     layer: "Layer 02 · Proxy Works",
     name: "Cache Cascade",
@@ -54,6 +72,24 @@ const nodes = [
       "Tune your Squid cache hierarchy to absorb a surprise traffic storm without melting the leased line.",
     url: "./cache-cascade/index.html",
     thumbnail: "Proxy Flow",
+  },
+  {
+    id: "gopher-groundskeeper",
+    layer: "Layer 02 · Campus Content",
+    name: "Gopher Groundskeeper",
+    description:
+      "Compose a spotless gophermap so the library's beige terminals show the latest banners, catalogs, and zines.",
+    url: "./gopher-groundskeeper/index.html",
+    thumbnail: "Burrow",
+  },
+  {
+    id: "ftp-flightdeck",
+    layer: "Layer 01 · Transfer Bay",
+    name: "FTP Flightdeck",
+    description:
+      "Sequence a flawless FTP session so the nightly build touches down in staging before QA clocks in.",
+    url: "./ftp-flightdeck/index.html",
+    thumbnail: "FTP Ops",
   },
 ];
 

--- a/madia.new/public/secret/net/stream-parser-depot/index.html
+++ b/madia.new/public/secret/net/stream-parser-depot/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Stream Parser Depot</title>
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="./stream-parser-depot.css" />
+  </head>
+  <body>
+    <header>
+      <p>Layer 03 · Log Sieve</p>
+      <h1>Stream Parser Depot</h1>
+      <p>
+        The overnight shift dumped raw radius logs into a flat file. Pick the awk and sed snippets that clean the
+        authentication report for the pager message.
+      </p>
+    </header>
+    <main>
+      <section class="control-panel" aria-labelledby="log-heading">
+        <h2 id="log-heading">Sample payload</h2>
+        <div class="log-panel">
+          <pre>
+rad_recv: Access-Request packet from host 10.2.9.12:59636, id=212, length=117
+User-Name = "dli"
+User-Password = ""
+NAS-IP-Address = 10.2.9.12
+NAS-Port = 0
+Calling-Station-Id = "00-00-F8-9A-42-10"
+Connect-Info = "CONNECT 64000/ARQ/V34/LAPM/V42BIS"
+rad_reply: Access-Accept packet
+rad_recv: Access-Request packet from host 10.2.9.14:59647, id=213, length=120
+User-Name = "guest"
+User-Password = "guest"
+NAS-Port = 1
+rad_reply: Access-Reject packet
+          </pre>
+        </div>
+      </section>
+      <section class="control-panel" aria-labelledby="parser-heading">
+        <h2 id="parser-heading">Pipeline builder</h2>
+        <p>Choose the command pair that yields <code>dli CONNECT 64000/ARQ/V34/LAPM/V42BIS</code>.</p>
+        <form id="parser-form" class="form-grid">
+          <fieldset>
+            <legend>Step selection</legend>
+            <div class="parser-grid">
+              <label>
+                Filter stage
+                <select name="filter">
+                  <option value="">--</option>
+                  <option value="awk-user">awk '/User-Name/ {u=$3}'</option>
+                  <option value="awk-pair">awk '/Access-Request/ {print $NF}'</option>
+                  <option value="sed-block">sed -n '1,6p'</option>
+                  <option value="sed-pull">sed -n '/Access-Accept/,$p'</option>
+                </select>
+              </label>
+              <label>
+                Format stage
+                <select name="format">
+                  <option value="">--</option>
+                  <option value="awk-print">awk 'NR==1 {printf "%s ", $1}'</option>
+                  <option value="awk-join">awk 'NR%2==1 {printf $0 " "}'</option>
+                  <option value="sed-trim">sed 's/["=]//g;s/User-Name //;s/\\t//g'</option>
+                  <option value="sed-collapse">sed -n 's/.*= \"\(.*\)\"/\1/p'</option>
+                </select>
+              </label>
+            </div>
+          </fieldset>
+          <button type="submit" class="execute-button">Run pipeline</button>
+        </form>
+        <div id="status-board" class="status-board" aria-live="polite">Awaiting command pair.</div>
+      </section>
+    </main>
+    <footer>Keep the pager brief and the regex sharp.</footer>
+    <script type="module" src="./stream-parser-depot.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.css
+++ b/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.css
@@ -1,0 +1,45 @@
+main {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.log-panel {
+  border: 1px solid rgba(138, 255, 219, 0.35);
+  background: rgba(0, 18, 26, 0.85);
+  padding: 1rem;
+  max-height: 18rem;
+  overflow: auto;
+}
+
+.log-panel pre {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.parser-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+label {
+  display: grid;
+  gap: 0.4rem;
+  font-weight: 500;
+}
+
+select {
+  background: rgba(0, 16, 26, 0.95);
+  border: 1px solid rgba(138, 255, 219, 0.4);
+  color: var(--text-primary);
+  padding: 0.4rem 0.6rem;
+}
+
+.status-board[data-state="success"] {
+  color: var(--status-success);
+  border-color: var(--status-success);
+}
+
+.status-board[data-state="error"] {
+  color: var(--status-error);
+  border-color: var(--status-error);
+}

--- a/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.js
+++ b/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.js
@@ -1,0 +1,47 @@
+const form = document.getElementById("parser-form");
+const board = document.getElementById("status-board");
+
+const expected = {
+  filter: "sed-block",
+  format: "sed-collapse",
+};
+
+const updateBoard = (message, state = "idle") => {
+  board.textContent = message;
+  board.dataset.state = state;
+};
+
+form?.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const data = new FormData(form);
+  const filter = data.get("filter");
+  const format = data.get("format");
+  if (filter !== expected.filter || format !== expected.format) {
+    updateBoard("Output still messy. Try a tighter selector or trim.", "error");
+    return;
+  }
+  updateBoard("Report distilled. Pager ready.", "success");
+  window.parent?.postMessage(
+    {
+      type: "net:level-complete",
+      game: "stream-parser-depot",
+      payload: {
+        status: "Regex on call",
+        score: 42000,
+      },
+    },
+    "*"
+  );
+});
+
+form?.addEventListener("input", () => {
+  if (board.dataset.state === "success") {
+    return;
+  }
+  const data = new FormData(form);
+  if (data.get("filter") && data.get("format")) {
+    updateBoard("Preview pipeline staged.");
+  } else {
+    updateBoard("Awaiting command pair.");
+  }
+});


### PR DESCRIPTION
## Summary
- add four new Net cabinets for routing diagnostics, log parsing, gopher menu authoring, and FTP transfers
- wire the new cabinets into the launcher grid with era-appropriate copy and thumbnails
- provide terminal-inspired UIs, validation, and completion signaling for each scenario

## Testing
- manual

------
https://chatgpt.com/codex/tasks/task_e_68e45c828eb08328aa36a84984917274