### PR TITLE
feat: energize net arcade minigames

### DIFF
--- a/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.css
+++ b/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.css
@@ -5,3 +5,161 @@ body {
 .execute-button {
   margin-top: 0.75rem;
 }
+
+.route-map {
+  margin-top: 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(4, 18, 28, 0.75);
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.route-map::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(56, 248, 122, 0.07), transparent 30%);
+  pointer-events: none;
+}
+
+.router {
+  display: grid;
+  justify-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem;
+  border-radius: 10px;
+  background: rgba(3, 12, 24, 0.85);
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  position: relative;
+  min-height: 90px;
+}
+
+.router-name {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.router-indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(255, 95, 109, 0.65);
+  box-shadow: 0 0 0 0 rgba(255, 95, 109, 0.3);
+  animation: pulse-alert 2s infinite;
+}
+
+.link {
+  position: relative;
+  padding: 0.75rem 0.5rem;
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--net-muted);
+}
+
+.link::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 15%;
+  right: 15%;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(56, 248, 122, 0.25);
+  transform: translateY(-50%);
+}
+
+.route-map.route-map--fiber [data-link="fiber"]::before,
+.route-map.route-map--backup [data-link="frame"]::before {
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0.4), rgba(56, 248, 122, 0.9));
+  box-shadow: 0 0 16px rgba(56, 248, 122, 0.35);
+}
+
+.route-map.route-map--fiber [data-router="metro"] .router-indicator {
+  background: rgba(56, 248, 122, 0.85);
+  animation: pulse-forward 1.2s infinite;
+}
+
+.route-map.route-map--fiber [data-router="backbone"] .router-indicator {
+  background: rgba(56, 248, 122, 0.65);
+}
+
+.route-map.route-map--backup [data-router="backup"] .router-indicator {
+  background: rgba(255, 173, 64, 0.85);
+  animation: pulse-warning 1.2s infinite;
+}
+
+.route-map.route-map--dampened [data-router="backbone"] .router-indicator {
+  animation: pulse-stable 1.8s infinite;
+}
+
+.route-map[data-state="success"] {
+  border-color: rgba(56, 248, 122, 0.6);
+  box-shadow: 0 0 28px rgba(56, 248, 122, 0.25);
+}
+
+.route-map[data-state="success"] .router-indicator {
+  background: rgba(56, 248, 122, 0.95);
+  animation: pulse-stable 1.5s infinite;
+}
+
+.route-map[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.5);
+  box-shadow: 0 0 24px rgba(255, 95, 109, 0.25);
+}
+
+.route-map[data-state="error"] .router-indicator {
+  background: rgba(255, 95, 109, 0.85);
+  animation: pulse-alert 1.2s infinite;
+}
+
+@keyframes pulse-alert {
+  0% {
+    box-shadow: 0 0 0 0 rgba(255, 95, 109, 0.35);
+  }
+  70% {
+    box-shadow: 0 0 0 14px rgba(255, 95, 109, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 95, 109, 0);
+  }
+}
+
+@keyframes pulse-forward {
+  0% {
+    box-shadow: 0 0 0 0 rgba(56, 248, 122, 0.45);
+  }
+  70% {
+    box-shadow: 0 0 0 14px rgba(56, 248, 122, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(56, 248, 122, 0);
+  }
+}
+
+@keyframes pulse-warning {
+  0% {
+    box-shadow: 0 0 0 0 rgba(244, 180, 0, 0.35);
+  }
+  70% {
+    box-shadow: 0 0 0 12px rgba(244, 180, 0, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(244, 180, 0, 0);
+  }
+}
+
+@keyframes pulse-stable {
+  0% {
+    box-shadow: 0 0 0 0 rgba(56, 248, 122, 0.3);
+  }
+  100% {
+    box-shadow: 0 0 0 10px rgba(56, 248, 122, 0);
+  }
+}

--- a/madia.new/public/secret/net/borderline-broadcast/index.html
+++ b/madia.new/public/secret/net/borderline-broadcast/index.html
@@ -50,6 +50,26 @@
           </label>
           <button type="submit" class="execute-button">Deploy policies</button>
         </form>
+        <div class="route-map" aria-hidden="true">
+          <div class="router" data-router="backbone">
+            <span class="router-name">Backbone-1</span>
+            <span class="router-indicator"></span>
+          </div>
+          <div class="link" data-link="fiber">
+            <span>Fiber ring</span>
+          </div>
+          <div class="router" data-router="metro">
+            <span class="router-name">Metro edge</span>
+            <span class="router-indicator"></span>
+          </div>
+          <div class="link" data-link="frame">
+            <span>Frame relay</span>
+          </div>
+          <div class="router" data-router="backup">
+            <span class="router-name">Transit backup</span>
+            <span class="router-indicator"></span>
+          </div>
+        </div>
         <div class="status-board" id="status-board" aria-live="polite">Session flapping. Apply damping plan…</div>
       </section>
     </main>

--- a/madia.new/public/secret/net/cache-cascade/cache-cascade.css
+++ b/madia.new/public/secret/net/cache-cascade/cache-cascade.css
@@ -19,3 +19,150 @@ body {
 .execute-button {
   margin-top: 0.75rem;
 }
+
+.cascade-visual {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1.25rem;
+  background: rgba(3, 14, 24, 0.8);
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  border-radius: 12px;
+  padding: 1.2rem 1.5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.cascade-visual::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(56, 248, 122, 0.12), transparent 65%);
+  pointer-events: none;
+}
+
+.cascade-stream {
+  position: relative;
+  padding: 0.5rem 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.stream-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  color: var(--net-muted);
+}
+
+.stream-name {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.stream-route {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 0.5rem 0.5rem;
+  border-radius: 10px;
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  background: rgba(0, 12, 20, 0.8);
+}
+
+.stream-route::before {
+  content: "";
+  position: absolute;
+  left: 12%;
+  right: 12%;
+  top: 50%;
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0.1), rgba(56, 248, 122, 0.25));
+  transform: translateY(-50%);
+}
+
+.route-node {
+  font-size: 0.75rem;
+  text-align: center;
+  color: rgba(148, 197, 183, 0.75);
+  z-index: 1;
+}
+
+.packet {
+  position: absolute;
+  top: 50%;
+  left: calc(12% - 10px);
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  background: rgba(56, 248, 122, 0.85);
+  box-shadow: 0 0 12px rgba(56, 248, 122, 0.45);
+  transform: translate(calc(var(--route-progress, 0) * 120%), -50%);
+  transition: transform 0.6s ease;
+  animation: packet-bob 1.8s ease-in-out infinite;
+}
+
+.ttl-meter {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(56, 248, 122, 0.12);
+  overflow: hidden;
+}
+
+.ttl-fill {
+  position: absolute;
+  inset: 0;
+  transform-origin: left center;
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0.4), rgba(56, 248, 122, 0.85));
+  transform: scaleX(var(--ttl-ratio, 0.2));
+  transition: transform 0.6s ease;
+}
+
+.cascade-stream[data-route="direct"] .packet {
+  --route-progress: 0;
+}
+
+.cascade-stream[data-route="parent"] .packet {
+  --route-progress: 0.65;
+}
+
+.cascade-stream[data-route="sibling"] .packet {
+  --route-progress: 1.2;
+}
+
+.cascade-stream[data-state="ready"] .packet {
+  background: rgba(56, 248, 122, 0.75);
+}
+
+.cascade-stream[data-state="error"] .packet {
+  background: rgba(255, 95, 109, 0.85);
+  box-shadow: 0 0 12px rgba(255, 95, 109, 0.45);
+}
+
+.cascade-stream[data-state="success"] .packet {
+  animation: packet-glow 1.2s ease-in-out infinite;
+}
+
+@keyframes packet-bob {
+  0%,
+  100% {
+    transform: translate(calc(var(--route-progress, 0) * 120%), -50%) scale(1);
+  }
+  50% {
+    transform: translate(calc(var(--route-progress, 0) * 120%), -60%) scale(1.05);
+  }
+}
+
+@keyframes packet-glow {
+  0%,
+  100% {
+    box-shadow: 0 0 12px rgba(56, 248, 122, 0.55);
+  }
+  50% {
+    box-shadow: 0 0 22px rgba(56, 248, 122, 0.9);
+  }
+}

--- a/madia.new/public/secret/net/cache-cascade/cache-cascade.js
+++ b/madia.new/public/secret/net/cache-cascade/cache-cascade.js
@@ -1,5 +1,8 @@
 const form = document.getElementById("cache-form");
 const board = document.getElementById("status-board");
+const streamVisuals = new Map(
+  Array.from(document.querySelectorAll(".cascade-stream")).map((element) => [element.dataset.stream, element])
+);
 
 const expected = {
   static: { route: "parent", ttl: "60" },
@@ -7,9 +10,14 @@ const expected = {
   mirror: { route: "sibling", ttl: "240" },
 };
 
+const TTL_MAX = 240;
+
 const updateBoard = (message, state = "idle") => {
   board.textContent = message;
   board.dataset.state = state;
+  streamVisuals.forEach((element) => {
+    element.dataset.state = state === "success" ? "success" : element.dataset.state;
+  });
 };
 
 const evaluateCache = (formData) => {
@@ -24,10 +32,44 @@ const evaluateCache = (formData) => {
   return mismatches;
 };
 
+const updateStreamVisuals = (formData, mismatches = []) => {
+  streamVisuals.forEach((element, prefix) => {
+    const route = formData.get(prefix) || "";
+    const ttl = formData.get(`${prefix}-ttl`) || "";
+    if (route) {
+      element.dataset.route = route;
+    } else {
+      delete element.dataset.route;
+    }
+
+    const ttlValue = Number(ttl);
+    const ttlFill = element.querySelector(".ttl-fill");
+    if (ttlFill) {
+      const ratio = ttlValue ? Math.min(ttlValue / TTL_MAX, 1) : 0.15;
+      ttlFill.style.setProperty("--ttl-ratio", ratio.toString());
+    }
+    const ttlReadout = element.querySelector('[data-role="ttl"]');
+    if (ttlReadout) {
+      ttlReadout.textContent = ttlValue ? `TTL ${ttlValue} min` : "TTL —";
+    }
+
+    if (board.dataset.state === "success") {
+      element.dataset.state = "success";
+    } else if (mismatches.includes(prefix)) {
+      element.dataset.state = "error";
+    } else if (route && ttl) {
+      element.dataset.state = "ready";
+    } else {
+      delete element.dataset.state;
+    }
+  });
+};
+
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
   const formData = new FormData(form);
   const mismatches = evaluateCache(formData);
+  updateStreamVisuals(formData, mismatches);
   if (mismatches.length) {
     updateBoard(`Hierarchy rejected: adjust ${mismatches.join(", ")}.`, "error");
     return;
@@ -52,9 +94,14 @@ form?.addEventListener("input", () => {
   }
   const formData = new FormData(form);
   const mismatches = evaluateCache(formData);
+  updateStreamVisuals(formData, mismatches);
   if (!mismatches.length) {
     updateBoard("Hierarchy ready. Commit to squid.conf.");
   } else {
     updateBoard("Cache hit ratio falling…");
   }
 });
+
+if (form) {
+  updateStreamVisuals(new FormData(form));
+}

--- a/madia.new/public/secret/net/cache-cascade/index.html
+++ b/madia.new/public/secret/net/cache-cascade/index.html
@@ -73,6 +73,50 @@
           </fieldset>
           <button type="submit" class="execute-button">Commit hierarchy</button>
         </form>
+        <div class="cascade-visual" aria-hidden="true">
+          <div class="cascade-stream" data-stream="static">
+            <div class="stream-header">
+              <span class="stream-name">Static assets</span>
+              <span class="ttl-readout" data-role="ttl">TTL —</span>
+            </div>
+            <div class="stream-route">
+              <span class="route-node">Origin</span>
+              <span class="route-node">Parent</span>
+              <span class="route-node">Sibling</span>
+              <span class="route-node">Client</span>
+              <span class="packet"></span>
+            </div>
+            <div class="ttl-meter"><span class="ttl-fill"></span></div>
+          </div>
+          <div class="cascade-stream" data-stream="cms">
+            <div class="stream-header">
+              <span class="stream-name">Newsroom CMS</span>
+              <span class="ttl-readout" data-role="ttl">TTL —</span>
+            </div>
+            <div class="stream-route">
+              <span class="route-node">Origin</span>
+              <span class="route-node">Parent</span>
+              <span class="route-node">Sibling</span>
+              <span class="route-node">Client</span>
+              <span class="packet"></span>
+            </div>
+            <div class="ttl-meter"><span class="ttl-fill"></span></div>
+          </div>
+          <div class="cascade-stream" data-stream="mirror">
+            <div class="stream-header">
+              <span class="stream-name">Software mirror</span>
+              <span class="ttl-readout" data-role="ttl">TTL —</span>
+            </div>
+            <div class="stream-route">
+              <span class="route-node">Origin</span>
+              <span class="route-node">Parent</span>
+              <span class="route-node">Sibling</span>
+              <span class="route-node">Client</span>
+              <span class="packet"></span>
+            </div>
+            <div class="ttl-meter"><span class="ttl-fill"></span></div>
+          </div>
+        </div>
         <div class="status-board" id="status-board" aria-live="polite">Cache hit ratio falling…
         </div>
       </section>

--- a/madia.new/public/secret/net/daemon-handshake/daemon-handshake.css
+++ b/madia.new/public/secret/net/daemon-handshake/daemon-handshake.css
@@ -14,3 +14,164 @@ body {
 .execute-button {
   margin-top: 0.5rem;
 }
+
+.rack-visual {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+  background: rgba(3, 13, 22, 0.85);
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  border-radius: 14px;
+  padding: 1.1rem 1.25rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.rack-visual::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(56, 248, 122, 0.08), transparent 65%);
+  pointer-events: none;
+}
+
+.rack-tier {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.55rem 0.75rem;
+  background: rgba(0, 10, 18, 0.8);
+  border-radius: 10px;
+  border: 1px solid rgba(56, 248, 122, 0.2);
+}
+
+.tier-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 197, 183, 0.8);
+}
+
+.tier-indicator {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: rgba(255, 95, 109, 0.7);
+  box-shadow: 0 0 0 0 rgba(255, 95, 109, 0.35);
+  animation: rack-alert 2s infinite;
+}
+
+.module-array {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.6rem;
+}
+
+.module-indicator {
+  position: relative;
+  padding: 0.6rem 0.75rem;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-align: center;
+  border-radius: 8px;
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  background: rgba(0, 10, 18, 0.8);
+  color: rgba(148, 197, 183, 0.75);
+  overflow: hidden;
+}
+
+.module-indicator::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle, rgba(56, 248, 122, 0.15), transparent 70%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.module-indicator[data-state="active"] {
+  border-color: rgba(56, 248, 122, 0.5);
+  color: var(--net-text);
+}
+
+.module-indicator[data-state="active"]::after {
+  opacity: 1;
+}
+
+.module-indicator[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.6);
+  color: #ffd9e1;
+}
+
+.module-indicator[data-state="error"]::after {
+  background: radial-gradient(circle, rgba(255, 95, 109, 0.2), transparent 70%);
+  opacity: 1;
+}
+
+.module-indicator[data-state="disabled"] {
+  opacity: 0.5;
+}
+
+.rack-tier[data-state="ready"] .tier-indicator {
+  background: rgba(56, 248, 122, 0.85);
+  animation: rack-stable 1.5s infinite;
+}
+
+.rack-tier[data-state="error"] .tier-indicator {
+  background: rgba(255, 95, 109, 0.9);
+  animation: rack-alert 1.2s infinite;
+}
+
+.rack-visual[data-state="success"] .tier-indicator {
+  background: rgba(56, 248, 122, 0.95);
+  animation: rack-glow 1.4s infinite;
+}
+
+.rack-visual[data-state="success"] .module-indicator[data-state="active"] {
+  animation: module-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes rack-alert {
+  0% {
+    box-shadow: 0 0 0 0 rgba(255, 95, 109, 0.35);
+  }
+  70% {
+    box-shadow: 0 0 0 14px rgba(255, 95, 109, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 95, 109, 0);
+  }
+}
+
+@keyframes rack-stable {
+  0% {
+    box-shadow: 0 0 0 0 rgba(56, 248, 122, 0.35);
+  }
+  70% {
+    box-shadow: 0 0 0 12px rgba(56, 248, 122, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(56, 248, 122, 0);
+  }
+}
+
+@keyframes rack-glow {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(56, 248, 122, 0.45);
+  }
+  50% {
+    box-shadow: 0 0 18px rgba(56, 248, 122, 0.8);
+  }
+}
+
+@keyframes module-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.04);
+  }
+}

--- a/madia.new/public/secret/net/daemon-handshake/index.html
+++ b/madia.new/public/secret/net/daemon-handshake/index.html
@@ -57,6 +57,22 @@
           </fieldset>
           <button type="submit" class="execute-button">Start daemon</button>
         </form>
+        <div class="rack-visual" aria-hidden="true">
+          <div class="rack-tier" data-tier="port">
+            <span class="tier-label">Listen 8080</span>
+            <span class="tier-indicator"></span>
+          </div>
+          <div class="rack-tier" data-tier="docroot">
+            <span class="tier-label">/var/www/altroot</span>
+            <span class="tier-indicator"></span>
+          </div>
+          <div class="module-array">
+            <span class="module-indicator" data-module="mod_ssl">mod_ssl</span>
+            <span class="module-indicator" data-module="mod_status">mod_status</span>
+            <span class="module-indicator" data-module="mod_userdir">mod_userdir</span>
+            <span class="module-indicator" data-module="mod_rewrite">mod_rewrite</span>
+          </div>
+        </div>
         <div class="status-board" id="status-board" aria-live="polite">Daemon halted. Awaiting config…</div>
       </section>
     </main>

--- a/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.css
+++ b/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.css
@@ -36,3 +36,143 @@ select {
   color: var(--status-error);
   border-color: var(--status-error);
 }
+
+.flight-path {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 0.9rem;
+  background: rgba(2, 15, 26, 0.82);
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  border-radius: 12px;
+  padding: 1.2rem 1.4rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.flight-path::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(56, 248, 122, 0.12), transparent 55%);
+  pointer-events: none;
+}
+
+.flight-track {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(56, 248, 122, 0.15);
+  overflow: hidden;
+}
+
+.flight-glow {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0.1), rgba(56, 248, 122, 0.5));
+  opacity: 0.4;
+}
+
+.flight-plane {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 36px;
+  height: 16px;
+  border-radius: 8px;
+  background: rgba(56, 248, 122, 0.9);
+  box-shadow: 0 0 14px rgba(56, 248, 122, 0.6);
+  transform: translate(calc(var(--flight-progress, 0) * (100% - 36px)), -50%);
+  transition: transform 0.6s ease;
+}
+
+.flight-plane::after {
+  content: "";
+  position: absolute;
+  inset: -6px 50% -6px -20px;
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0.45), transparent);
+  border-radius: 999px;
+}
+
+.flight-steps {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.flight-step {
+  display: grid;
+  justify-items: center;
+  gap: 0.4rem;
+  padding: 0.65rem 0.4rem;
+  border-radius: 10px;
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  background: rgba(0, 10, 18, 0.8);
+  position: relative;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.75rem;
+  color: rgba(148, 197, 183, 0.8);
+}
+
+.flight-step::after {
+  content: attr(data-slot);
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  font-size: 0.7rem;
+  color: rgba(244, 213, 118, 0.85);
+  letter-spacing: 0.05em;
+}
+
+.step-index {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1px solid rgba(56, 248, 122, 0.3);
+  background: rgba(0, 14, 24, 0.9);
+  font-size: 0.75rem;
+}
+
+.flight-step[data-state="correct"] {
+  border-color: rgba(56, 248, 122, 0.6);
+  color: var(--net-text);
+  box-shadow: 0 0 18px rgba(56, 248, 122, 0.25);
+}
+
+.flight-step[data-state="pending"] {
+  border-color: rgba(244, 180, 0, 0.45);
+  color: rgba(244, 213, 118, 0.9);
+}
+
+.flight-step[data-state="duplicate"] {
+  border-color: rgba(255, 95, 109, 0.5);
+  color: #ffd9e1;
+  animation: step-alert 1s ease-in-out infinite;
+}
+
+.flight-path[data-state="success"] .flight-plane {
+  animation: plane-cruise 1.6s ease-in-out infinite;
+}
+
+@keyframes step-alert {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 95, 109, 0.35);
+  }
+  50% {
+    box-shadow: 0 0 12px rgba(255, 95, 109, 0.55);
+  }
+}
+
+@keyframes plane-cruise {
+  0%,
+  100% {
+    transform: translate(calc(var(--flight-progress, 0) * (100% - 36px)), -50%) scale(1);
+  }
+  50% {
+    transform: translate(calc(var(--flight-progress, 0) * (100% - 36px)), -54%) scale(1.05);
+  }
+}

--- a/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.js
+++ b/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.js
@@ -1,5 +1,10 @@
 const form = document.getElementById("ftp-form");
 const board = document.getElementById("status-board");
+const flightPath = document.querySelector(".flight-path");
+const flightPlane = flightPath?.querySelector(".flight-plane");
+const flightSteps = new Map(
+  Array.from(document.querySelectorAll(".flight-step")).map((element) => [element.dataset.command, element])
+);
 
 const expectedOrder = {
   open: "1",
@@ -10,34 +15,87 @@ const expectedOrder = {
   quit: "6",
 };
 
+const expectedSequence = Object.entries(expectedOrder).sort(([, a], [, b]) => Number(a) - Number(b));
+
 const updateBoard = (message, state = "idle") => {
   board.textContent = message;
   board.dataset.state = state;
+  if (flightPath) {
+    flightPath.dataset.state = state;
+  }
 };
 
-const hasDuplicates = (values) => {
+const collectValues = (formData) =>
+  Object.fromEntries(Object.keys(expectedOrder).map((key) => [key, formData.get(key) || ""]));
+
+const evaluateOrder = (values) => {
   const used = new Set();
-  for (const value of Object.values(values)) {
+  const duplicates = new Set();
+  Object.values(values).forEach((value) => {
     if (!value) {
-      continue;
+      return;
     }
     if (used.has(value)) {
-      return true;
+      duplicates.add(value);
     }
     used.add(value);
+  });
+  const mismatches = Object.entries(expectedOrder).filter(([key, value]) => values[key] !== value);
+  return { duplicates, mismatches };
+};
+
+const computeProgress = (values, duplicates) => {
+  let progress = 0;
+  for (const [command, step] of expectedSequence) {
+    const assigned = values[command];
+    if (!assigned || duplicates.has(assigned) || assigned !== step) {
+      break;
+    }
+    progress += 1;
   }
-  return false;
+  return progress;
+};
+
+const updateFlightVisual = (values, duplicates, mismatches) => {
+  const mismatchLookup = new Set(mismatches.map(([command]) => command));
+  flightSteps.forEach((element, command) => {
+    const assigned = values[command];
+    element.dataset.slot = assigned || "";
+    const indexEl = element.querySelector(".step-index");
+    if (indexEl) {
+      indexEl.textContent = assigned || expectedOrder[command];
+    }
+    if (!assigned) {
+      element.dataset.state = "";
+      return;
+    }
+    if (duplicates.has(assigned)) {
+      element.dataset.state = "duplicate";
+      return;
+    }
+    if (!mismatchLookup.has(command)) {
+      element.dataset.state = "correct";
+    } else {
+      element.dataset.state = "pending";
+    }
+  });
+  if (flightPlane) {
+    const progress = computeProgress(values, duplicates);
+    const ratio = expectedSequence.length ? progress / expectedSequence.length : 0;
+    flightPlane.style.setProperty("--flight-progress", ratio.toString());
+  }
 };
 
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
   const data = new FormData(form);
-  const values = Object.fromEntries(Object.keys(expectedOrder).map((key) => [key, data.get(key) || ""]));
-  if (hasDuplicates(values)) {
+  const values = collectValues(data);
+  const { duplicates, mismatches } = evaluateOrder(values);
+  updateFlightVisual(values, duplicates, mismatches);
+  if (duplicates.size) {
     updateBoard("Sequence conflict detected. Remove duplicate slots.", "error");
     return;
   }
-  const mismatches = Object.entries(expectedOrder).filter(([key, value]) => values[key] !== value);
   if (mismatches.length) {
     updateBoard("Transfer aborted. Adjust command ordering.", "error");
     return;
@@ -60,5 +118,19 @@ form?.addEventListener("input", () => {
   if (board.dataset.state === "success") {
     return;
   }
-  updateBoard("Transfer queue idle.");
+  const data = new FormData(form);
+  const values = collectValues(data);
+  const { duplicates, mismatches } = evaluateOrder(values);
+  updateFlightVisual(values, duplicates, mismatches);
+  if (!duplicates.size && !mismatches.length) {
+    updateBoard("Flight plan aligned. Initiate transfer.");
+  } else {
+    updateBoard("Transfer queue idle.");
+  }
 });
+
+if (form) {
+  const values = collectValues(new FormData(form));
+  const { duplicates, mismatches } = evaluateOrder(values);
+  updateFlightVisual(values, duplicates, mismatches);
+}

--- a/madia.new/public/secret/net/ftp-flightdeck/index.html
+++ b/madia.new/public/secret/net/ftp-flightdeck/index.html
@@ -108,6 +108,38 @@
           </fieldset>
           <button type="submit" class="execute-button">Initiate transfer</button>
         </form>
+        <div class="flight-path" aria-hidden="true">
+          <div class="flight-track">
+            <div class="flight-plane"></div>
+            <div class="flight-glow"></div>
+          </div>
+          <div class="flight-steps">
+            <div class="flight-step" data-command="open">
+              <span class="step-index">1</span>
+              <span class="step-label">open</span>
+            </div>
+            <div class="flight-step" data-command="user">
+              <span class="step-index">2</span>
+              <span class="step-label">user</span>
+            </div>
+            <div class="flight-step" data-command="passive">
+              <span class="step-index">3</span>
+              <span class="step-label">passive</span>
+            </div>
+            <div class="flight-step" data-command="cd">
+              <span class="step-index">4</span>
+              <span class="step-label">cd</span>
+            </div>
+            <div class="flight-step" data-command="put">
+              <span class="step-index">5</span>
+              <span class="step-label">put</span>
+            </div>
+            <div class="flight-step" data-command="quit">
+              <span class="step-index">6</span>
+              <span class="step-label">quit</span>
+            </div>
+          </div>
+        </div>
         <div id="status-board" class="status-board" aria-live="polite">Transfer queue idle.</div>
       </section>
     </main>

--- a/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.css
+++ b/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.css
@@ -43,3 +43,93 @@ input[type="text"] {
   color: var(--status-error);
   border-color: var(--status-error);
 }
+
+.terminal-preview {
+  margin-top: 1.5rem;
+  position: relative;
+  background: rgba(5, 14, 24, 0.92);
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  border-radius: 12px;
+  padding: 1rem 1.25rem 1.5rem;
+  overflow: hidden;
+}
+
+.terminal-preview::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(56, 248, 122, 0.1), transparent 60%);
+  pointer-events: none;
+}
+
+.terminal-title {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+  color: rgba(148, 197, 183, 0.75);
+  margin-bottom: 0.65rem;
+}
+
+.terminal-screen {
+  background: rgba(0, 10, 18, 0.85);
+  border-radius: 10px;
+  padding: 0.85rem 1rem;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  min-height: 150px;
+  display: grid;
+  gap: 0.4rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.terminal-line {
+  color: rgba(148, 197, 183, 0.85);
+  font-family: inherit;
+  white-space: pre;
+  transition: color 0.3s ease;
+}
+
+.terminal-line[data-state="ready"] {
+  color: var(--net-text);
+}
+
+.terminal-line[data-state="error"] {
+  color: #ffd9e1;
+}
+
+.terminal-line[data-state="success"] {
+  animation: line-glow 1.6s ease-in-out infinite;
+}
+
+.terminal-cursor {
+  position: absolute;
+  bottom: 1rem;
+  left: 1.25rem;
+  width: 10px;
+  height: 18px;
+  border-radius: 2px;
+  background: rgba(56, 248, 122, 0.8);
+  animation: cursor-blink 1.2s step-end infinite;
+}
+
+@keyframes cursor-blink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  51%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes line-glow {
+  0%,
+  100% {
+    text-shadow: 0 0 8px rgba(56, 248, 122, 0.6);
+  }
+  50% {
+    text-shadow: 0 0 16px rgba(56, 248, 122, 0.85);
+  }
+}

--- a/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.js
+++ b/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.js
@@ -1,5 +1,8 @@
 const form = document.getElementById("gopher-form");
 const board = document.getElementById("status-board");
+const terminalLines = new Map(
+  Array.from(document.querySelectorAll(".terminal-line")).map((element) => [element.dataset.line, element])
+);
 
 const expected = {
   "banner-text": "Library Net Welcome",
@@ -19,12 +22,68 @@ const expected = {
 const updateBoard = (message, state = "idle") => {
   board.textContent = message;
   board.dataset.state = state;
+  terminalLines.forEach((line) => {
+    if (state === "success") {
+      line.dataset.state = "success";
+    }
+  });
+};
+
+const rowFields = {
+  banner: {
+    text: "banner-text",
+    selector: "banner-selector",
+    host: "banner-host",
+    type: "banner-type",
+  },
+  catalog: {
+    text: "catalog-text",
+    selector: "catalog-selector",
+    host: "catalog-host",
+    type: "catalog-type",
+  },
+  zine: {
+    text: "zine-text",
+    selector: "zine-selector",
+    host: "zine-host",
+    type: "zine-type",
+  },
+};
+
+const updateTerminal = (formData, errors = []) => {
+  terminalLines.forEach((line, key) => {
+    const fields = rowFields[key];
+    if (!fields) {
+      return;
+    }
+    const text = (formData.get(fields.text) || "").trim();
+    const selector = (formData.get(fields.selector) || "").trim();
+    const host = (formData.get(fields.host) || "").trim();
+    const type = (formData.get(fields.type) || "").trim();
+    const ready = text && selector && host && type;
+    if (ready) {
+      line.textContent = `${type}${text}\t${selector}\t${host}\t70`;
+    } else {
+      line.textContent = `• waiting for ${key} entry`;
+    }
+    if (board.dataset.state === "success") {
+      line.dataset.state = "success";
+      return;
+    }
+    if (!ready) {
+      line.dataset.state = "";
+      return;
+    }
+    const hasError = errors.some((field) => field.startsWith(key));
+    line.dataset.state = hasError ? "error" : "ready";
+  });
 };
 
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
   const data = new FormData(form);
   const errors = Object.entries(expected).filter(([name, value]) => (data.get(name) || "").trim() !== value);
+  updateTerminal(data, errors.map(([name]) => name));
   if (errors.length) {
     updateBoard("Menu mismatch. Check selector, type, and host fields.", "error");
     return;
@@ -47,5 +106,19 @@ form?.addEventListener("input", () => {
   if (board.dataset.state === "success") {
     return;
   }
-  updateBoard("Awaiting menu entries.");
+  const data = new FormData(form);
+  const errors = Object.entries(expected)
+    .filter(([name, value]) => (data.get(name) || "").trim() !== value)
+    .map(([name]) => name);
+  updateTerminal(data, errors);
+  const ready = Array.from(terminalLines.values()).every((line) => line.dataset.state === "ready");
+  if (ready) {
+    updateBoard("Preview aligned. Save to publish.");
+  } else {
+    updateBoard("Awaiting menu entries.");
+  }
 });
+
+if (form) {
+  updateTerminal(new FormData(form));
+}

--- a/madia.new/public/secret/net/gopher-groundskeeper/index.html
+++ b/madia.new/public/secret/net/gopher-groundskeeper/index.html
@@ -102,6 +102,15 @@
           </fieldset>
           <button type="submit" class="execute-button">Save gophermap</button>
         </form>
+        <div class="terminal-preview" aria-hidden="true">
+          <div class="terminal-title">gophermap preview</div>
+          <div class="terminal-screen" id="terminal-screen">
+            <div class="terminal-line" data-line="banner">• waiting for banner entry</div>
+            <div class="terminal-line" data-line="catalog">• waiting for catalog entry</div>
+            <div class="terminal-line" data-line="zine">• waiting for zine entry</div>
+          </div>
+          <span class="terminal-cursor"></span>
+        </div>
         <div id="status-board" class="status-board" aria-live="polite">Awaiting menu entries.</div>
       </section>
     </main>

--- a/madia.new/public/secret/net/hopline-diagnostics/hopline-diagnostics.css
+++ b/madia.new/public/secret/net/hopline-diagnostics/hopline-diagnostics.css
@@ -50,3 +50,162 @@ select {
   border-color: var(--status-error);
   color: var(--status-error);
 }
+
+.topology-map {
+  margin-top: 1.5rem;
+  background: rgba(3, 15, 26, 0.85);
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  border-radius: 14px;
+  padding: 1.1rem 1.25rem 1.5rem;
+  display: grid;
+  gap: 1rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.topology-map::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top, rgba(56, 248, 122, 0.12), transparent 60%);
+  pointer-events: none;
+}
+
+.router-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.router-card {
+  position: relative;
+  padding: 0.75rem 0.9rem;
+  border-radius: 12px;
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  background: rgba(0, 10, 18, 0.85);
+  display: grid;
+  gap: 0.5rem;
+  justify-items: center;
+}
+
+.router-name {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 197, 183, 0.75);
+}
+
+.router-light {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(255, 95, 109, 0.8);
+  box-shadow: 0 0 0 0 rgba(255, 95, 109, 0.4);
+  animation: router-alert 2s infinite;
+}
+
+.router-card[data-state="ready"] .router-light {
+  background: rgba(56, 248, 122, 0.85);
+  animation: router-stable 1.6s infinite;
+}
+
+.router-card[data-state="error"] .router-light {
+  background: rgba(255, 95, 109, 0.9);
+  animation: router-alert 1.2s infinite;
+}
+
+.prefix-layer {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.prefix-chip {
+  padding: 0.65rem;
+  border-radius: 999px;
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  background: rgba(0, 12, 20, 0.85);
+  text-align: center;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 183, 0.8);
+  transition: transform 0.4s ease, border-color 0.3s ease, color 0.3s ease;
+}
+
+.prefix-chip[data-router="edge-hub"] {
+  grid-column: 1;
+}
+
+.prefix-chip[data-router="studio-loop"] {
+  grid-column: 2;
+}
+
+.prefix-chip[data-router="metro-border"] {
+  grid-column: 3;
+}
+
+.prefix-chip[data-state="ready"] {
+  border-color: rgba(56, 248, 122, 0.55);
+  color: var(--net-text);
+  transform: translateY(-6px);
+}
+
+.prefix-chip[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.5);
+  color: #ffd9e1;
+  animation: chip-alert 1.2s ease-in-out infinite;
+}
+
+.topology-map[data-state="success"] .router-light {
+  background: rgba(56, 248, 122, 0.9);
+  animation: router-stable 1.5s infinite;
+}
+
+.topology-map[data-state="success"] .prefix-chip[data-state="ready"] {
+  animation: chip-glow 1.8s ease-in-out infinite;
+}
+
+@keyframes router-alert {
+  0% {
+    box-shadow: 0 0 0 0 rgba(255, 95, 109, 0.4);
+  }
+  70% {
+    box-shadow: 0 0 0 14px rgba(255, 95, 109, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 95, 109, 0);
+  }
+}
+
+@keyframes router-stable {
+  0% {
+    box-shadow: 0 0 0 0 rgba(56, 248, 122, 0.4);
+  }
+  70% {
+    box-shadow: 0 0 0 12px rgba(56, 248, 122, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(56, 248, 122, 0);
+  }
+}
+
+@keyframes chip-alert {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-4px);
+  }
+}
+
+@keyframes chip-glow {
+  0%,
+  100% {
+    box-shadow: 0 0 12px rgba(56, 248, 122, 0.45);
+  }
+  50% {
+    box-shadow: 0 0 18px rgba(56, 248, 122, 0.75);
+  }
+}

--- a/madia.new/public/secret/net/hopline-diagnostics/hopline-diagnostics.js
+++ b/madia.new/public/secret/net/hopline-diagnostics/hopline-diagnostics.js
@@ -1,5 +1,12 @@
 const form = document.getElementById("route-form");
 const board = document.getElementById("status-board");
+const topologyMap = document.querySelector(".topology-map");
+const prefixChips = new Map(
+  Array.from(document.querySelectorAll(".prefix-chip")).map((element) => [element.dataset.prefix, element])
+);
+const routerCards = new Map(
+  Array.from(document.querySelectorAll(".router-card")).map((element) => [element.dataset.router, element])
+);
 
 const expected = {
   lab: "edge-hub",
@@ -10,12 +17,55 @@ const expected = {
 const updateBoard = (message, state = "idle") => {
   board.textContent = message;
   board.dataset.state = state;
+  if (topologyMap) {
+    topologyMap.dataset.state = state;
+  }
+};
+
+const updateTopology = (formData, mismatches = []) => {
+  const mismatchSet = new Set(mismatches);
+  const mismatchRouters = new Set(mismatches.map((prefix) => expected[prefix]));
+  prefixChips.forEach((chip, prefix) => {
+    const router = formData.get(prefix) || "";
+    if (router) {
+      chip.dataset.router = router;
+    } else {
+      delete chip.dataset.router;
+    }
+    if (board.dataset.state === "success") {
+      chip.dataset.state = "ready";
+      return;
+    }
+    if (!router) {
+      delete chip.dataset.state;
+      return;
+    }
+    chip.dataset.state = mismatchSet.has(prefix) ? "error" : "ready";
+  });
+
+  routerCards.forEach((card, router) => {
+    if (board.dataset.state === "success") {
+      card.dataset.state = "success";
+      return;
+    }
+    const active = Array.from(prefixChips.values()).some(
+      (chip) => chip.dataset.router === router && chip.dataset.state
+    );
+    if (!active) {
+      delete card.dataset.state;
+      return;
+    }
+    card.dataset.state = mismatchRouters.has(router) ? "error" : "ready";
+  });
 };
 
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
   const data = new FormData(form);
-  const mismatches = Object.entries(expected).filter(([key, value]) => data.get(key) !== value);
+  const mismatches = Object.entries(expected)
+    .filter(([key, value]) => data.get(key) !== value)
+    .map(([key]) => key);
+  updateTopology(data, mismatches);
   if (mismatches.length) {
     updateBoard("Traceroute still breaks. Check the mismatched prefixes.", "error");
     return;
@@ -38,5 +88,18 @@ form?.addEventListener("input", () => {
   if (board.dataset.state === "success") {
     return;
   }
-  updateBoard("Routing daemon idle.");
+  const data = new FormData(form);
+  const mismatches = Object.entries(expected)
+    .filter(([key, value]) => data.get(key) !== value)
+    .map(([key]) => key);
+  updateTopology(data, mismatches);
+  if (!mismatches.length) {
+    updateBoard("Routes staged. Commit when ready.");
+  } else {
+    updateBoard("Routing daemon idle.");
+  }
 });
+
+if (form) {
+  updateTopology(new FormData(form));
+}

--- a/madia.new/public/secret/net/hopline-diagnostics/index.html
+++ b/madia.new/public/secret/net/hopline-diagnostics/index.html
@@ -74,6 +74,27 @@ $ traceroute studio.lan
           </fieldset>
           <button type="submit" class="execute-button">Deploy routes</button>
         </form>
+        <div class="topology-map" aria-hidden="true">
+          <div class="router-grid">
+            <div class="router-card" data-router="edge-hub">
+              <span class="router-name">edge-hub</span>
+              <span class="router-light"></span>
+            </div>
+            <div class="router-card" data-router="studio-loop">
+              <span class="router-name">studio-loop</span>
+              <span class="router-light"></span>
+            </div>
+            <div class="router-card" data-router="metro-border">
+              <span class="router-name">metro-border</span>
+              <span class="router-light"></span>
+            </div>
+          </div>
+          <div class="prefix-layer">
+            <div class="prefix-chip" data-prefix="lab">10.20.0.0/16</div>
+            <div class="prefix-chip" data-prefix="studio">172.22.40.0/21</div>
+            <div class="prefix-chip" data-prefix="isp">198.51.100.0/28</div>
+          </div>
+        </div>
         <div id="status-board" class="status-board" aria-live="polite">Routing daemon idle.</div>
       </section>
     </main>

--- a/madia.new/public/secret/net/kernel-forge-20/index.html
+++ b/madia.new/public/secret/net/kernel-forge-20/index.html
@@ -69,6 +69,24 @@
           </fieldset>
           <button type="submit" class="execute-button">make bzImage</button>
         </form>
+        <div class="forge-monitor" aria-hidden="true">
+          <div class="forge-meter">
+            <div class="meter-track">
+              <div class="meter-fill"></div>
+            </div>
+            <span class="meter-label" data-role="meter-label">Compile progress 0%</span>
+          </div>
+          <div class="flag-grid">
+            <span class="flag-chip" data-flag="forwarding">IP forwarding</span>
+            <span class="flag-chip" data-flag="firewall">IP firewalling</span>
+            <span class="flag-chip" data-flag="ipv6">IPv6 trimmed</span>
+          </div>
+          <div class="driver-grid">
+            <span class="driver-chip" data-driver="3c59x">3c59x built-in</span>
+            <span class="driver-chip" data-driver="scsi">SCSI removed</span>
+            <span class="driver-chip" data-driver="sound">Sound removed</span>
+          </div>
+        </div>
         <div class="status-board" id="status-board" aria-live="polite">Awaiting config for make menuconfig…</div>
       </section>
     </main>

--- a/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.css
+++ b/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.css
@@ -14,3 +14,132 @@ body {
 .execute-button {
   margin-top: 0.75rem;
 }
+
+.forge-monitor {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1rem;
+  background: rgba(3, 14, 24, 0.85);
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  border-radius: 14px;
+  padding: 1.25rem 1.5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.forge-monitor::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(140deg, rgba(56, 248, 122, 0.12), transparent 55%);
+  pointer-events: none;
+}
+
+.forge-meter {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.meter-track {
+  position: relative;
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(56, 248, 122, 0.1);
+  overflow: hidden;
+}
+
+.meter-fill {
+  position: absolute;
+  inset: 0;
+  transform-origin: left center;
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0.3), rgba(56, 248, 122, 0.85));
+  transform: scaleX(var(--forge-progress, 0));
+  transition: transform 0.5s ease;
+}
+
+.meter-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 183, 0.75);
+}
+
+.flag-grid,
+.driver-grid {
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.flag-chip,
+.driver-chip {
+  position: relative;
+  padding: 0.65rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  background: rgba(0, 10, 18, 0.85);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  color: rgba(148, 197, 183, 0.75);
+  overflow: hidden;
+  transition: border-color 0.3s ease, color 0.3s ease, transform 0.3s ease;
+}
+
+.flag-chip[data-state="active"],
+.driver-chip[data-state="active"] {
+  border-color: rgba(56, 248, 122, 0.55);
+  color: var(--net-text);
+  transform: translateY(-4px);
+}
+
+.flag-chip[data-state="error"],
+.driver-chip[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.5);
+  color: #ffd9e1;
+  animation: chip-alert 1.2s ease-in-out infinite;
+}
+
+.flag-chip[data-state="idle"],
+.driver-chip[data-state="idle"] {
+  opacity: 0.6;
+}
+
+.forge-monitor[data-state="success"] .meter-fill {
+  animation: forge-pulse 1.6s ease-in-out infinite;
+}
+
+.forge-monitor[data-state="success"] .flag-chip[data-state="active"],
+.forge-monitor[data-state="success"] .driver-chip[data-state="active"] {
+  animation: flag-glow 1.8s ease-in-out infinite;
+}
+
+@keyframes forge-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 16px rgba(56, 248, 122, 0.6);
+  }
+  50% {
+    box-shadow: 0 0 24px rgba(56, 248, 122, 0.85);
+  }
+}
+
+@keyframes flag-glow {
+  0%,
+  100% {
+    box-shadow: 0 0 12px rgba(56, 248, 122, 0.4);
+  }
+  50% {
+    box-shadow: 0 0 18px rgba(56, 248, 122, 0.7);
+  }
+}
+
+@keyframes chip-alert {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-4px);
+  }
+}

--- a/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.js
+++ b/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.js
@@ -1,5 +1,14 @@
 const form = document.getElementById("kernel-form");
 const board = document.getElementById("status-board");
+const monitor = document.querySelector(".forge-monitor");
+const meterFill = monitor?.querySelector(".meter-fill");
+const meterLabel = monitor?.querySelector('[data-role="meter-label"]');
+const flagChips = new Map(
+  Array.from(document.querySelectorAll(".flag-chip")).map((element) => [element.dataset.flag, element])
+);
+const driverChips = new Map(
+  Array.from(document.querySelectorAll(".driver-chip")).map((element) => [element.dataset.driver, element])
+);
 
 const REQUIRED_NETWORK = ["forwarding", "firewall"];
 const OPTIONAL_NETWORK = ["ipv6"];
@@ -9,6 +18,9 @@ const FORBIDDEN_DRIVERS = ["scsi", "sound"];
 const updateBoard = (message, state = "idle") => {
   board.textContent = message;
   board.dataset.state = state;
+  if (monitor) {
+    monitor.dataset.state = state;
+  }
 };
 
 const evaluateKernel = (formData) => {
@@ -42,10 +54,79 @@ const evaluateKernel = (formData) => {
   return issues;
 };
 
+const applyChipState = (chip, isActive, hasIssue) => {
+  if (!chip) {
+    return isActive && !hasIssue ? 1 : 0;
+  }
+  if (board.dataset.state === "success") {
+    chip.dataset.state = "active";
+    return 1;
+  }
+  if (hasIssue) {
+    chip.dataset.state = "error";
+    return 0;
+  }
+  if (isActive) {
+    chip.dataset.state = "active";
+    return 1;
+  }
+  chip.dataset.state = "idle";
+  return 0;
+};
+
+const updateForgeMonitor = (formData, issues = []) => {
+  const network = new Set(formData.getAll("network"));
+  const drivers = new Set(formData.getAll("drivers"));
+  const nicMode = formData.get("nic-mode");
+  const issueLookup = new Set(issues.map((issue) => issue.toLowerCase()));
+
+  let satisfied = 0;
+  satisfied += applyChipState(
+    flagChips.get("forwarding"),
+    network.has("forwarding"),
+    issueLookup.has("enable forwarding")
+  );
+  satisfied += applyChipState(
+    flagChips.get("firewall"),
+    network.has("firewall"),
+    issueLookup.has("enable firewall")
+  );
+  satisfied += applyChipState(
+    flagChips.get("ipv6"),
+    !network.has("ipv6"),
+    issueLookup.has("disable ipv6")
+  );
+  satisfied += applyChipState(
+    driverChips.get("3c59x"),
+    nicMode === REQUIRED_NIC_MODE,
+    issueLookup.has("3c59x mode")
+  );
+  satisfied += applyChipState(
+    driverChips.get("scsi"),
+    !drivers.has("scsi"),
+    issueLookup.has("remove scsi")
+  );
+  satisfied += applyChipState(
+    driverChips.get("sound"),
+    !drivers.has("sound"),
+    issueLookup.has("remove sound")
+  );
+
+  const total = 6;
+  const ratio = total ? Math.max(0, Math.min(1, satisfied / total)) : 0;
+  if (meterFill) {
+    meterFill.style.setProperty("--forge-progress", ratio.toString());
+  }
+  if (meterLabel) {
+    meterLabel.textContent = `Compile progress ${Math.round(ratio * 100)}%`;
+  }
+};
+
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
   const formData = new FormData(form);
   const issues = evaluateKernel(formData);
+  updateForgeMonitor(formData, issues);
   if (issues.length) {
     updateBoard(`Build failed: ${issues.join(", ")}.`, "error");
     return;
@@ -70,9 +151,14 @@ form?.addEventListener("input", () => {
   }
   const formData = new FormData(form);
   const issues = evaluateKernel(formData);
+  updateForgeMonitor(formData, issues);
   if (!issues.length) {
     updateBoard("Config matches memo. make bzImage ready.");
   } else {
     updateBoard("Awaiting config for make menuconfig…");
   }
 });
+
+if (form) {
+  updateForgeMonitor(new FormData(form));
+}

--- a/madia.new/public/secret/net/modem-skunkworks/index.html
+++ b/madia.new/public/secret/net/modem-skunkworks/index.html
@@ -68,6 +68,29 @@
           </fieldset>
           <button type="submit" class="execute-button">Dial now</button>
         </form>
+        <div class="handshake-visual" aria-hidden="true">
+          <div class="signal-track">
+            <div class="signal-wave"></div>
+          </div>
+          <div class="phase-steps">
+            <div class="phase-chip" data-phase="carrier">
+              <span class="phase-index">1</span>
+              <span class="phase-label">Carrier</span>
+            </div>
+            <div class="phase-chip" data-phase="lcp">
+              <span class="phase-index">2</span>
+              <span class="phase-label">LCP</span>
+            </div>
+            <div class="phase-chip" data-phase="auth">
+              <span class="phase-index">3</span>
+              <span class="phase-label">Auth</span>
+            </div>
+            <div class="phase-chip" data-phase="ipcp">
+              <span class="phase-index">4</span>
+              <span class="phase-label">IPCP</span>
+            </div>
+          </div>
+        </div>
         <div class="status-board" id="status-board" aria-live="polite">Modem idle. Awaiting script…</div>
       </section>
     </main>

--- a/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.css
+++ b/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.css
@@ -11,3 +11,129 @@ body {
 .execute-button {
   margin-top: 0.75rem;
 }
+
+.handshake-visual {
+  margin-top: 1.5rem;
+  background: rgba(2, 14, 24, 0.85);
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  border-radius: 14px;
+  padding: 1.2rem 1.4rem;
+  display: grid;
+  gap: 1rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.handshake-visual::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(125deg, rgba(56, 248, 122, 0.12), transparent 50%);
+  pointer-events: none;
+}
+
+.signal-track {
+  position: relative;
+  height: 60px;
+  background: rgba(0, 10, 18, 0.9);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.signal-wave {
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+      90deg,
+      rgba(56, 248, 122, 0.8) 0,
+      rgba(56, 248, 122, 0.8) 6px,
+      transparent 6px,
+      transparent 14px
+    ),
+    linear-gradient(90deg, rgba(56, 248, 122, 0.1), rgba(56, 248, 122, 0.4));
+  transform: translateX(calc(var(--handshake-progress, 0) * 40%));
+  animation: wave-scroll 3s linear infinite;
+}
+
+.phase-steps {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.phase-chip {
+  display: grid;
+  gap: 0.4rem;
+  justify-items: center;
+  padding: 0.65rem 0.5rem;
+  border-radius: 12px;
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  background: rgba(0, 10, 18, 0.85);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: rgba(148, 197, 183, 0.75);
+  position: relative;
+}
+
+.phase-index {
+  display: inline-flex;
+  width: 30px;
+  height: 30px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1px solid rgba(56, 248, 122, 0.35);
+  background: rgba(0, 14, 24, 0.85);
+  font-size: 0.8rem;
+}
+
+.phase-chip[data-state="active"] {
+  border-color: rgba(56, 248, 122, 0.6);
+  color: var(--net-text);
+  box-shadow: 0 0 16px rgba(56, 248, 122, 0.25);
+}
+
+.phase-chip[data-state="pending"] {
+  border-color: rgba(244, 180, 0, 0.5);
+  color: rgba(244, 213, 118, 0.85);
+}
+
+.phase-chip[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.55);
+  color: #ffd9e1;
+  animation: phase-alert 1.2s ease-in-out infinite;
+}
+
+.handshake-visual[data-state="success"] .signal-wave {
+  animation: wave-glow 1.8s ease-in-out infinite;
+}
+
+@keyframes wave-scroll {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: -80px 0;
+  }
+}
+
+@keyframes wave-glow {
+  0%,
+  100% {
+    box-shadow: inset 0 0 20px rgba(56, 248, 122, 0.5);
+  }
+  50% {
+    box-shadow: inset 0 0 32px rgba(56, 248, 122, 0.85);
+  }
+}
+
+@keyframes phase-alert {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-4px);
+  }
+}

--- a/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.js
+++ b/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.js
@@ -1,5 +1,10 @@
 const form = document.getElementById("ppp-form");
 const board = document.getElementById("status-board");
+const handshakeVisual = document.querySelector(".handshake-visual");
+const signalWave = handshakeVisual?.querySelector(".signal-wave");
+const phaseChips = new Map(
+  Array.from(document.querySelectorAll(".phase-chip")).map((element) => [element.dataset.phase, element])
+);
 
 const expectedOrder = {
   carrier: "1",
@@ -8,32 +13,81 @@ const expectedOrder = {
   ipcp: "4",
 };
 
+const expectedPhases = Object.entries(expectedOrder).sort(([, a], [, b]) => Number(a) - Number(b));
+
 const updateBoard = (message, state = "idle") => {
   board.textContent = message;
   board.dataset.state = state;
+  if (handshakeVisual) {
+    handshakeVisual.dataset.state = state;
+  }
 };
 
-const evaluateOrder = (formData) => {
-  const values = Object.fromEntries(Object.keys(expectedOrder).map((key) => [key, formData.get(key) || ""]));
+const collectValues = (formData) =>
+  Object.fromEntries(Object.keys(expectedOrder).map((key) => [key, formData.get(key) || ""]));
+
+const evaluateOrder = (values) => {
+  const used = new Set();
   const duplicates = new Set();
-  const seen = new Map();
-  Object.entries(values).forEach(([key, value]) => {
+  Object.values(values).forEach((value) => {
     if (!value) {
       return;
     }
-    if (seen.has(value)) {
+    if (used.has(value)) {
       duplicates.add(value);
     }
-    seen.set(value, key);
+    used.add(value);
   });
   const mismatches = Object.entries(expectedOrder).filter(([key, value]) => values[key] !== value).map(([key]) => key);
   return { duplicates, mismatches };
 };
 
+const computeProgress = (values, duplicates) => {
+  let progress = 0;
+  for (const [phase, step] of expectedPhases) {
+    const assigned = values[phase];
+    if (!assigned || duplicates.has(assigned) || assigned !== step) {
+      break;
+    }
+    progress += 1;
+  }
+  return progress / expectedPhases.length;
+};
+
+const updateHandshakeVisual = (values, duplicates, mismatches) => {
+  const mismatchSet = new Set(mismatches);
+  phaseChips.forEach((chip, phase) => {
+    const assigned = values[phase];
+    const indexEl = chip.querySelector(".phase-index");
+    if (indexEl) {
+      indexEl.textContent = assigned || expectedOrder[phase];
+    }
+    if (!assigned) {
+      chip.dataset.state = "";
+      return;
+    }
+    if (duplicates.has(assigned)) {
+      chip.dataset.state = "error";
+      return;
+    }
+    if (!mismatchSet.has(phase)) {
+      chip.dataset.state = "active";
+    } else {
+      chip.dataset.state = "pending";
+    }
+  });
+  if (signalWave) {
+    const progressRatio = computeProgress(values, duplicates);
+    signalWave.style.setProperty("--handshake-progress", progressRatio.toString());
+  }
+};
+
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
   const formData = new FormData(form);
-  const { duplicates, mismatches } = evaluateOrder(formData);
+  const values = collectValues(formData);
+  const { duplicates, mismatches } = evaluateOrder(values);
+  updateHandshakeVisual(values, duplicates, mismatches);
   if (duplicates.size) {
     updateBoard(`Modem error: duplicate steps ${Array.from(duplicates).join(", ")}.`, "error");
     return;
@@ -61,10 +115,18 @@ form?.addEventListener("input", () => {
     return;
   }
   const formData = new FormData(form);
-  const { duplicates, mismatches } = evaluateOrder(formData);
+  const values = collectValues(formData);
+  const { duplicates, mismatches } = evaluateOrder(values);
+  updateHandshakeVisual(values, duplicates, mismatches);
   if (!duplicates.size && !mismatches.length) {
     updateBoard("Sequence locked. Dial when ready.");
   } else {
     updateBoard("Modem idle. Awaiting script…");
   }
 });
+
+if (form) {
+  const values = collectValues(new FormData(form));
+  const { duplicates, mismatches } = evaluateOrder(values);
+  updateHandshakeVisual(values, duplicates, mismatches);
+}

--- a/madia.new/public/secret/net/root-zone-relay/index.html
+++ b/madia.new/public/secret/net/root-zone-relay/index.html
@@ -87,6 +87,26 @@
           </fieldset>
           <button type="submit" class="execute-button">Push zone live</button>
         </form>
+        <div class="zone-visual" aria-hidden="true">
+          <div class="zone-core">@</div>
+          <div class="record-ring">
+            <div class="record-chip" data-record="www">
+              <span class="record-name">www</span>
+              <span class="record-type" data-role="type">—</span>
+              <span class="record-value" data-role="value">pending</span>
+            </div>
+            <div class="record-chip" data-record="mail">
+              <span class="record-name">mail</span>
+              <span class="record-type" data-role="type">—</span>
+              <span class="record-value" data-role="value">pending</span>
+            </div>
+            <div class="record-chip" data-record="root">
+              <span class="record-name">@</span>
+              <span class="record-type" data-role="type">—</span>
+              <span class="record-value" data-role="value">pending</span>
+            </div>
+          </div>
+        </div>
         <div class="status-board" id="status-board" aria-live="polite">Awaiting alignment…</div>
       </section>
     </main>

--- a/madia.new/public/secret/net/root-zone-relay/root-zone-relay.css
+++ b/madia.new/public/secret/net/root-zone-relay/root-zone-relay.css
@@ -15,3 +15,159 @@ body {
 .execute-button {
   margin-top: 0.25rem;
 }
+
+.zone-visual {
+  margin-top: 1.5rem;
+  position: relative;
+  background: rgba(3, 14, 24, 0.85);
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  border-radius: 50%;
+  width: clamp(220px, 40vw, 320px);
+  aspect-ratio: 1;
+  margin-inline: auto;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.zone-visual::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: conic-gradient(from 90deg, rgba(56, 248, 122, 0.12), transparent 40%, rgba(56, 248, 122, 0.12));
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+.zone-core {
+  position: relative;
+  z-index: 1;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: rgba(0, 12, 20, 0.85);
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  display: grid;
+  place-items: center;
+  font-size: 1.5rem;
+  color: var(--net-text);
+  box-shadow: 0 0 18px rgba(56, 248, 122, 0.25);
+}
+
+.record-ring {
+  position: absolute;
+  inset: 12%;
+  display: grid;
+  place-items: center;
+  animation: ring-spin 18s linear infinite;
+}
+
+.record-chip {
+  position: absolute;
+  width: 140px;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(0, 10, 18, 0.88);
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.7rem;
+  color: rgba(148, 197, 183, 0.75);
+  transition: transform 0.4s ease, border-color 0.3s ease, color 0.3s ease;
+}
+
+.record-chip[data-record="www"] {
+  transform: rotate(0deg) translateY(-115px);
+}
+
+.record-chip[data-record="mail"] {
+  transform: rotate(120deg) translateY(-115px);
+}
+
+.record-chip[data-record="root"] {
+  transform: rotate(240deg) translateY(-115px);
+}
+
+.record-chip::after {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  border: 1px dashed rgba(56, 248, 122, 0.2);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.record-name {
+  display: block;
+  font-size: 0.75rem;
+  margin-bottom: 0.25rem;
+  color: rgba(148, 197, 183, 0.9);
+}
+
+.record-type {
+  display: block;
+  font-size: 0.7rem;
+  color: rgba(244, 213, 118, 0.85);
+  margin-bottom: 0.15rem;
+}
+
+.record-value {
+  display: block;
+  font-size: 0.65rem;
+  color: rgba(148, 197, 183, 0.75);
+}
+
+.record-chip[data-state="ready"] {
+  border-color: rgba(56, 248, 122, 0.6);
+  color: var(--net-text);
+  transform: translateY(-110px) scale(1.05);
+}
+
+.record-chip[data-state="ready"]::after {
+  opacity: 1;
+}
+
+.record-chip[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.55);
+  color: #ffd9e1;
+  animation: record-alert 1.4s ease-in-out infinite;
+}
+
+.zone-visual[data-state="success"] .record-ring {
+  animation-duration: 12s;
+}
+
+.zone-visual[data-state="success"] .record-chip[data-state="ready"] {
+  animation: record-glow 1.8s ease-in-out infinite;
+}
+
+@keyframes ring-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes record-alert {
+  0%,
+  100% {
+    transform: translateY(-115px);
+  }
+  50% {
+    transform: translateY(-108px);
+  }
+}
+
+@keyframes record-glow {
+  0%,
+  100% {
+    box-shadow: 0 0 14px rgba(56, 248, 122, 0.45);
+  }
+  50% {
+    box-shadow: 0 0 22px rgba(56, 248, 122, 0.75);
+  }
+}

--- a/madia.new/public/secret/net/stream-parser-depot/index.html
+++ b/madia.new/public/secret/net/stream-parser-depot/index.html
@@ -68,6 +68,19 @@ rad_reply: Access-Reject packet
           </fieldset>
           <button type="submit" class="execute-button">Run pipeline</button>
         </form>
+        <div class="pipeline-visual" aria-hidden="true">
+          <div class="pipeline-stage" data-stage="filter">
+            <div class="stage-title">Filter</div>
+            <div class="stage-output" data-role="filter-output">Select a filter snippet</div>
+          </div>
+          <div class="pipeline-connector">
+            <span class="data-packet"></span>
+          </div>
+          <div class="pipeline-stage" data-stage="format">
+            <div class="stage-title">Format</div>
+            <div class="stage-output" data-role="format-output">Awaiting formatter</div>
+          </div>
+        </div>
         <div id="status-board" class="status-board" aria-live="polite">Awaiting command pair.</div>
       </section>
     </main>

--- a/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.css
+++ b/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.css
@@ -43,3 +43,105 @@ select {
   color: var(--status-error);
   border-color: var(--status-error);
 }
+
+.pipeline-visual {
+  margin-top: 1.5rem;
+  background: rgba(3, 15, 26, 0.85);
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  border-radius: 14px;
+  padding: 1.1rem 1.4rem;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 1rem;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.pipeline-visual::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(56, 248, 122, 0.12), transparent 60%);
+  pointer-events: none;
+}
+
+.pipeline-stage {
+  display: grid;
+  gap: 0.6rem;
+  background: rgba(0, 12, 20, 0.85);
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  border-radius: 12px;
+  padding: 0.9rem 1rem;
+  position: relative;
+  min-height: 130px;
+}
+
+.stage-title {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+  color: rgba(148, 197, 183, 0.85);
+}
+
+.stage-output {
+  font-family: inherit;
+  font-size: 0.85rem;
+  color: rgba(148, 197, 183, 0.75);
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.pipeline-connector {
+  position: relative;
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  border: 1px dashed rgba(56, 248, 122, 0.25);
+  display: grid;
+  place-items: center;
+}
+
+.data-packet {
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  background: rgba(56, 248, 122, 0.85);
+  box-shadow: 0 0 12px rgba(56, 248, 122, 0.4);
+  animation: packet-spin 3s linear infinite;
+}
+
+.pipeline-stage[data-state="ready"] {
+  border-color: rgba(56, 248, 122, 0.55);
+  box-shadow: 0 0 18px rgba(56, 248, 122, 0.25);
+}
+
+.pipeline-stage[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.5);
+  box-shadow: 0 0 18px rgba(255, 95, 109, 0.25);
+}
+
+.pipeline-visual[data-state="success"] .data-packet {
+  animation: packet-glow 1.6s ease-in-out infinite;
+}
+
+@keyframes packet-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes packet-glow {
+  0%,
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 16px rgba(56, 248, 122, 0.55);
+  }
+  50% {
+    transform: scale(1.15);
+    box-shadow: 0 0 24px rgba(56, 248, 122, 0.85);
+  }
+}

--- a/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.js
+++ b/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.js
@@ -1,5 +1,12 @@
 const form = document.getElementById("parser-form");
 const board = document.getElementById("status-board");
+const pipelineVisual = document.querySelector(".pipeline-visual");
+const filterOutput = pipelineVisual?.querySelector('[data-role="filter-output"]');
+const formatOutput = pipelineVisual?.querySelector('[data-role="format-output"]');
+const filterStage = pipelineVisual?.querySelector('[data-stage="filter"]');
+const formatStage = pipelineVisual?.querySelector('[data-stage="format"]');
+const filterSelect = form?.querySelector('select[name="filter"]');
+const formatSelect = form?.querySelector('select[name="format"]');
 
 const expected = {
   filter: "sed-block",
@@ -9,14 +16,58 @@ const expected = {
 const updateBoard = (message, state = "idle") => {
   board.textContent = message;
   board.dataset.state = state;
+  if (pipelineVisual) {
+    pipelineVisual.dataset.state = state;
+  }
+};
+
+const optionLabel = (select, value) => {
+  if (!select || !value) {
+    return "";
+  }
+  const option = Array.from(select.options).find((item) => item.value === value);
+  return option ? option.textContent.trim() : value;
+};
+
+const updatePipeline = (formData, mismatches = []) => {
+  const filterValue = formData.get("filter") || "";
+  const formatValue = formData.get("format") || "";
+  if (filterOutput) {
+    filterOutput.textContent = filterValue ? optionLabel(filterSelect, filterValue) : "Select a filter snippet";
+  }
+  if (formatOutput) {
+    formatOutput.textContent = formatValue ? optionLabel(formatSelect, formatValue) : "Awaiting formatter";
+  }
+  if (filterStage) {
+    if (board.dataset.state === "success") {
+      filterStage.dataset.state = "ready";
+    } else if (!filterValue) {
+      delete filterStage.dataset.state;
+    } else {
+      filterStage.dataset.state = mismatches.includes("filter") ? "error" : "ready";
+    }
+  }
+  if (formatStage) {
+    if (board.dataset.state === "success") {
+      formatStage.dataset.state = "ready";
+    } else if (!formatValue) {
+      delete formatStage.dataset.state;
+    } else {
+      formatStage.dataset.state = mismatches.includes("format") ? "error" : "ready";
+    }
+  }
 };
 
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
   const data = new FormData(form);
-  const filter = data.get("filter");
-  const format = data.get("format");
-  if (filter !== expected.filter || format !== expected.format) {
+  const filter = data.get("filter") || "";
+  const format = data.get("format") || "";
+  const mismatches = Object.entries(expected)
+    .filter(([key, value]) => data.get(key) !== value)
+    .map(([key]) => key);
+  updatePipeline(data, mismatches);
+  if (mismatches.length) {
     updateBoard("Output still messy. Try a tighter selector or trim.", "error");
     return;
   }
@@ -39,9 +90,21 @@ form?.addEventListener("input", () => {
     return;
   }
   const data = new FormData(form);
+  const mismatches = Object.entries(expected)
+    .filter(([key, value]) => data.get(key) !== value)
+    .map(([key]) => key);
+  updatePipeline(data, mismatches);
   if (data.get("filter") && data.get("format")) {
     updateBoard("Preview pipeline staged.");
   } else {
     updateBoard("Awaiting command pair.");
   }
 });
+
+if (form) {
+  const data = new FormData(form);
+  const mismatches = Object.entries(expected)
+    .filter(([key, value]) => data.get(key) !== value)
+    .map(([key]) => key);
+  updatePipeline(data, mismatches);
+}


### PR DESCRIPTION
## Summary
- add bespoke visualizers to each Net minigame to highlight routing, caching, and record-state changes
- animate sequencing and text-entry games with live previews and progress feedback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5a3becb588328bdfd3199d63b252e