### PR TITLE
feat: energize net arcade challenges

### DIFF
--- a/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.css
+++ b/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.css
@@ -5,3 +5,160 @@ body {
 .execute-button {
   margin-top: 0.75rem;
 }
+
+.bgp-visual {
+  margin-top: 1.25rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(5, 14, 26, 0.9), rgba(6, 18, 36, 0.95));
+  position: relative;
+  overflow: hidden;
+}
+
+.bgp-map {
+  position: relative;
+  height: 120px;
+  display: grid;
+  place-items: center;
+}
+
+.bgp-node {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: rgba(56, 248, 122, 0.5);
+  box-shadow: 0 0 16px rgba(56, 248, 122, 0.6);
+  opacity: 0.8;
+  --node-position: translate(0, 0);
+  transform: var(--node-position);
+  transform-origin: center;
+}
+
+.node-core {
+  top: 50%;
+  left: 50%;
+  --node-position: translate(-50%, -50%);
+}
+
+.node-edge {
+  top: 20%;
+  right: 18%;
+}
+
+.node-backup {
+  bottom: 16%;
+  left: 12%;
+}
+
+.bgp-link {
+  position: absolute;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0), rgba(56, 248, 122, 0.9), rgba(56, 248, 122, 0));
+  opacity: 0.15;
+}
+
+.link-a {
+  width: 60%;
+  height: 2px;
+  top: 50%;
+  left: 20%;
+  transform: rotate(12deg);
+}
+
+.link-b {
+  width: 52%;
+  height: 2px;
+  top: 38%;
+  left: 26%;
+  transform: rotate(-22deg);
+}
+
+.link-c {
+  width: 48%;
+  height: 2px;
+  bottom: 28%;
+  left: 22%;
+  transform: rotate(18deg);
+}
+
+.visual-caption {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(148, 197, 183, 0.82);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.bgp-visual[data-state="processing"] .bgp-link {
+  opacity: 0.5;
+  animation: bgp-flow 2s linear infinite;
+}
+
+.bgp-visual[data-state="processing"] .bgp-node {
+  animation: bgp-node-pulse 1.6s ease-in-out infinite;
+}
+
+.bgp-visual[data-state="success"] {
+  border-color: rgba(56, 248, 122, 0.75);
+  box-shadow: 0 0 30px rgba(56, 248, 122, 0.28);
+}
+
+.bgp-visual[data-state="success"] .bgp-link {
+  opacity: 0.8;
+  animation: bgp-stable 1.8s ease-in-out infinite;
+}
+
+.bgp-visual[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.6);
+  box-shadow: 0 0 22px rgba(255, 95, 109, 0.3);
+  animation: bgp-jitter 0.6s ease;
+}
+
+.bgp-visual[data-state="error"] .bgp-node {
+  background: rgba(255, 95, 109, 0.7);
+  box-shadow: 0 0 16px rgba(255, 95, 109, 0.5);
+}
+
+@keyframes bgp-flow {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 200% 50%;
+  }
+}
+
+@keyframes bgp-node-pulse {
+  0%,
+  100% {
+    transform: var(--node-position) scale(1);
+  }
+  50% {
+    transform: var(--node-position) scale(1.25);
+  }
+}
+
+@keyframes bgp-stable {
+  0%,
+  100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 0.9;
+  }
+}
+
+@keyframes bgp-jitter {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-4px);
+  }
+  75% {
+    transform: translateX(4px);
+  }
+}

--- a/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.js
+++ b/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.js
@@ -1,5 +1,7 @@
 const form = document.getElementById("bgp-form");
 const board = document.getElementById("status-board");
+const visual = document.getElementById("bgp-visual");
+const visualCaption = visual?.querySelector(".visual-caption");
 
 const expected = {
   "local-pref": "raise",
@@ -12,6 +14,23 @@ const updateBoard = (message, state = "idle") => {
   board.dataset.state = state;
 };
 
+const visualMessages = {
+  idle: "Backbone telemetry nominal.",
+  processing: "Propagating policy changes…",
+  success: "Routes converged on the fiber ring.",
+  error: "Instability detected—adjust policy mix.",
+};
+
+const setVisualState = (state) => {
+  if (!visual) {
+    return;
+  }
+  visual.dataset.state = state;
+  if (visualCaption && visualMessages[state]) {
+    visualCaption.textContent = visualMessages[state];
+  }
+};
+
 const evaluatePolicy = (formData) => {
   const mismatches = Object.entries(expected)
     .filter(([key, value]) => (formData.get(key) || "") !== value)
@@ -21,13 +40,16 @@ const evaluatePolicy = (formData) => {
 
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
+  setVisualState("processing");
   const formData = new FormData(form);
   const mismatches = evaluatePolicy(formData);
   if (mismatches.length) {
     updateBoard(`Route map rejected: fix ${mismatches.join(", ")}.`, "error");
+    setVisualState("error");
     return;
   }
   updateBoard("Policies live. Backbone prefers fiber ring.", "success");
+  setVisualState("success");
   window.parent?.postMessage(
     {
       type: "net:level-complete",
@@ -49,7 +71,9 @@ form?.addEventListener("input", () => {
   const mismatches = evaluatePolicy(formData);
   if (!mismatches.length) {
     updateBoard("Policy ready. Deploy to routers.");
+    setVisualState("processing");
   } else {
     updateBoard("Session flapping. Apply damping plan…");
+    setVisualState("idle");
   }
 });

--- a/madia.new/public/secret/net/borderline-broadcast/index.html
+++ b/madia.new/public/secret/net/borderline-broadcast/index.html
@@ -51,6 +51,17 @@
           <button type="submit" class="execute-button">Deploy policies</button>
         </form>
         <div class="status-board" id="status-board" aria-live="polite">Session flapping. Apply damping plan…</div>
+        <div id="bgp-visual" class="bgp-visual" data-state="idle" aria-hidden="true">
+          <div class="bgp-map">
+            <span class="bgp-node node-core"></span>
+            <span class="bgp-node node-edge"></span>
+            <span class="bgp-node node-backup"></span>
+            <span class="bgp-link link-a"></span>
+            <span class="bgp-link link-b"></span>
+            <span class="bgp-link link-c"></span>
+          </div>
+          <p class="visual-caption">Backbone telemetry nominal.</p>
+        </div>
       </section>
     </main>
     <footer>Peering etiquette keeps the network breathing.</footer>

--- a/madia.new/public/secret/net/cache-cascade/cache-cascade.css
+++ b/madia.new/public/secret/net/cache-cascade/cache-cascade.css
@@ -19,3 +19,159 @@ body {
 .execute-button {
   margin-top: 0.75rem;
 }
+
+.cache-visual {
+  margin-top: 1.25rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  border-radius: 12px;
+  background: linear-gradient(160deg, rgba(4, 14, 28, 0.9), rgba(6, 22, 36, 0.95));
+  position: relative;
+  overflow: hidden;
+}
+
+.cache-streams {
+  position: relative;
+  height: 120px;
+  display: grid;
+  place-items: center;
+}
+
+.stream-node {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  background: rgba(56, 248, 122, 0.5);
+  box-shadow: 0 0 16px rgba(56, 248, 122, 0.5);
+  opacity: 0.75;
+  transform-origin: center;
+}
+
+.node-origin {
+  top: 50%;
+  left: 18%;
+}
+
+.node-parent {
+  top: 30%;
+  left: 45%;
+}
+
+.node-sibling {
+  bottom: 22%;
+  left: 55%;
+}
+
+.node-edge {
+  top: 50%;
+  right: 14%;
+}
+
+.stream-flow {
+  position: absolute;
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0), rgba(56, 248, 122, 0.85), rgba(56, 248, 122, 0));
+  opacity: 0.2;
+}
+
+.flow-a {
+  width: 44%;
+  top: 46%;
+  left: 18%;
+}
+
+.flow-b {
+  width: 36%;
+  top: 58%;
+  left: 32%;
+  transform: rotate(18deg);
+}
+
+.flow-c {
+  width: 38%;
+  top: 34%;
+  left: 36%;
+  transform: rotate(-16deg);
+}
+
+.visual-caption {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(148, 197, 183, 0.8);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.cache-visual[data-state="processing"] .stream-flow {
+  opacity: 0.55;
+  animation: cache-flow 1.6s linear infinite;
+}
+
+.cache-visual[data-state="processing"] .stream-node {
+  animation: cache-node-pulse 1.8s ease-in-out infinite;
+}
+
+.cache-visual[data-state="success"] {
+  border-color: rgba(56, 248, 122, 0.75);
+  box-shadow: 0 0 28px rgba(56, 248, 122, 0.28);
+}
+
+.cache-visual[data-state="success"] .stream-flow {
+  opacity: 0.8;
+  animation: cache-stable 2s ease-in-out infinite;
+}
+
+.cache-visual[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.6);
+  box-shadow: 0 0 22px rgba(255, 95, 109, 0.28);
+  animation: cache-shake 0.6s ease;
+}
+
+.cache-visual[data-state="error"] .stream-node {
+  background: rgba(255, 95, 109, 0.7);
+  box-shadow: 0 0 18px rgba(255, 95, 109, 0.45);
+}
+
+@keyframes cache-flow {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 200% 50%;
+  }
+}
+
+@keyframes cache-node-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.15);
+  }
+}
+
+@keyframes cache-stable {
+  0%,
+  100% {
+    opacity: 0.7;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes cache-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-5px);
+  }
+  75% {
+    transform: translateX(5px);
+  }
+}

--- a/madia.new/public/secret/net/cache-cascade/cache-cascade.js
+++ b/madia.new/public/secret/net/cache-cascade/cache-cascade.js
@@ -1,5 +1,7 @@
 const form = document.getElementById("cache-form");
 const board = document.getElementById("status-board");
+const visual = document.getElementById("cache-visual");
+const visualCaption = visual?.querySelector(".visual-caption");
 
 const expected = {
   static: { route: "parent", ttl: "60" },
@@ -10,6 +12,23 @@ const expected = {
 const updateBoard = (message, state = "idle") => {
   board.textContent = message;
   board.dataset.state = state;
+};
+
+const visualMessages = {
+  idle: "Hierarchy cooling channels primed.",
+  processing: "Balancing request load…",
+  success: "Cascade locked. Hit ratio stabilized.",
+  error: "Hot spot detected—revise routing.",
+};
+
+const setVisualState = (state) => {
+  if (!visual) {
+    return;
+  }
+  visual.dataset.state = state;
+  if (visualCaption && visualMessages[state]) {
+    visualCaption.textContent = visualMessages[state];
+  }
 };
 
 const evaluateCache = (formData) => {
@@ -26,13 +45,16 @@ const evaluateCache = (formData) => {
 
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
+  setVisualState("processing");
   const formData = new FormData(form);
   const mismatches = evaluateCache(formData);
   if (mismatches.length) {
     updateBoard(`Hierarchy rejected: adjust ${mismatches.join(", ")}.`, "error");
+    setVisualState("error");
     return;
   }
   updateBoard("Hit ratio climbing. Line holds steady.", "success");
+  setVisualState("success");
   window.parent?.postMessage(
     {
       type: "net:level-complete",
@@ -54,7 +76,9 @@ form?.addEventListener("input", () => {
   const mismatches = evaluateCache(formData);
   if (!mismatches.length) {
     updateBoard("Hierarchy ready. Commit to squid.conf.");
+    setVisualState("processing");
   } else {
     updateBoard("Cache hit ratio falling…");
+    setVisualState("idle");
   }
 });

--- a/madia.new/public/secret/net/cache-cascade/index.html
+++ b/madia.new/public/secret/net/cache-cascade/index.html
@@ -75,6 +75,18 @@
         </form>
         <div class="status-board" id="status-board" aria-live="polite">Cache hit ratio falling…
         </div>
+        <div id="cache-visual" class="cache-visual" data-state="idle" aria-hidden="true">
+          <div class="cache-streams">
+            <span class="stream-node node-origin"></span>
+            <span class="stream-node node-parent"></span>
+            <span class="stream-node node-sibling"></span>
+            <span class="stream-node node-edge"></span>
+            <span class="stream-flow flow-a"></span>
+            <span class="stream-flow flow-b"></span>
+            <span class="stream-flow flow-c"></span>
+          </div>
+          <p class="visual-caption">Hierarchy cooling channels primed.</p>
+        </div>
       </section>
     </main>
     <footer>Remember: always warm the cache before the press release.</footer>

--- a/madia.new/public/secret/net/daemon-handshake/daemon-handshake.css
+++ b/madia.new/public/secret/net/daemon-handshake/daemon-handshake.css
@@ -14,3 +14,139 @@ body {
 .execute-button {
   margin-top: 0.5rem;
 }
+
+.daemon-visual {
+  margin-top: 1.25rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  border-radius: 12px;
+  background: linear-gradient(160deg, rgba(4, 12, 24, 0.9), rgba(6, 20, 32, 0.95));
+  position: relative;
+  overflow: hidden;
+}
+
+.rack-panel {
+  position: relative;
+  height: 120px;
+  display: grid;
+  place-items: center;
+}
+
+.rack-light {
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  background: rgba(56, 248, 122, 0.45);
+  box-shadow: 0 0 14px rgba(56, 248, 122, 0.45);
+  opacity: 0.75;
+}
+
+.light-a {
+  align-self: flex-start;
+  margin-top: 12px;
+}
+
+.light-b {
+  align-self: center;
+}
+
+.light-c {
+  align-self: flex-end;
+  margin-bottom: 12px;
+}
+
+.rack-panel {
+  display: grid;
+  gap: 18px;
+}
+
+.rack-scan {
+  position: absolute;
+  width: 80%;
+  height: 8px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0), rgba(56, 248, 122, 0.9), rgba(56, 248, 122, 0));
+  opacity: 0.15;
+}
+
+.visual-caption {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(148, 197, 183, 0.82);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.daemon-visual[data-state="processing"] .rack-light {
+  animation: rack-cycle 1.5s ease-in-out infinite;
+}
+
+.daemon-visual[data-state="processing"] .rack-scan {
+  opacity: 0.6;
+  animation: rack-sweep 1.4s linear infinite;
+}
+
+.daemon-visual[data-state="success"] {
+  border-color: rgba(56, 248, 122, 0.75);
+  box-shadow: 0 0 28px rgba(56, 248, 122, 0.28);
+}
+
+.daemon-visual[data-state="success"] .rack-light {
+  animation: rack-cheer 2s ease-in-out infinite;
+}
+
+.daemon-visual[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.6);
+  box-shadow: 0 0 22px rgba(255, 95, 109, 0.28);
+  animation: rack-shake 0.55s ease;
+}
+
+.daemon-visual[data-state="error"] .rack-light {
+  background: rgba(255, 95, 109, 0.75);
+  box-shadow: 0 0 16px rgba(255, 95, 109, 0.4);
+}
+
+@keyframes rack-cycle {
+  0%,
+  100% {
+    filter: brightness(0.9);
+  }
+  50% {
+    filter: brightness(1.35);
+  }
+}
+
+@keyframes rack-sweep {
+  0% {
+    top: 18%;
+  }
+  100% {
+    top: 78%;
+  }
+}
+
+@keyframes rack-cheer {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  40% {
+    transform: scale(1.2);
+  }
+  70% {
+    transform: scale(0.9);
+  }
+}
+
+@keyframes rack-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-4px);
+  }
+  75% {
+    transform: translateX(4px);
+  }
+}

--- a/madia.new/public/secret/net/daemon-handshake/index.html
+++ b/madia.new/public/secret/net/daemon-handshake/index.html
@@ -58,6 +58,15 @@
           <button type="submit" class="execute-button">Start daemon</button>
         </form>
         <div class="status-board" id="status-board" aria-live="polite">Daemon halted. Awaiting config…</div>
+        <div id="daemon-visual" class="daemon-visual" data-state="idle" aria-hidden="true">
+          <div class="rack-panel">
+            <span class="rack-light light-a"></span>
+            <span class="rack-light light-b"></span>
+            <span class="rack-light light-c"></span>
+            <span class="rack-scan"></span>
+          </div>
+          <p class="visual-caption">Rack power cycling in standby.</p>
+        </div>
       </section>
     </main>
     <footer>Keep alive ping courtesy of the campus NOC.</footer>

--- a/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.css
+++ b/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.css
@@ -36,3 +36,141 @@ select {
   color: var(--status-error);
   border-color: var(--status-error);
 }
+
+.flight-visual {
+  margin-top: 1.25rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  border-radius: 12px;
+  background: radial-gradient(circle at 20% 20%, rgba(56, 248, 122, 0.08), rgba(4, 12, 26, 0.95));
+  position: relative;
+  overflow: hidden;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.flight-track {
+  position: relative;
+  height: 96px;
+  border: 1px dashed rgba(56, 248, 122, 0.35);
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1.5rem;
+  overflow: hidden;
+}
+
+.flight-marker {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: rgba(56, 248, 122, 0.45);
+  box-shadow: 0 0 14px rgba(56, 248, 122, 0.45);
+  opacity: 0.6;
+}
+
+.flight-plane {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0), rgba(56, 248, 122, 0.65), rgba(56, 248, 122, 0));
+  clip-path: polygon(8% 45%, 80% 30%, 88% 50%, 80% 70%);
+  opacity: 0;
+  transform: translateX(-60%);
+}
+
+.visual-caption {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(148, 197, 183, 0.8);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.flight-visual[data-state="processing"] {
+  border-color: rgba(56, 248, 122, 0.6);
+  box-shadow: 0 0 22px rgba(56, 248, 122, 0.18);
+}
+
+.flight-visual[data-state="processing"] .flight-marker {
+  animation: marker-pulse 1.8s ease-in-out infinite;
+}
+
+.flight-visual[data-state="processing"] .marker-b {
+  animation-delay: 0.3s;
+}
+
+.flight-visual[data-state="processing"] .marker-c {
+  animation-delay: 0.6s;
+}
+
+.flight-visual[data-state="processing"] .flight-plane {
+  opacity: 1;
+  animation: holding-pattern 1.6s ease-in-out infinite;
+}
+
+.flight-visual[data-state="success"] .flight-plane {
+  opacity: 1;
+  animation: touchdown 1.2s ease-out forwards;
+}
+
+.flight-visual[data-state="success"] {
+  border-color: rgba(56, 248, 122, 0.75);
+  box-shadow: 0 0 30px rgba(56, 248, 122, 0.25);
+}
+
+.flight-visual[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.6);
+  box-shadow: 0 0 24px rgba(255, 95, 109, 0.3);
+  animation: flight-shake 0.5s ease;
+}
+
+.flight-visual[data-state="error"] .flight-marker {
+  background: rgba(255, 95, 109, 0.7);
+  box-shadow: 0 0 16px rgba(255, 95, 109, 0.4);
+}
+
+@keyframes marker-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.5;
+  }
+  50% {
+    transform: scale(1.4);
+    opacity: 1;
+  }
+}
+
+@keyframes holding-pattern {
+  0%,
+  100% {
+    transform: translateX(-60%);
+  }
+  50% {
+    transform: translateX(20%);
+  }
+}
+
+@keyframes touchdown {
+  0% {
+    transform: translateX(-60%);
+    opacity: 0.7;
+  }
+  100% {
+    transform: translateX(120%);
+    opacity: 0;
+  }
+}
+
+@keyframes flight-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-6px);
+  }
+  75% {
+    transform: translateX(6px);
+  }
+}

--- a/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.js
+++ b/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.js
@@ -1,5 +1,7 @@
 const form = document.getElementById("ftp-form");
 const board = document.getElementById("status-board");
+const visual = document.getElementById("flight-visual");
+const visualCaption = visual?.querySelector(".visual-caption");
 
 const expectedOrder = {
   open: "1",
@@ -13,6 +15,23 @@ const expectedOrder = {
 const updateBoard = (message, state = "idle") => {
   board.textContent = message;
   board.dataset.state = state;
+};
+
+const visualMessages = {
+  idle: "Flight path holding steady.",
+  processing: "Spooling command macros…",
+  success: "Autopilot confirms smooth touchdown.",
+  error: "Guidance fault! Adjust command lineup.",
+};
+
+const setVisualState = (state) => {
+  if (!visual) {
+    return;
+  }
+  visual.dataset.state = state;
+  if (visualCaption && visualMessages[state]) {
+    visualCaption.textContent = visualMessages[state];
+  }
 };
 
 const hasDuplicates = (values) => {
@@ -31,18 +50,22 @@ const hasDuplicates = (values) => {
 
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
+  setVisualState("processing");
   const data = new FormData(form);
   const values = Object.fromEntries(Object.keys(expectedOrder).map((key) => [key, data.get(key) || ""]));
   if (hasDuplicates(values)) {
     updateBoard("Sequence conflict detected. Remove duplicate slots.", "error");
+    setVisualState("error");
     return;
   }
   const mismatches = Object.entries(expectedOrder).filter(([key, value]) => values[key] !== value);
   if (mismatches.length) {
     updateBoard("Transfer aborted. Adjust command ordering.", "error");
+    setVisualState("error");
     return;
   }
   updateBoard("Payload delivered. QA has their bits.", "success");
+  setVisualState("success");
   window.parent?.postMessage(
     {
       type: "net:level-complete",
@@ -61,4 +84,5 @@ form?.addEventListener("input", () => {
     return;
   }
   updateBoard("Transfer queue idle.");
+  setVisualState("idle");
 });

--- a/madia.new/public/secret/net/ftp-flightdeck/index.html
+++ b/madia.new/public/secret/net/ftp-flightdeck/index.html
@@ -109,6 +109,15 @@
           <button type="submit" class="execute-button">Initiate transfer</button>
         </form>
         <div id="status-board" class="status-board" aria-live="polite">Transfer queue idle.</div>
+        <div id="flight-visual" class="flight-visual" data-state="idle" aria-hidden="true">
+          <div class="flight-track">
+            <span class="flight-marker marker-a"></span>
+            <span class="flight-marker marker-b"></span>
+            <span class="flight-marker marker-c"></span>
+            <span class="flight-plane"></span>
+          </div>
+          <p class="visual-caption">Flight path holding steady.</p>
+        </div>
       </section>
     </main>
     <footer>Keep the channel clear and the payload intact.</footer>

--- a/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.css
+++ b/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.css
@@ -43,3 +43,155 @@ input[type="text"] {
   color: var(--status-error);
   border-color: var(--status-error);
 }
+
+.gopher-visual {
+  margin-top: 1.25rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  border-radius: 12px;
+  background: radial-gradient(circle at 30% 30%, rgba(56, 248, 122, 0.1), rgba(6, 16, 28, 0.95));
+  position: relative;
+  overflow: hidden;
+}
+
+.tunnel-map {
+  position: relative;
+  height: 120px;
+}
+
+.tunnel-node {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid rgba(56, 248, 122, 0.65);
+  background: rgba(6, 18, 28, 0.8);
+  box-shadow: 0 0 16px rgba(56, 248, 122, 0.35);
+  opacity: 0.85;
+}
+
+.tunnel-a {
+  top: 18%;
+  left: 18%;
+}
+
+.tunnel-b {
+  top: 50%;
+  right: 24%;
+}
+
+.tunnel-c {
+  bottom: 14%;
+  left: 32%;
+}
+
+.tunnel-path {
+  position: absolute;
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0), rgba(56, 248, 122, 0.9), rgba(56, 248, 122, 0));
+  height: 4px;
+  border-radius: 999px;
+  opacity: 0.2;
+}
+
+.path-1 {
+  width: 52%;
+  top: 24%;
+  left: 20%;
+  transform: rotate(8deg);
+}
+
+.path-2 {
+  width: 58%;
+  top: 58%;
+  left: 18%;
+  transform: rotate(-6deg);
+}
+
+.path-3 {
+  width: 38%;
+  bottom: 18%;
+  left: 30%;
+  transform: rotate(24deg);
+}
+
+.visual-caption {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(148, 197, 183, 0.82);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.gopher-visual[data-state="processing"] .tunnel-node {
+  animation: tunnel-pulse 1.6s ease-in-out infinite;
+}
+
+.gopher-visual[data-state="processing"] .tunnel-path {
+  opacity: 0.55;
+  animation: tunnel-flow 1.4s linear infinite;
+}
+
+.gopher-visual[data-state="success"] {
+  border-color: rgba(56, 248, 122, 0.75);
+  box-shadow: 0 0 26px rgba(56, 248, 122, 0.25);
+}
+
+.gopher-visual[data-state="success"] .tunnel-node {
+  animation: tunnel-celebrate 2.2s ease-in-out infinite;
+}
+
+.gopher-visual[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.6);
+  box-shadow: 0 0 22px rgba(255, 95, 109, 0.28);
+  animation: tunnel-shake 0.55s ease;
+}
+
+.gopher-visual[data-state="error"] .tunnel-node {
+  border-color: rgba(255, 95, 109, 0.8);
+  box-shadow: 0 0 18px rgba(255, 95, 109, 0.45);
+}
+
+@keyframes tunnel-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.2);
+  }
+}
+
+@keyframes tunnel-flow {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 200% 50%;
+  }
+}
+
+@keyframes tunnel-celebrate {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  40% {
+    transform: scale(1.15);
+  }
+  70% {
+    transform: scale(0.95);
+  }
+}
+
+@keyframes tunnel-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-4px);
+  }
+  75% {
+    transform: translateX(4px);
+  }
+}

--- a/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.js
+++ b/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.js
@@ -1,5 +1,7 @@
 const form = document.getElementById("gopher-form");
 const board = document.getElementById("status-board");
+const visual = document.getElementById("gopher-visual");
+const visualCaption = visual?.querySelector(".visual-caption");
 
 const expected = {
   "banner-text": "Library Net Welcome",
@@ -21,15 +23,35 @@ const updateBoard = (message, state = "idle") => {
   board.dataset.state = state;
 };
 
+const visualMessages = {
+  idle: "Gopher tunnels awaiting signage.",
+  processing: "Routing burrow paths…",
+  success: "All tunnels labeled. Visitors guided.",
+  error: "Dead end detected—fix the entries.",
+};
+
+const setVisualState = (state) => {
+  if (!visual) {
+    return;
+  }
+  visual.dataset.state = state;
+  if (visualCaption && visualMessages[state]) {
+    visualCaption.textContent = visualMessages[state];
+  }
+};
+
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
+  setVisualState("processing");
   const data = new FormData(form);
   const errors = Object.entries(expected).filter(([name, value]) => (data.get(name) || "").trim() !== value);
   if (errors.length) {
     updateBoard("Menu mismatch. Check selector, type, and host fields.", "error");
+    setVisualState("error");
     return;
   }
   updateBoard("Gophermap saved. Terminals update in sync.", "success");
+  setVisualState("success");
   window.parent?.postMessage(
     {
       type: "net:level-complete",
@@ -48,4 +70,5 @@ form?.addEventListener("input", () => {
     return;
   }
   updateBoard("Awaiting menu entries.");
+  setVisualState("idle");
 });

--- a/madia.new/public/secret/net/gopher-groundskeeper/index.html
+++ b/madia.new/public/secret/net/gopher-groundskeeper/index.html
@@ -103,6 +103,17 @@
           <button type="submit" class="execute-button">Save gophermap</button>
         </form>
         <div id="status-board" class="status-board" aria-live="polite">Awaiting menu entries.</div>
+        <div id="gopher-visual" class="gopher-visual" data-state="idle" aria-hidden="true">
+          <div class="tunnel-map">
+            <span class="tunnel-node tunnel-a"></span>
+            <span class="tunnel-node tunnel-b"></span>
+            <span class="tunnel-node tunnel-c"></span>
+            <span class="tunnel-path path-1"></span>
+            <span class="tunnel-path path-2"></span>
+            <span class="tunnel-path path-3"></span>
+          </div>
+          <p class="visual-caption">Gopher tunnels awaiting signage.</p>
+        </div>
       </section>
     </main>
     <footer>Keep the burrows tidy and the menu crisp.</footer>

--- a/madia.new/public/secret/net/hopline-diagnostics/hopline-diagnostics.css
+++ b/madia.new/public/secret/net/hopline-diagnostics/hopline-diagnostics.css
@@ -50,3 +50,158 @@ select {
   border-color: var(--status-error);
   color: var(--status-error);
 }
+
+.hopline-visual {
+  margin-top: 1.25rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(4, 16, 28, 0.9), rgba(6, 22, 34, 0.95));
+  position: relative;
+  overflow: hidden;
+}
+
+.hopline-map {
+  position: relative;
+  height: 120px;
+}
+
+.hop-node {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(56, 248, 122, 0.5);
+  box-shadow: 0 0 16px rgba(56, 248, 122, 0.45);
+  opacity: 0.85;
+  transform-origin: center;
+}
+
+.node-a {
+  top: 18%;
+  left: 26%;
+}
+
+.node-b {
+  top: 62%;
+  left: 48%;
+}
+
+.node-c {
+  top: 30%;
+  right: 18%;
+}
+
+.hop-path {
+  position: absolute;
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0), rgba(56, 248, 122, 0.9), rgba(56, 248, 122, 0));
+  opacity: 0.25;
+}
+
+.path-1 {
+  width: 48%;
+  top: 28%;
+  left: 26%;
+  transform: rotate(12deg);
+}
+
+.path-2 {
+  width: 44%;
+  top: 52%;
+  left: 28%;
+  transform: rotate(-18deg);
+}
+
+.path-3 {
+  width: 58%;
+  top: 44%;
+  left: 24%;
+  transform: rotate(6deg);
+}
+
+.visual-caption {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(148, 197, 183, 0.82);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.hopline-visual[data-state="processing"] .hop-path {
+  opacity: 0.6;
+  animation: hopline-flow 1.5s linear infinite;
+}
+
+.hopline-visual[data-state="processing"] .hop-node {
+  animation: hopline-pulse 1.6s ease-in-out infinite;
+}
+
+.hopline-visual[data-state="success"] {
+  border-color: rgba(56, 248, 122, 0.75);
+  box-shadow: 0 0 28px rgba(56, 248, 122, 0.28);
+}
+
+.hopline-visual[data-state="success"] .hop-node {
+  animation: hopline-sync 2.1s ease-in-out infinite;
+}
+
+.hopline-visual[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.6);
+  box-shadow: 0 0 22px rgba(255, 95, 109, 0.28);
+  animation: hopline-shake 0.55s ease;
+}
+
+.hopline-visual[data-state="error"] .hop-node {
+  background: rgba(255, 95, 109, 0.7);
+  box-shadow: 0 0 18px rgba(255, 95, 109, 0.45);
+}
+
+@keyframes hopline-flow {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 200% 50%;
+  }
+}
+
+@keyframes hopline-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.2);
+  }
+}
+
+@keyframes hopline-sync {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  25% {
+    transform: scale(1.1);
+  }
+  50% {
+    transform: scale(0.95);
+  }
+  75% {
+    transform: scale(1.05);
+  }
+}
+
+@keyframes hopline-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-4px);
+  }
+  75% {
+    transform: translateX(4px);
+  }
+}

--- a/madia.new/public/secret/net/hopline-diagnostics/index.html
+++ b/madia.new/public/secret/net/hopline-diagnostics/index.html
@@ -75,6 +75,17 @@ $ traceroute studio.lan
           <button type="submit" class="execute-button">Deploy routes</button>
         </form>
         <div id="status-board" class="status-board" aria-live="polite">Routing daemon idle.</div>
+        <div id="hopline-visual" class="hopline-visual" data-state="idle" aria-hidden="true">
+          <div class="hopline-map">
+            <span class="hop-node node-a"></span>
+            <span class="hop-node node-b"></span>
+            <span class="hop-node node-c"></span>
+            <span class="hop-path path-1"></span>
+            <span class="hop-path path-2"></span>
+            <span class="hop-path path-3"></span>
+          </div>
+          <p class="visual-caption">Signal probes aligned.</p>
+        </div>
       </section>
     </main>
     <footer>Keep the traceroute green and the pager silent.</footer>

--- a/madia.new/public/secret/net/kernel-forge-20/index.html
+++ b/madia.new/public/secret/net/kernel-forge-20/index.html
@@ -70,6 +70,15 @@
           <button type="submit" class="execute-button">make bzImage</button>
         </form>
         <div class="status-board" id="status-board" aria-live="polite">Awaiting config for make menuconfig…</div>
+        <div id="kernel-visual" class="kernel-visual" data-state="idle" aria-hidden="true">
+          <div class="kernel-gauge">
+            <span class="kernel-ring ring-a"></span>
+            <span class="kernel-ring ring-b"></span>
+            <span class="kernel-ring ring-c"></span>
+            <span class="kernel-core"></span>
+          </div>
+          <p class="visual-caption">Compiler idle at prompt.</p>
+        </div>
       </section>
     </main>
     <footer>Remember to copy System.map once it boots.</footer>

--- a/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.css
+++ b/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.css
@@ -14,3 +14,126 @@ body {
 .execute-button {
   margin-top: 0.75rem;
 }
+
+.kernel-visual {
+  margin-top: 1.25rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  border-radius: 12px;
+  background: linear-gradient(140deg, rgba(4, 12, 24, 0.9), rgba(6, 20, 30, 0.95));
+  position: relative;
+  overflow: hidden;
+}
+
+.kernel-gauge {
+  position: relative;
+  height: 120px;
+  display: grid;
+  place-items: center;
+}
+
+.kernel-ring {
+  position: absolute;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: 2px solid rgba(56, 248, 122, 0.35);
+  box-shadow: 0 0 18px rgba(56, 248, 122, 0.25);
+  opacity: 0.7;
+}
+
+.ring-b {
+  width: 86px;
+  height: 86px;
+}
+
+.ring-c {
+  width: 110px;
+  height: 110px;
+}
+
+.kernel-core {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: rgba(56, 248, 122, 0.6);
+  box-shadow: 0 0 24px rgba(56, 248, 122, 0.6);
+}
+
+.visual-caption {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(148, 197, 183, 0.82);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.kernel-visual[data-state="processing"] .kernel-ring {
+  animation: kernel-spin 1.6s linear infinite;
+}
+
+.kernel-visual[data-state="processing"] .kernel-core {
+  animation: kernel-pulse 1.4s ease-in-out infinite;
+}
+
+.kernel-visual[data-state="success"] {
+  border-color: rgba(56, 248, 122, 0.75);
+  box-shadow: 0 0 30px rgba(56, 248, 122, 0.28);
+}
+
+.kernel-visual[data-state="success"] .kernel-ring {
+  animation: kernel-victory 2.2s ease-in-out infinite;
+}
+
+.kernel-visual[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.6);
+  box-shadow: 0 0 22px rgba(255, 95, 109, 0.28);
+  animation: kernel-shake 0.55s ease;
+}
+
+.kernel-visual[data-state="error"] .kernel-ring {
+  border-color: rgba(255, 95, 109, 0.7);
+  box-shadow: 0 0 18px rgba(255, 95, 109, 0.45);
+}
+
+@keyframes kernel-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes kernel-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.3);
+  }
+}
+
+@keyframes kernel-victory {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.15);
+  }
+}
+
+@keyframes kernel-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-4px);
+  }
+  75% {
+    transform: translateX(4px);
+  }
+}

--- a/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.js
+++ b/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.js
@@ -1,5 +1,7 @@
 const form = document.getElementById("kernel-form");
 const board = document.getElementById("status-board");
+const visual = document.getElementById("kernel-visual");
+const visualCaption = visual?.querySelector(".visual-caption");
 
 const REQUIRED_NETWORK = ["forwarding", "firewall"];
 const OPTIONAL_NETWORK = ["ipv6"];
@@ -9,6 +11,23 @@ const FORBIDDEN_DRIVERS = ["scsi", "sound"];
 const updateBoard = (message, state = "idle") => {
   board.textContent = message;
   board.dataset.state = state;
+};
+
+const visualMessages = {
+  idle: "Compiler idle at prompt.",
+  processing: "Running make menuconfig…",
+  success: "Kernel forged. Routers will reboot clean.",
+  error: "Build halted. Check toggles.",
+};
+
+const setVisualState = (state) => {
+  if (!visual) {
+    return;
+  }
+  visual.dataset.state = state;
+  if (visualCaption && visualMessages[state]) {
+    visualCaption.textContent = visualMessages[state];
+  }
 };
 
 const evaluateKernel = (formData) => {
@@ -44,13 +63,16 @@ const evaluateKernel = (formData) => {
 
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
+  setVisualState("processing");
   const formData = new FormData(form);
   const issues = evaluateKernel(formData);
   if (issues.length) {
     updateBoard(`Build failed: ${issues.join(", ")}.`, "error");
+    setVisualState("error");
     return;
   }
   updateBoard("Kernel linked. bzImage staged in /boot.", "success");
+  setVisualState("success");
   window.parent?.postMessage(
     {
       type: "net:level-complete",
@@ -72,7 +94,9 @@ form?.addEventListener("input", () => {
   const issues = evaluateKernel(formData);
   if (!issues.length) {
     updateBoard("Config matches memo. make bzImage ready.");
+    setVisualState("processing");
   } else {
     updateBoard("Awaiting config for make menuconfig…");
+    setVisualState("idle");
   }
 });

--- a/madia.new/public/secret/net/modem-skunkworks/index.html
+++ b/madia.new/public/secret/net/modem-skunkworks/index.html
@@ -69,6 +69,15 @@
           <button type="submit" class="execute-button">Dial now</button>
         </form>
         <div class="status-board" id="status-board" aria-live="polite">Modem idle. Awaiting script…</div>
+        <div id="modem-visual" class="modem-visual" data-state="idle" aria-hidden="true">
+          <div class="waveform">
+            <span class="wave wave-a"></span>
+            <span class="wave wave-b"></span>
+            <span class="wave wave-c"></span>
+            <span class="wave-cursor"></span>
+          </div>
+          <p class="visual-caption">Carrier tone standing by.</p>
+        </div>
       </section>
     </main>
     <footer>Pair your 56K with a clean copper line.</footer>

--- a/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.css
+++ b/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.css
@@ -11,3 +11,132 @@ body {
 .execute-button {
   margin-top: 0.75rem;
 }
+
+.modem-visual {
+  margin-top: 1.25rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  border-radius: 12px;
+  background: linear-gradient(120deg, rgba(4, 14, 26, 0.9), rgba(6, 20, 34, 0.95));
+  position: relative;
+  overflow: hidden;
+}
+
+.waveform {
+  position: relative;
+  height: 110px;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+}
+
+.wave {
+  position: relative;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid rgba(56, 248, 122, 0.35);
+  box-shadow: 0 0 18px rgba(56, 248, 122, 0.28);
+  opacity: 0.75;
+}
+
+.wave::after {
+  content: "";
+  position: absolute;
+  inset: 4px;
+  border-radius: 50%;
+  border: 2px solid rgba(56, 248, 122, 0.2);
+}
+
+.wave-cursor {
+  position: absolute;
+  top: 18%;
+  left: 16%;
+  width: 68%;
+  height: 64%;
+  border-radius: 999px;
+  border: 2px solid rgba(56, 248, 122, 0.4);
+  opacity: 0.2;
+}
+
+.visual-caption {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(148, 197, 183, 0.82);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.modem-visual[data-state="processing"] .wave {
+  animation: modem-pulse 1.3s ease-in-out infinite;
+}
+
+.modem-visual[data-state="processing"] .wave-cursor {
+  opacity: 0.6;
+  animation: modem-scan 1.5s linear infinite;
+}
+
+.modem-visual[data-state="success"] {
+  border-color: rgba(56, 248, 122, 0.75);
+  box-shadow: 0 0 28px rgba(56, 248, 122, 0.28);
+}
+
+.modem-visual[data-state="success"] .wave {
+  animation: modem-lock 2.1s ease-in-out infinite;
+}
+
+.modem-visual[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.6);
+  box-shadow: 0 0 22px rgba(255, 95, 109, 0.28);
+  animation: modem-shake 0.55s ease;
+}
+
+.modem-visual[data-state="error"] .wave {
+  border-color: rgba(255, 95, 109, 0.7);
+  box-shadow: 0 0 18px rgba(255, 95, 109, 0.45);
+}
+
+@keyframes modem-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.25);
+  }
+}
+
+@keyframes modem-scan {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes modem-lock {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  40% {
+    transform: scale(1.15);
+  }
+  70% {
+    transform: scale(0.95);
+  }
+}
+
+@keyframes modem-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-4px);
+  }
+  75% {
+    transform: translateX(4px);
+  }
+}

--- a/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.js
+++ b/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.js
@@ -1,5 +1,7 @@
 const form = document.getElementById("ppp-form");
 const board = document.getElementById("status-board");
+const visual = document.getElementById("modem-visual");
+const visualCaption = visual?.querySelector(".visual-caption");
 
 const expectedOrder = {
   carrier: "1",
@@ -11,6 +13,23 @@ const expectedOrder = {
 const updateBoard = (message, state = "idle") => {
   board.textContent = message;
   board.dataset.state = state;
+};
+
+const visualMessages = {
+  idle: "Carrier tone standing by.",
+  processing: "Negotiating PPP sequence…",
+  success: "Link locked. Syncing newsroom feed.",
+  error: "Handshake jammed. Reorder the phases.",
+};
+
+const setVisualState = (state) => {
+  if (!visual) {
+    return;
+  }
+  visual.dataset.state = state;
+  if (visualCaption && visualMessages[state]) {
+    visualCaption.textContent = visualMessages[state];
+  }
 };
 
 const evaluateOrder = (formData) => {
@@ -32,17 +51,21 @@ const evaluateOrder = (formData) => {
 
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
+  setVisualState("processing");
   const formData = new FormData(form);
   const { duplicates, mismatches } = evaluateOrder(formData);
   if (duplicates.size) {
     updateBoard(`Modem error: duplicate steps ${Array.from(duplicates).join(", ")}.`, "error");
+    setVisualState("error");
     return;
   }
   if (mismatches.length) {
     updateBoard(`Negotiation failed: adjust ${mismatches.join(", ")}.`, "error");
+    setVisualState("error");
     return;
   }
   updateBoard("PPP link live. newsroom feed synchronized.", "success");
+  setVisualState("success");
   window.parent?.postMessage(
     {
       type: "net:level-complete",
@@ -64,7 +87,9 @@ form?.addEventListener("input", () => {
   const { duplicates, mismatches } = evaluateOrder(formData);
   if (!duplicates.size && !mismatches.length) {
     updateBoard("Sequence locked. Dial when ready.");
+    setVisualState("processing");
   } else {
     updateBoard("Modem idle. Awaiting script…");
+    setVisualState("idle");
   }
 });

--- a/madia.new/public/secret/net/root-zone-relay/index.html
+++ b/madia.new/public/secret/net/root-zone-relay/index.html
@@ -88,6 +88,17 @@
           <button type="submit" class="execute-button">Push zone live</button>
         </form>
         <div class="status-board" id="status-board" aria-live="polite">Awaiting alignment…</div>
+        <div id="zone-visual" class="zone-visual" data-state="idle" aria-hidden="true">
+          <div class="zone-grid">
+            <span class="zone-node node-www"></span>
+            <span class="zone-node node-mail"></span>
+            <span class="zone-node node-root"></span>
+            <span class="zone-link link-1"></span>
+            <span class="zone-link link-2"></span>
+            <span class="zone-link link-3"></span>
+          </div>
+          <p class="visual-caption">Zone relays listening for updates.</p>
+        </div>
       </section>
     </main>
     <footer>Based on IETF RFCs that kept the '96 backbone humming.</footer>

--- a/madia.new/public/secret/net/root-zone-relay/root-zone-relay.css
+++ b/madia.new/public/secret/net/root-zone-relay/root-zone-relay.css
@@ -15,3 +15,155 @@ body {
 .execute-button {
   margin-top: 0.25rem;
 }
+
+.zone-visual {
+  margin-top: 1.25rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  border-radius: 12px;
+  background: linear-gradient(150deg, rgba(4, 14, 28, 0.9), rgba(6, 22, 36, 0.95));
+  position: relative;
+  overflow: hidden;
+}
+
+.zone-grid {
+  position: relative;
+  height: 120px;
+}
+
+.zone-node {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(56, 248, 122, 0.5);
+  box-shadow: 0 0 16px rgba(56, 248, 122, 0.45);
+  opacity: 0.85;
+  transform-origin: center;
+}
+
+.node-www {
+  top: 20%;
+  left: 22%;
+}
+
+.node-mail {
+  top: 50%;
+  right: 20%;
+}
+
+.node-root {
+  bottom: 20%;
+  left: 32%;
+}
+
+.zone-link {
+  position: absolute;
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0), rgba(56, 248, 122, 0.9), rgba(56, 248, 122, 0));
+  opacity: 0.25;
+}
+
+.link-1 {
+  width: 52%;
+  top: 26%;
+  left: 24%;
+  transform: rotate(10deg);
+}
+
+.link-2 {
+  width: 46%;
+  top: 58%;
+  left: 28%;
+  transform: rotate(-16deg);
+}
+
+.link-3 {
+  width: 38%;
+  top: 66%;
+  left: 30%;
+  transform: rotate(24deg);
+}
+
+.visual-caption {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(148, 197, 183, 0.82);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.zone-visual[data-state="processing"] .zone-link {
+  opacity: 0.6;
+  animation: zone-flow 1.6s linear infinite;
+}
+
+.zone-visual[data-state="processing"] .zone-node {
+  animation: zone-pulse 1.5s ease-in-out infinite;
+}
+
+.zone-visual[data-state="success"] {
+  border-color: rgba(56, 248, 122, 0.75);
+  box-shadow: 0 0 28px rgba(56, 248, 122, 0.28);
+}
+
+.zone-visual[data-state="success"] .zone-node {
+  animation: zone-stable 2.1s ease-in-out infinite;
+}
+
+.zone-visual[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.6);
+  box-shadow: 0 0 22px rgba(255, 95, 109, 0.28);
+  animation: zone-shake 0.55s ease;
+}
+
+.zone-visual[data-state="error"] .zone-node {
+  background: rgba(255, 95, 109, 0.7);
+  box-shadow: 0 0 18px rgba(255, 95, 109, 0.45);
+}
+
+@keyframes zone-flow {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 200% 50%;
+  }
+}
+
+@keyframes zone-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.2);
+  }
+}
+
+@keyframes zone-stable {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  40% {
+    transform: scale(1.1);
+  }
+  70% {
+    transform: scale(0.95);
+  }
+}
+
+@keyframes zone-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-4px);
+  }
+  75% {
+    transform: translateX(4px);
+  }
+}

--- a/madia.new/public/secret/net/stream-parser-depot/index.html
+++ b/madia.new/public/secret/net/stream-parser-depot/index.html
@@ -69,6 +69,15 @@ rad_reply: Access-Reject packet
           <button type="submit" class="execute-button">Run pipeline</button>
         </form>
         <div id="status-board" class="status-board" aria-live="polite">Awaiting command pair.</div>
+        <div id="parser-visual" class="parser-visual" data-state="idle" aria-hidden="true">
+          <div class="log-tape">
+            <span class="log-segment segment-a"></span>
+            <span class="log-segment segment-b"></span>
+            <span class="log-segment segment-c"></span>
+            <span class="log-head"></span>
+          </div>
+          <p class="visual-caption">Log tape ready for slicing.</p>
+        </div>
       </section>
     </main>
     <footer>Keep the pager brief and the regex sharp.</footer>

--- a/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.css
+++ b/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.css
@@ -43,3 +43,140 @@ select {
   color: var(--status-error);
   border-color: var(--status-error);
 }
+
+.parser-visual {
+  margin-top: 1.25rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  border-radius: 12px;
+  background: linear-gradient(180deg, rgba(4, 14, 28, 0.9), rgba(6, 18, 30, 0.95));
+  position: relative;
+  overflow: hidden;
+}
+
+.log-tape {
+  position: relative;
+  height: 110px;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.log-segment {
+  flex: 1;
+  height: 24px;
+  background: repeating-linear-gradient(
+    90deg,
+    rgba(56, 248, 122, 0.1) 0,
+    rgba(56, 248, 122, 0.1) 12px,
+    rgba(56, 248, 122, 0.28) 13px
+  );
+  border: 1px solid rgba(56, 248, 122, 0.3);
+  border-radius: 6px;
+  box-shadow: inset 0 0 12px rgba(56, 248, 122, 0.2);
+  position: relative;
+}
+
+.segment-a {
+  height: 20px;
+}
+
+.segment-b {
+  height: 28px;
+}
+
+.segment-c {
+  height: 24px;
+}
+
+.log-head {
+  position: absolute;
+  top: 50%;
+  left: 12%;
+  width: 18px;
+  height: 46px;
+  border-radius: 6px;
+  border: 2px solid rgba(56, 248, 122, 0.65);
+  background: rgba(6, 18, 30, 0.95);
+  box-shadow: 0 0 16px rgba(56, 248, 122, 0.4);
+  transform: translateY(-50%);
+  opacity: 0.85;
+}
+
+.visual-caption {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(148, 197, 183, 0.82);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.parser-visual[data-state="processing"] .log-head {
+  animation: parser-scan 1.8s linear infinite;
+}
+
+.parser-visual[data-state="processing"] .log-segment {
+  animation: parser-glow 1.6s ease-in-out infinite;
+}
+
+.parser-visual[data-state="success"] {
+  border-color: rgba(56, 248, 122, 0.75);
+  box-shadow: 0 0 28px rgba(56, 248, 122, 0.28);
+}
+
+.parser-visual[data-state="success"] .log-segment {
+  animation: parser-celebrate 1.8s ease-in-out infinite;
+}
+
+.parser-visual[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.6);
+  box-shadow: 0 0 22px rgba(255, 95, 109, 0.28);
+  animation: parser-shake 0.55s ease;
+}
+
+.parser-visual[data-state="error"] .log-head {
+  border-color: rgba(255, 95, 109, 0.8);
+  box-shadow: 0 0 18px rgba(255, 95, 109, 0.45);
+}
+
+@keyframes parser-scan {
+  0% {
+    left: 12%;
+  }
+  100% {
+    left: 78%;
+  }
+}
+
+@keyframes parser-glow {
+  0%,
+  100% {
+    box-shadow: inset 0 0 12px rgba(56, 248, 122, 0.2);
+  }
+  50% {
+    box-shadow: inset 0 0 18px rgba(56, 248, 122, 0.45);
+  }
+}
+
+@keyframes parser-celebrate {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
+@keyframes parser-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-4px);
+  }
+  75% {
+    transform: translateX(4px);
+  }
+}

--- a/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.js
+++ b/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.js
@@ -1,5 +1,7 @@
 const form = document.getElementById("parser-form");
 const board = document.getElementById("status-board");
+const visual = document.getElementById("parser-visual");
+const visualCaption = visual?.querySelector(".visual-caption");
 
 const expected = {
   filter: "sed-block",
@@ -11,16 +13,36 @@ const updateBoard = (message, state = "idle") => {
   board.dataset.state = state;
 };
 
+const visualMessages = {
+  idle: "Log tape ready for slicing.",
+  processing: "Spooling awk | sed pipeline…",
+  success: "Clean extract queued to pager.",
+  error: "Parse failed. Refine the filters.",
+};
+
+const setVisualState = (state) => {
+  if (!visual) {
+    return;
+  }
+  visual.dataset.state = state;
+  if (visualCaption && visualMessages[state]) {
+    visualCaption.textContent = visualMessages[state];
+  }
+};
+
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
+  setVisualState("processing");
   const data = new FormData(form);
   const filter = data.get("filter");
   const format = data.get("format");
   if (filter !== expected.filter || format !== expected.format) {
     updateBoard("Output still messy. Try a tighter selector or trim.", "error");
+    setVisualState("error");
     return;
   }
   updateBoard("Report distilled. Pager ready.", "success");
+  setVisualState("success");
   window.parent?.postMessage(
     {
       type: "net:level-complete",
@@ -41,7 +63,9 @@ form?.addEventListener("input", () => {
   const data = new FormData(form);
   if (data.get("filter") && data.get("format")) {
     updateBoard("Preview pipeline staged.");
+    setVisualState("processing");
   } else {
     updateBoard("Awaiting command pair.");
+    setVisualState("idle");
   }
 });


### PR DESCRIPTION
## Summary
- add animated visualizer sections to each Net operations minigame so their layouts read as action-oriented terminals
- drive the new visuals alongside existing status boards by wiring idle/processing/success/error states in each puzzle script

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5a3becb588328bdfd3199d63b252e