### PR TITLE
Fix Net Operations arcade bootstrap fallback

### DIFF
--- a/madia.new/public/secret/net/index.html
+++ b/madia.new/public/secret/net/index.html
@@ -24,6 +24,9 @@
         <button type="button" id="reset-progress" class="reset-button">Reset cabinet memory</button>
       </section>
       <section class="net-grid" id="node-grid" aria-label="Cabinet selection"></section>
+      <p id="net-load-error" class="load-error" role="alert" hidden>
+        Unable to boot the Net Operations cabinets. Refresh to retry the sequence.
+      </p>
     </main>
     <template id="node-card-template">
       <article class="node-card">
@@ -63,6 +66,15 @@
     <script type="module">
       const cacheBustUrl = (path, version) => `${path}?v=${encodeURIComponent(version)}`;
 
+      const showLoadError = (message) => {
+        const errorElement = document.getElementById("net-load-error");
+        if (!errorElement) {
+          return;
+        }
+        errorElement.textContent = message;
+        errorElement.hidden = false;
+      };
+
       const getBuildId = async () => {
         try {
           const response = await fetch("./build-info.json", { cache: "no-store" });
@@ -77,15 +89,27 @@
         }
       };
 
-      const buildId = await getBuildId();
-      window.__NET_BUILD_ID__ = buildId;
+      const bootstrapNet = async () => {
+        const buildId = await getBuildId();
+        window.__NET_BUILD_ID__ = buildId;
 
-      const stylesheet = document.getElementById("net-style");
-      if (stylesheet) {
-        stylesheet.href = cacheBustUrl("net.css", buildId);
-      }
+        const stylesheet = document.getElementById("net-style");
+        if (stylesheet) {
+          stylesheet.href = cacheBustUrl("net.css", buildId);
+        }
 
-      await import(cacheBustUrl("./net.js", buildId));
+        try {
+          await import(cacheBustUrl("./net.js", buildId));
+        } catch (error) {
+          console.error("Failed to load Net Operations module", error);
+          showLoadError("Unable to boot the Net Operations cabinets. Refresh to retry the sequence.");
+        }
+      };
+
+      bootstrapNet().catch((error) => {
+        console.error("Failed to initialize Net Operations", error);
+        showLoadError("Net Operations initialization failed. Reload the page to try again.");
+      });
     </script>
   </body>
 </html>

--- a/madia.new/public/secret/net/net.css
+++ b/madia.new/public/secret/net/net.css
@@ -130,6 +130,19 @@ main {
   gap: clamp(1rem, 3vw, 2rem);
 }
 
+.load-error {
+  margin: 0 auto;
+  max-width: 640px;
+  padding: 1rem 1.25rem;
+  background: rgba(7, 16, 30, 0.88);
+  border: 1px solid rgba(255, 95, 109, 0.45);
+  border-radius: 10px;
+  color: #ffd9e1;
+  text-align: center;
+  font-size: 0.95rem;
+  box-shadow: 0 12px 28px rgba(255, 95, 109, 0.12);
+}
+
 .node-card {
   position: relative;
   background: var(--card-bg);


### PR DESCRIPTION
## Summary
- update the Net Operations launcher to bootstrap without relying on top-level await and surface module load failures
- add an inline status message style so the cabinet grid explains when bootstrapping fails

## Testing
- not run (static files)


------
https://chatgpt.com/codex/tasks/task_e_68e47ae407a483288699f4c2f9cbc932