### PR TITLE
fix: hide net overlay until cabinet opens

### DIFF
--- a/madia.new/public/secret/net/net.css
+++ b/madia.new/public/secret/net/net.css
@@ -261,6 +261,10 @@ main {
   z-index: 20;
 }
 
+.player-overlay:not([data-open="true"]) {
+  display: none;
+}
+
 .overlay-backdrop {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Summary
- ensure the Net Operations player overlay stays hidden until a cabinet sets `data-open="true"`

## Testing
- `python -m http.server 5000` (manual)

------
https://chatgpt.com/codex/tasks/task_e_68e48671fd2883289e891d0b8547490b