### PR TITLE
Add telemetry meters to every Net minigame

### DIFF
--- a/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.css
+++ b/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.css
@@ -5,3 +5,332 @@ body {
 .execute-button {
   margin-top: 0.75rem;
 }
+
+.topology-display {
+  margin-top: 1.25rem;
+  position: relative;
+  border: 1px solid rgba(88, 255, 200, 0.35);
+  background: radial-gradient(circle at center, rgba(10, 40, 60, 0.8), rgba(0, 12, 20, 0.95));
+  min-height: 220px;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: inset 0 0 18px rgba(0, 0, 0, 0.4);
+}
+
+.router {
+  position: absolute;
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  border: 1px solid rgba(100, 255, 210, 0.4);
+  display: grid;
+  place-items: center;
+  text-align: center;
+  background: rgba(0, 18, 28, 0.9);
+  box-shadow: 0 0 18px rgba(18, 140, 120, 0.2);
+  transition: transform 0.4s ease, border-color 0.3s ease;
+}
+
+.router-label {
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.router-pulse {
+  position: absolute;
+  inset: 14px;
+  border-radius: 50%;
+  border: 1px solid rgba(90, 255, 200, 0.25);
+  background: radial-gradient(circle, rgba(68, 255, 200, 0.12), transparent 60%);
+  transition: border-color 0.3s ease, background 0.3s ease, opacity 0.3s ease;
+}
+
+.router[data-node="backbone"] {
+  top: 50%;
+  left: 6%;
+  transform: translateY(-50%);
+}
+
+.router[data-node="transit"] {
+  top: 22%;
+  right: 6%;
+}
+
+.router[data-node="community"] {
+  bottom: 10%;
+  right: 18%;
+}
+
+.router[data-state="good"] {
+  border-color: rgba(110, 255, 210, 0.9);
+  box-shadow: 0 0 20px rgba(110, 255, 210, 0.35);
+}
+
+.router[data-state="good"] .router-pulse {
+  border-color: rgba(110, 255, 210, 0.8);
+  background: radial-gradient(circle, rgba(110, 255, 210, 0.35), transparent 70%);
+  animation: router-pulse 1.6s infinite;
+}
+
+.router[data-state="warn"] {
+  border-color: rgba(255, 166, 0, 0.8);
+}
+
+.router[data-state="warn"] .router-pulse {
+  border-color: rgba(255, 166, 0, 0.7);
+  background: radial-gradient(circle, rgba(255, 166, 0, 0.28), transparent 70%);
+  animation: router-warn 0.7s steps(2, jump-none) infinite;
+}
+
+.router[data-state="idle"] .router-pulse {
+  opacity: 0.6;
+}
+
+.link {
+  position: absolute;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(68, 255, 200, 0.05), rgba(68, 255, 200, 0.3));
+  box-shadow: 0 0 12px rgba(68, 255, 200, 0.2);
+  transition: opacity 0.3s ease, box-shadow 0.3s ease;
+  overflow: hidden;
+}
+
+.link::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(110, 255, 210, 0.4) 50%,
+    transparent 100%
+  );
+  background-size: 220%;
+  transform: translateX(-100%);
+  animation: link-flow 3s linear infinite;
+  opacity: 0.8;
+}
+
+.link[data-link="fiber"] {
+  width: 45%;
+  height: 16px;
+  top: 46%;
+  left: 23%;
+}
+
+.link[data-link="relay"] {
+  width: 42%;
+  height: 12px;
+  top: 30%;
+  left: 30%;
+}
+
+.link[data-link="blackhole"] {
+  width: 28%;
+  height: 12px;
+  bottom: 18%;
+  right: 26%;
+  transform: rotate(35deg);
+}
+
+.link[data-state="idle"] {
+  opacity: 0.4;
+}
+
+.link[data-state="good"] {
+  box-shadow: 0 0 18px rgba(110, 255, 210, 0.45);
+}
+
+.link[data-state="good"]::after {
+  animation-duration: 1.6s;
+}
+
+.link[data-state="warn"] {
+  box-shadow: 0 0 14px rgba(255, 166, 0, 0.4);
+}
+
+.link[data-state="warn"]::after {
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 166, 0, 0.5) 50%,
+    transparent 100%
+  );
+  animation-duration: 1.4s;
+}
+
+.topology-display[data-flow="off"] .packet {
+  animation-play-state: paused;
+  opacity: 0.2;
+}
+
+.topology-display[data-flow="on"] {
+  box-shadow: inset 0 0 18px rgba(0, 0, 0, 0.35), 0 0 24px rgba(110, 255, 210, 0.15);
+}
+
+.packet-sim {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.packet {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--neon-green);
+  filter: drop-shadow(0 0 6px rgba(68, 255, 200, 0.8));
+  animation: packet-drift 3.2s linear infinite;
+}
+
+.packet:nth-child(2) {
+  animation-delay: 1.1s;
+}
+
+.packet:nth-child(3) {
+  animation-delay: 2.2s;
+}
+
+@keyframes router-pulse {
+  0% {
+    transform: scale(0.94);
+    opacity: 0.75;
+  }
+  50% {
+    transform: scale(1.03);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(0.94);
+    opacity: 0.75;
+  }
+}
+
+@keyframes router-warn {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes link-flow {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes packet-drift {
+  0% {
+    transform: translate(20px, 90px);
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  50% {
+    transform: translate(190px, 30px);
+  }
+  90% {
+    opacity: 1;
+    transform: translate(300px, -10px);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(330px, -30px);
+  }
+}
+
+.telemetry-gauge {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translate(-50%, 50%);
+  width: min(320px, 80%);
+  padding: 1rem 1.25rem 1.5rem;
+  border-radius: 20px;
+  background: linear-gradient(180deg, rgba(6, 32, 48, 0.95), rgba(2, 16, 24, 0.95));
+  border: 1px solid rgba(110, 255, 210, 0.25);
+  box-shadow: 0 0 22px rgba(20, 160, 130, 0.2);
+  --progress: 0;
+}
+
+.gauge-ring {
+  position: relative;
+  height: 16px;
+  border-radius: 999px;
+  background: rgba(6, 56, 72, 0.8);
+  overflow: hidden;
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.6);
+}
+
+.gauge-fill {
+  position: absolute;
+  inset: 0;
+  transform-origin: left center;
+  transform: scaleX(var(--progress));
+  background: linear-gradient(90deg, rgba(68, 255, 200, 0.2), rgba(68, 255, 200, 0.9));
+  transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.gauge-glow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at right, rgba(68, 255, 200, 0.35), transparent 65%);
+  mix-blend-mode: screen;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.telemetry-gauge[data-state="warming"] .gauge-glow {
+  opacity: 0.4;
+}
+
+.telemetry-gauge[data-state="locked"] .gauge-glow {
+  opacity: 0.8;
+}
+
+.gauge-readout {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 0.75rem;
+  font-family: var(--mono-font);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.gauge-value {
+  font-size: 1.1rem;
+  color: var(--neon-green);
+  text-shadow: 0 0 12px rgba(68, 255, 200, 0.55);
+}
+
+.gauge-markers {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.75rem;
+}
+
+.gauge-marker {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 1px solid rgba(68, 255, 200, 0.25);
+  box-shadow: 0 0 0 rgba(68, 255, 200, 0.2);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+  background: rgba(6, 24, 30, 0.85);
+}
+
+.gauge-marker[data-active="on"] {
+  background: var(--neon-green);
+  box-shadow: 0 0 12px rgba(68, 255, 200, 0.65);
+}

--- a/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.js
+++ b/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.js
@@ -1,15 +1,83 @@
 const form = document.getElementById("bgp-form");
 const board = document.getElementById("status-board");
+const topology = document.querySelector(".topology-display");
+const nodeIndicators = {
+  backbone: document.querySelector('[data-node="backbone"]'),
+  transit: document.querySelector('[data-node="transit"]'),
+  community: document.querySelector('[data-node="community"]'),
+};
+const linkIndicators = {
+  fiber: document.querySelector('[data-link="fiber"]'),
+  relay: document.querySelector('[data-link="relay"]'),
+  blackhole: document.querySelector('[data-link="blackhole"]'),
+};
+const gauge = document.querySelector(".telemetry-gauge");
+const gaugeValue = document.getElementById("bgp-gauge-value");
+const gaugeMarkers = gauge ? gauge.querySelectorAll(".gauge-marker") : [];
 
 const expected = {
   "local-pref": "raise",
   "as-path": "double",
   community: "blackhole",
 };
+const totalChecks = Object.keys(expected).length;
 
 const updateBoard = (message, state = "idle") => {
   board.textContent = message;
   board.dataset.state = state;
+};
+
+const applyIndicatorState = (element, state) => {
+  if (!element) {
+    return;
+  }
+  element.dataset.state = state;
+};
+
+const deriveState = (value, matches) => {
+  if (!value) {
+    return "idle";
+  }
+  return matches ? "good" : "warn";
+};
+
+const updateVisual = (formData) => {
+  const localPref = formData.get("local-pref") || "";
+  const asPath = formData.get("as-path") || "";
+  const communityValue = formData.get("community") || "";
+
+  const matches = {
+    backbone: localPref === expected["local-pref"],
+    transit: asPath === expected["as-path"],
+    community: communityValue === expected.community,
+  };
+  const matchCount = Object.values(matches).filter(Boolean).length;
+  const ratio = totalChecks ? matchCount / totalChecks : 0;
+
+  applyIndicatorState(nodeIndicators.backbone, deriveState(localPref, matches.backbone));
+  applyIndicatorState(nodeIndicators.transit, deriveState(asPath, matches.transit));
+  applyIndicatorState(nodeIndicators.community, deriveState(communityValue, matches.community));
+
+  applyIndicatorState(linkIndicators.fiber, deriveState(localPref, matches.backbone));
+  applyIndicatorState(linkIndicators.relay, deriveState(asPath, matches.transit));
+  applyIndicatorState(linkIndicators.blackhole, deriveState(communityValue, matches.community));
+
+  if (topology) {
+    const allGood = matches.backbone && matches.transit && matches.community;
+    topology.dataset.flow = allGood ? "on" : "off";
+  }
+
+  if (gauge) {
+    gauge.style.setProperty("--progress", String(ratio));
+    gauge.dataset.state = matchCount === totalChecks ? "locked" : matchCount > 0 ? "warming" : "idle";
+    gauge.dataset.progress = String(matchCount);
+  }
+  gaugeMarkers.forEach((marker, index) => {
+    marker.dataset.active = index < matchCount ? "on" : "off";
+  });
+  if (gaugeValue) {
+    gaugeValue.textContent = `${Math.round(ratio * 100)}%`;
+  }
 };
 
 const evaluatePolicy = (formData) => {
@@ -22,6 +90,7 @@ const evaluatePolicy = (formData) => {
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
   const formData = new FormData(form);
+  updateVisual(formData);
   const mismatches = evaluatePolicy(formData);
   if (mismatches.length) {
     updateBoard(`Route map rejected: fix ${mismatches.join(", ")}.`, "error");
@@ -46,6 +115,7 @@ form?.addEventListener("input", () => {
     return;
   }
   const formData = new FormData(form);
+  updateVisual(formData);
   const mismatches = evaluatePolicy(formData);
   if (!mismatches.length) {
     updateBoard("Policy ready. Deploy to routers.");
@@ -53,3 +123,7 @@ form?.addEventListener("input", () => {
     updateBoard("Session flapping. Apply damping plan…");
   }
 });
+
+if (form) {
+  updateVisual(new FormData(form));
+}

--- a/madia.new/public/secret/net/borderline-broadcast/index.html
+++ b/madia.new/public/secret/net/borderline-broadcast/index.html
@@ -51,6 +51,43 @@
           <button type="submit" class="execute-button">Deploy policies</button>
         </form>
         <div class="status-board" id="status-board" aria-live="polite">Session flapping. Apply damping plan…</div>
+        <div class="topology-display" aria-hidden="true">
+          <div class="router" data-node="backbone">
+            <span class="router-label">Backbone-1</span>
+            <span class="router-pulse"></span>
+          </div>
+          <div class="router" data-node="transit">
+            <span class="router-label">Transit Backup</span>
+            <span class="router-pulse"></span>
+          </div>
+          <div class="router" data-node="community">
+            <span class="router-label">Community 64512:90</span>
+            <span class="router-pulse"></span>
+          </div>
+          <div class="link" data-link="fiber"></div>
+          <div class="link" data-link="relay"></div>
+          <div class="link" data-link="blackhole"></div>
+          <div class="packet-sim">
+            <div class="packet" aria-hidden="true"></div>
+            <div class="packet" aria-hidden="true"></div>
+            <div class="packet" aria-hidden="true"></div>
+          </div>
+          <div class="telemetry-gauge" aria-hidden="true">
+            <div class="gauge-ring">
+              <span class="gauge-fill"></span>
+              <span class="gauge-glow"></span>
+            </div>
+            <div class="gauge-readout">
+              <span class="gauge-label">Signal integrity</span>
+              <span class="gauge-value" id="bgp-gauge-value">0%</span>
+            </div>
+            <div class="gauge-markers">
+              <span class="gauge-marker" data-slot="1"></span>
+              <span class="gauge-marker" data-slot="2"></span>
+              <span class="gauge-marker" data-slot="3"></span>
+            </div>
+          </div>
+        </div>
       </section>
     </main>
     <footer>Peering etiquette keeps the network breathing.</footer>

--- a/madia.new/public/secret/net/cache-cascade/cache-cascade.css
+++ b/madia.new/public/secret/net/cache-cascade/cache-cascade.css
@@ -19,3 +19,240 @@ body {
 .execute-button {
   margin-top: 0.75rem;
 }
+
+.stream-visual {
+  margin-top: 1.25rem;
+  display: grid;
+  gap: 1rem;
+  position: relative;
+  padding: 1rem;
+  border: 1px solid rgba(110, 255, 210, 0.3);
+  background: linear-gradient(135deg, rgba(4, 30, 38, 0.8), rgba(0, 12, 20, 0.95));
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.stream-visual[data-flow="on"] {
+  border-color: rgba(110, 255, 210, 0.55);
+  box-shadow: 0 0 20px rgba(110, 255, 210, 0.18);
+}
+
+.stream-meter {
+  padding: 0.6rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(0, 18, 26, 0.88);
+  border: 1px solid rgba(110, 255, 210, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.5);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.stream-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.stream-tag {
+  color: rgba(198, 234, 232, 0.7);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+}
+
+.meter-shell {
+  position: relative;
+  height: 12px;
+  background: rgba(4, 40, 52, 0.9);
+  border-radius: 999px;
+  overflow: hidden;
+  border: 1px solid rgba(110, 255, 210, 0.25);
+}
+
+.meter-fill {
+  position: absolute;
+  inset: 0;
+  display: block;
+  background: linear-gradient(90deg, rgba(68, 255, 200, 0.2), rgba(68, 255, 200, 0.85));
+  transform-origin: left center;
+  transform: scaleX(var(--fill, 0));
+  transition: transform 0.5s ease;
+}
+
+.stream-meter[data-state="idle"] .meter-fill {
+  --fill: 0.05;
+  opacity: 0.45;
+}
+
+.stream-meter[data-state="partial"] .meter-fill {
+  --fill: 0.45;
+  opacity: 0.7;
+}
+
+.stream-meter[data-state="warn"] {
+  border-color: rgba(255, 166, 0, 0.5);
+}
+
+.stream-meter[data-state="warn"] .meter-fill {
+  --fill: 0.7;
+  background: linear-gradient(90deg, rgba(255, 166, 0, 0.15), rgba(255, 166, 0, 0.8));
+  animation: meter-flicker 0.7s steps(2, jump-none) infinite;
+}
+
+.stream-meter[data-state="good"] {
+  border-color: rgba(110, 255, 210, 0.6);
+  box-shadow: 0 0 14px rgba(110, 255, 210, 0.2);
+}
+
+.stream-meter[data-state="good"] .meter-fill {
+  --fill: 1;
+  animation: meter-flow 1.6s linear infinite;
+}
+
+.stream-flow {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.flow-burst {
+  position: absolute;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(68, 255, 200, 0.6), transparent 65%);
+  filter: blur(0.4px);
+  animation: burst 3.4s linear infinite;
+}
+
+.flow-burst:nth-child(1) {
+  top: 18%;
+  left: 12%;
+}
+
+.flow-burst:nth-child(2) {
+  bottom: 18%;
+  left: 32%;
+  animation-delay: 1.1s;
+}
+
+.flow-burst:nth-child(3) {
+  top: 32%;
+  right: 10%;
+  animation-delay: 2.2s;
+}
+
+.stream-visual[data-flow="off"] .flow-burst {
+  animation-play-state: paused;
+  opacity: 0.15;
+}
+
+@keyframes meter-flow {
+  0% {
+    transform: scaleX(0.35);
+  }
+  50% {
+    transform: scaleX(1);
+  }
+  100% {
+    transform: scaleX(0.35);
+  }
+}
+
+@keyframes meter-flicker {
+  0%,
+  100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes burst {
+  0% {
+    transform: scale(0.5) translateX(-8px);
+    opacity: 0;
+  }
+  20% {
+    opacity: 0.8;
+  }
+  60% {
+    transform: scale(1.1) translateX(26px);
+    opacity: 0.6;
+  }
+  100% {
+    transform: scale(0.5) translateX(56px);
+    opacity: 0;
+  }
+}
+
+.surge-monitor {
+  position: relative;
+  margin-top: 0.25rem;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  background: rgba(2, 18, 28, 0.9);
+  border: 1px solid rgba(110, 255, 210, 0.2);
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.65);
+  --progress: 0;
+}
+
+.surge-monitor[data-state="warming"] {
+  border-color: rgba(110, 255, 210, 0.35);
+  box-shadow: 0 0 18px rgba(68, 255, 200, 0.22);
+}
+
+.surge-monitor[data-state="steady"] {
+  border-color: rgba(110, 255, 210, 0.55);
+  box-shadow: 0 0 24px rgba(68, 255, 200, 0.28);
+}
+
+.surge-label {
+  display: block;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(198, 234, 232, 0.7);
+}
+
+.surge-bar {
+  margin-top: 0.5rem;
+  position: relative;
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(6, 50, 62, 0.85);
+  overflow: hidden;
+}
+
+.surge-fill {
+  position: absolute;
+  inset: 0;
+  transform-origin: left center;
+  transform: scaleX(var(--progress));
+  background: linear-gradient(90deg, rgba(68, 255, 200, 0.3), rgba(68, 255, 200, 0.85));
+  transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.surge-lights {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.6rem;
+}
+
+.surge-dot {
+  flex: 1;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(6, 32, 40, 0.9);
+  border: 1px solid rgba(110, 255, 210, 0.25);
+  box-shadow: 0 0 0 rgba(110, 255, 210, 0.2);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.surge-dot[data-active="on"] {
+  background: var(--neon-green);
+  box-shadow: 0 0 14px rgba(68, 255, 200, 0.65);
+}

--- a/madia.new/public/secret/net/cache-cascade/cache-cascade.js
+++ b/madia.new/public/secret/net/cache-cascade/cache-cascade.js
@@ -1,5 +1,14 @@
 const form = document.getElementById("cache-form");
 const board = document.getElementById("status-board");
+const streamVisual = document.querySelector(".stream-visual");
+const meterLookup = {
+  static: document.querySelector('[data-stream="static"]'),
+  cms: document.querySelector('[data-stream="cms"]'),
+  mirror: document.querySelector('[data-stream="mirror"]'),
+};
+const surgeMonitor = document.querySelector(".surge-monitor");
+const surgeFill = surgeMonitor?.querySelector(".surge-fill");
+const surgeDots = surgeMonitor ? surgeMonitor.querySelectorAll(".surge-dot") : [];
 
 const expected = {
   static: { route: "parent", ttl: "60" },
@@ -10,6 +19,61 @@ const expected = {
 const updateBoard = (message, state = "idle") => {
   board.textContent = message;
   board.dataset.state = state;
+};
+
+const setMeterState = (key, state) => {
+  const meter = meterLookup[key];
+  if (!meter) {
+    return;
+  }
+  meter.dataset.state = state;
+};
+
+const updateStreamVisual = (formData) => {
+  let allGood = true;
+  let correctStreams = 0;
+  Object.entries(expected).forEach(([key, config]) => {
+    const route = formData.get(key) || "";
+    const ttl = formData.get(`${key}-ttl`) || "";
+    let state = "idle";
+    if (!route && !ttl) {
+      state = "idle";
+      allGood = false;
+    } else if ((route && !ttl) || (!route && ttl)) {
+      state = "partial";
+      allGood = false;
+    } else if (route === config.route && ttl === config.ttl) {
+      state = "good";
+      correctStreams += 1;
+    } else {
+      state = "warn";
+      allGood = false;
+    }
+    setMeterState(key, state);
+  });
+
+  if (streamVisual) {
+    streamVisual.dataset.flow = allGood ? "on" : "off";
+  }
+
+  const ratio = Object.keys(expected).length
+    ? correctStreams / Object.keys(expected).length
+    : 0;
+  if (surgeMonitor) {
+    surgeMonitor.style.setProperty("--progress", String(ratio));
+    surgeMonitor.dataset.progress = String(correctStreams);
+    if (correctStreams === Object.keys(expected).length) {
+      surgeMonitor.dataset.state = "steady";
+    } else if (correctStreams > 0) {
+      surgeMonitor.dataset.state = "warming";
+    } else {
+      surgeMonitor.dataset.state = "idle";
+    }
+  }
+  surgeDots.forEach((dot, index) => {
+    dot.dataset.active = index < correctStreams ? "on" : "off";
+  });
+  surgeFill?.style.setProperty("--progress", String(ratio));
 };
 
 const evaluateCache = (formData) => {
@@ -27,6 +91,7 @@ const evaluateCache = (formData) => {
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
   const formData = new FormData(form);
+  updateStreamVisual(formData);
   const mismatches = evaluateCache(formData);
   if (mismatches.length) {
     updateBoard(`Hierarchy rejected: adjust ${mismatches.join(", ")}.`, "error");
@@ -51,6 +116,7 @@ form?.addEventListener("input", () => {
     return;
   }
   const formData = new FormData(form);
+  updateStreamVisual(formData);
   const mismatches = evaluateCache(formData);
   if (!mismatches.length) {
     updateBoard("Hierarchy ready. Commit to squid.conf.");
@@ -58,3 +124,7 @@ form?.addEventListener("input", () => {
     updateBoard("Cache hit ratio falling…");
   }
 });
+
+if (form) {
+  updateStreamVisual(new FormData(form));
+}

--- a/madia.new/public/secret/net/cache-cascade/index.html
+++ b/madia.new/public/secret/net/cache-cascade/index.html
@@ -75,6 +75,45 @@
         </form>
         <div class="status-board" id="status-board" aria-live="polite">Cache hit ratio falling…
         </div>
+        <div class="stream-visual" aria-hidden="true">
+          <div class="stream-meter" data-stream="static">
+            <div class="stream-header">
+              <span class="stream-label">Static assets</span>
+              <span class="stream-tag">cdn.partner.net</span>
+            </div>
+            <div class="meter-shell"><span class="meter-fill"></span></div>
+          </div>
+          <div class="stream-meter" data-stream="cms">
+            <div class="stream-header">
+              <span class="stream-label">CMS console</span>
+              <span class="stream-tag">cms.local</span>
+            </div>
+            <div class="meter-shell"><span class="meter-fill"></span></div>
+          </div>
+          <div class="stream-meter" data-stream="mirror">
+            <div class="stream-header">
+              <span class="stream-label">Software mirror</span>
+              <span class="stream-tag">mirror.archive</span>
+            </div>
+            <div class="meter-shell"><span class="meter-fill"></span></div>
+          </div>
+          <div class="stream-flow" aria-hidden="true">
+            <span class="flow-burst"></span>
+            <span class="flow-burst"></span>
+            <span class="flow-burst"></span>
+          </div>
+          <div class="surge-monitor" aria-hidden="true">
+            <span class="surge-label">Cache pressure</span>
+            <div class="surge-bar">
+              <span class="surge-fill"></span>
+            </div>
+            <div class="surge-lights">
+              <span class="surge-dot" data-index="0"></span>
+              <span class="surge-dot" data-index="1"></span>
+              <span class="surge-dot" data-index="2"></span>
+            </div>
+          </div>
+        </div>
       </section>
     </main>
     <footer>Remember: always warm the cache before the press release.</footer>

--- a/madia.new/public/secret/net/daemon-handshake/daemon-handshake.css
+++ b/madia.new/public/secret/net/daemon-handshake/daemon-handshake.css
@@ -14,3 +14,213 @@ body {
 .execute-button {
   margin-top: 0.5rem;
 }
+
+.rack-visual {
+  margin-top: 1.25rem;
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+  padding: 1.25rem 1rem 1.5rem;
+  border-radius: 18px;
+  background: linear-gradient(160deg, rgba(4, 28, 36, 0.85), rgba(0, 10, 16, 0.95));
+  border: 1px solid rgba(110, 255, 210, 0.25);
+  overflow: hidden;
+}
+
+.rack-visual[data-online="on"] {
+  border-color: rgba(110, 255, 210, 0.6);
+  box-shadow: 0 0 20px rgba(110, 255, 210, 0.2);
+}
+
+.rack-visual[data-online="on"]::before {
+  background: radial-gradient(circle, rgba(110, 255, 210, 0.18), transparent 72%);
+}
+
+.rack-visual::before {
+  content: "";
+  position: absolute;
+  inset: -40% -30% auto;
+  height: 120%;
+  background: radial-gradient(circle, rgba(54, 196, 150, 0.12), transparent 70%);
+  pointer-events: none;
+}
+
+.rack-rail {
+  position: absolute;
+  inset: auto 0 0;
+  height: 16px;
+  background: linear-gradient(90deg, rgba(68, 255, 200, 0.05), rgba(68, 255, 200, 0.25), rgba(68, 255, 200, 0.05));
+  opacity: 0.7;
+}
+
+.light {
+  position: relative;
+  padding: 0.85rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(80, 255, 200, 0.2);
+  background: rgba(0, 20, 28, 0.88);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.65);
+  overflow: hidden;
+}
+
+.light-label {
+  position: relative;
+  z-index: 1;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(198, 234, 232, 0.8);
+}
+
+.light-glow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle, rgba(68, 255, 200, 0.24), transparent 70%);
+  opacity: 0.35;
+  transition: opacity 0.3s ease, background 0.3s ease;
+}
+
+.light[data-state="idle"] .light-glow {
+  opacity: 0.2;
+}
+
+.light[data-state="good"] {
+  border-color: rgba(110, 255, 210, 0.55);
+  box-shadow: 0 0 18px rgba(110, 255, 210, 0.18);
+}
+
+.light[data-state="good"] .light-glow {
+  opacity: 0.65;
+  background: radial-gradient(circle, rgba(110, 255, 210, 0.45), transparent 70%);
+  animation: rack-pulse 1.6s infinite;
+}
+
+.light[data-state="warn"] {
+  border-color: rgba(255, 166, 0, 0.6);
+}
+
+.light[data-state="warn"] .light-glow {
+  opacity: 0.5;
+  background: radial-gradient(circle, rgba(255, 166, 0, 0.45), transparent 70%);
+  animation: rack-warn 0.8s steps(2, jump-none) infinite;
+}
+
+@keyframes rack-pulse {
+  0% {
+    transform: scale(0.96);
+    opacity: 0.45;
+  }
+  50% {
+    transform: scale(1.05);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(0.96);
+    opacity: 0.45;
+  }
+}
+
+@keyframes rack-warn {
+  0%,
+  100% {
+    opacity: 0.45;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+.handshake-oscilloscope {
+  margin-top: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 18px;
+  background: linear-gradient(160deg, rgba(4, 24, 32, 0.92), rgba(0, 10, 14, 0.95));
+  border: 1px solid rgba(110, 255, 210, 0.22);
+  box-shadow: inset 0 0 16px rgba(0, 0, 0, 0.6);
+  --progress: 0;
+}
+
+.handshake-oscilloscope[data-state="sync"] {
+  border-color: rgba(110, 255, 210, 0.55);
+  box-shadow: 0 0 24px rgba(68, 255, 200, 0.25);
+}
+
+.handshake-oscilloscope[data-state="warming"] {
+  border-color: rgba(110, 255, 210, 0.35);
+  box-shadow: 0 0 18px rgba(68, 255, 200, 0.18);
+}
+
+.scope-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(198, 234, 232, 0.75);
+}
+
+.scope-readout {
+  font-family: var(--mono-font);
+  font-size: 1rem;
+  color: var(--neon-green);
+  text-shadow: 0 0 10px rgba(68, 255, 200, 0.55);
+}
+
+.scope-wave {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.75rem;
+  margin-top: 0.8rem;
+}
+
+.scope-pulse {
+  height: 26px;
+  border-radius: 12px;
+  background: rgba(6, 42, 52, 0.85);
+  border: 1px solid rgba(110, 255, 210, 0.22);
+  position: relative;
+  overflow: hidden;
+}
+
+.scope-pulse::before {
+  content: "";
+  position: absolute;
+  inset: 4px;
+  border-radius: 999px;
+  background: rgba(68, 255, 200, 0.2);
+  transform-origin: left center;
+  transform: scaleX(var(--pulse, 0));
+  transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.scope-pulse[data-active="on"]::before {
+  --pulse: 1;
+  animation: scope-glow 1.4s ease-in-out infinite;
+}
+
+.scope-pulse[data-state="warn"]::before {
+  background: rgba(255, 166, 0, 0.35);
+  animation: scope-warn 0.8s steps(2, jump-none) infinite;
+}
+
+@keyframes scope-glow {
+  0%,
+  100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes scope-warn {
+  0%,
+  100% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 1;
+  }
+}

--- a/madia.new/public/secret/net/daemon-handshake/daemon-handshake.js
+++ b/madia.new/public/secret/net/daemon-handshake/daemon-handshake.js
@@ -1,5 +1,18 @@
 const form = document.getElementById("daemon-form");
 const board = document.getElementById("status-board");
+const rack = document.querySelector(".rack-visual");
+const lights = {
+  port: document.querySelector('[data-light="port"]'),
+  docroot: document.querySelector('[data-light="docroot"]'),
+  ssl: document.querySelector('[data-light="ssl"]'),
+  status: document.querySelector('[data-light="status"]'),
+  userdir: document.querySelector('[data-light="userdir"]'),
+};
+const scope = document.querySelector(".handshake-oscilloscope");
+const scopePulses = scope ? scope.querySelectorAll(".scope-pulse") : [];
+const scopeReadout = document.getElementById("handshake-readout");
+
+const TOTAL_CHECKS = 5;
 
 const REQUIRED_PORT = 8080;
 const REQUIRED_ROOT = "/var/www/altroot";
@@ -38,6 +51,7 @@ const evaluateConfig = (formData) => {
 const handleSubmit = (event) => {
   event.preventDefault();
   const formData = new FormData(form);
+  updateLights(formData);
   const issues = evaluateConfig(formData);
   if (issues.length) {
     updateBoard(`Daemon refused: ${issues.join(", ")}.`, "error");
@@ -62,6 +76,7 @@ const handleInput = () => {
     return;
   }
   const formData = new FormData(form);
+  updateLights(formData);
   const issues = evaluateConfig(formData);
   if (!issues.length) {
     updateBoard("Checklist satisfied. Ready to launch.");
@@ -72,3 +87,87 @@ const handleInput = () => {
 
 form?.addEventListener("submit", handleSubmit);
 form?.addEventListener("input", handleInput);
+
+const applyLightState = (name, state) => {
+  const target = lights[name];
+  if (!target) {
+    return;
+  }
+  target.dataset.state = state;
+};
+
+const deriveState = (condition, touched) => {
+  if (!touched) {
+    return "idle";
+  }
+  return condition ? "good" : "warn";
+};
+
+function updateLights(formData) {
+  const portRaw = formData.get("port");
+  const portTouched = portRaw !== null && portRaw !== "";
+  const portMatch = Number(portRaw) === REQUIRED_PORT;
+  applyLightState("port", deriveState(portMatch, portTouched));
+
+  const docrootRaw = (formData.get("docroot") || "").trim();
+  const docrootTouched = docrootRaw.length > 0;
+  const docrootMatch = docrootRaw === REQUIRED_ROOT;
+  applyLightState("docroot", deriveState(docrootMatch, docrootTouched));
+
+  const modules = new Set(formData.getAll("modules"));
+  const modulesTouched = modules.size > 0;
+  let matchCount = 0;
+  if (portMatch) {
+    matchCount += 1;
+  }
+  if (docrootMatch) {
+    matchCount += 1;
+  }
+
+  applyLightState("ssl", deriveState(modules.has("mod_ssl"), modulesTouched));
+  applyLightState("status", deriveState(modules.has("mod_status"), modulesTouched));
+  if (modules.has("mod_ssl")) {
+    matchCount += 1;
+  }
+  if (modules.has("mod_status")) {
+    matchCount += 1;
+  }
+
+  const userdirTouched = modulesTouched && (modules.has("mod_userdir") || modules.size > 0);
+  let userdirState = "idle";
+  if (userdirTouched) {
+    userdirState = modules.has("mod_userdir") ? "warn" : "good";
+  }
+  applyLightState("userdir", userdirState);
+  if (userdirTouched && !modules.has("mod_userdir")) {
+    matchCount += 1;
+  }
+
+  if (rack) {
+    const rackOnline =
+      portMatch &&
+      docrootMatch &&
+      modules.has("mod_ssl") &&
+      modules.has("mod_status") &&
+      !modules.has("mod_userdir");
+    rack.dataset.online = rackOnline ? "on" : "off";
+  }
+
+  const ratio = matchCount / TOTAL_CHECKS;
+  if (scope) {
+    scope.dataset.state = matchCount === TOTAL_CHECKS ? "sync" : matchCount > 0 ? "warming" : "idle";
+    scope.style.setProperty("--progress", String(ratio));
+  }
+  scopePulses.forEach((pulse, index) => {
+    const active = index < matchCount;
+    pulse.dataset.active = active ? "on" : "off";
+    pulse.dataset.state = index < matchCount ? "good" : "idle";
+  });
+  if (scopeReadout) {
+    scopeReadout.textContent = `${matchCount}/${TOTAL_CHECKS}`;
+  }
+}
+
+if (form) {
+  updateLights(new FormData(form));
+}

--- a/madia.new/public/secret/net/daemon-handshake/index.html
+++ b/madia.new/public/secret/net/daemon-handshake/index.html
@@ -58,6 +58,42 @@
           <button type="submit" class="execute-button">Start daemon</button>
         </form>
         <div class="status-board" id="status-board" aria-live="polite">Daemon halted. Awaiting config…</div>
+        <div class="rack-visual" aria-hidden="true">
+          <div class="light" data-light="port">
+            <span class="light-label">Port 8080</span>
+            <span class="light-glow"></span>
+          </div>
+          <div class="light" data-light="docroot">
+            <span class="light-label">/var/www/altroot</span>
+            <span class="light-glow"></span>
+          </div>
+          <div class="light" data-light="ssl">
+            <span class="light-label">mod_ssl</span>
+            <span class="light-glow"></span>
+          </div>
+          <div class="light" data-light="status">
+            <span class="light-label">mod_status</span>
+            <span class="light-glow"></span>
+          </div>
+          <div class="light" data-light="userdir">
+            <span class="light-label">mod_userdir (off)</span>
+            <span class="light-glow"></span>
+          </div>
+          <div class="rack-rail"></div>
+        </div>
+        <div class="handshake-oscilloscope" aria-hidden="true">
+          <div class="scope-header">
+            <span class="scope-label">Checklist sync</span>
+            <span class="scope-readout" id="handshake-readout">0/5</span>
+          </div>
+          <div class="scope-wave">
+            <span class="scope-pulse"></span>
+            <span class="scope-pulse"></span>
+            <span class="scope-pulse"></span>
+            <span class="scope-pulse"></span>
+            <span class="scope-pulse"></span>
+          </div>
+        </div>
       </section>
     </main>
     <footer>Keep alive ping courtesy of the campus NOC.</footer>

--- a/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.css
+++ b/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.css
@@ -36,3 +36,198 @@ select {
   color: var(--status-error);
   border-color: var(--status-error);
 }
+
+.flight-visual {
+  margin-top: 1.25rem;
+  border: 1px solid rgba(110, 255, 210, 0.3);
+  border-radius: 18px;
+  background: linear-gradient(140deg, rgba(4, 30, 42, 0.85), rgba(0, 10, 18, 0.95));
+  padding: 1.1rem 1.25rem 1.8rem;
+  position: relative;
+}
+
+.flight-track {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.75rem;
+  align-items: end;
+  padding-bottom: 1.5rem;
+}
+
+.flight-track::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0.6rem;
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(68, 255, 200, 0.2), rgba(68, 255, 200, 0.8), rgba(68, 255, 200, 0.2));
+  opacity: 0.5;
+  transition: opacity 0.3s ease;
+}
+
+.flight-track[data-state="good"]::after {
+  opacity: 0.95;
+  box-shadow: 0 0 16px rgba(110, 255, 210, 0.35);
+}
+
+.flight-track[data-state="warn"]::after {
+  background: linear-gradient(90deg, rgba(255, 166, 0, 0.2), rgba(255, 166, 0, 0.7), rgba(255, 166, 0, 0.2));
+  opacity: 0.8;
+}
+
+.flight-step {
+  position: relative;
+  padding: 0.65rem 0.6rem;
+  border-radius: 12px;
+  border: 1px solid rgba(110, 255, 210, 0.25);
+  background: rgba(0, 16, 24, 0.9);
+  display: grid;
+  gap: 0.35rem;
+  justify-items: center;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.flight-step .step-slot {
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  color: rgba(198, 234, 232, 0.8);
+}
+
+.flight-step[data-state="idle"] .step-slot {
+  color: rgba(198, 234, 232, 0.4);
+}
+
+.flight-step[data-state="good"] {
+  border-color: rgba(110, 255, 210, 0.6);
+  box-shadow: 0 0 14px rgba(110, 255, 210, 0.2);
+}
+
+.flight-step[data-state="good"] .step-slot {
+  color: var(--status-success);
+}
+
+.flight-step[data-state="warn"] {
+  border-color: rgba(255, 166, 0, 0.6);
+  box-shadow: 0 0 12px rgba(255, 166, 0, 0.15);
+}
+
+.flight-step[data-state="warn"] .step-slot {
+  color: rgba(255, 182, 73, 0.85);
+}
+
+.flight-plane {
+  position: absolute;
+  bottom: 1.1rem;
+  left: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(110, 255, 210, 0.9), rgba(0, 40, 56, 0.2));
+  box-shadow: 0 0 16px rgba(110, 255, 210, 0.4);
+  transform: translateX(calc(var(--progress, 0) * (100% - 36px)));
+  transition: transform 0.4s ease;
+  display: grid;
+  place-items: center;
+}
+
+.flight-plane::after {
+  content: "✈";
+  color: rgba(0, 34, 44, 0.85);
+  font-size: 1.1rem;
+  transform: rotate(6deg);
+}
+
+.flight-plane[data-state="taxi"] {
+  animation: plane-taxi 1.6s ease-in-out infinite;
+}
+
+.flight-plane[data-state="dock"] {
+  animation: plane-dock 1.4s ease-in-out infinite;
+}
+
+@keyframes plane-taxi {
+  0%,
+  100% {
+    transform: translateX(calc(var(--progress, 0) * (100% - 36px))) translateY(0);
+  }
+  50% {
+    transform: translateX(calc(var(--progress, 0) * (100% - 36px))) translateY(-4px);
+  }
+}
+
+@keyframes plane-dock {
+  0%,
+  100% {
+    transform: translateX(calc(var(--progress, 0) * (100% - 36px)));
+  }
+  40% {
+    transform: translateX(calc(var(--progress, 0) * (100% - 36px))) scale(1.06);
+  }
+  70% {
+    transform: translateX(calc(var(--progress, 0) * (100% - 36px))) scale(0.98);
+  }
+}
+
+.flight-dashboard {
+  margin-top: 1.2rem;
+  padding: 1rem 1.25rem 1.2rem;
+  border-radius: 16px;
+  background: rgba(0, 14, 22, 0.92);
+  border: 1px solid rgba(110, 255, 210, 0.25);
+  box-shadow: inset 0 0 14px rgba(0, 0, 0, 0.55);
+}
+
+.flight-dashboard[data-state="active"] {
+  border-color: rgba(110, 255, 210, 0.38);
+  box-shadow: 0 0 18px rgba(68, 255, 200, 0.22);
+}
+
+.flight-dashboard[data-state="ready"] {
+  border-color: rgba(110, 255, 210, 0.6);
+  box-shadow: 0 0 24px rgba(68, 255, 200, 0.28);
+}
+
+.dashboard-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(198, 234, 232, 0.75);
+}
+
+.dashboard-value {
+  font-family: var(--mono-font);
+  font-size: 1.1rem;
+  color: var(--neon-green);
+  text-shadow: 0 0 12px rgba(68, 255, 200, 0.55);
+}
+
+.dashboard-lights {
+  margin-top: 0.8rem;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.5rem;
+}
+
+.dashboard-light {
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(6, 40, 52, 0.85);
+  border: 1px solid rgba(110, 255, 210, 0.25);
+  box-shadow: 0 0 0 rgba(68, 255, 200, 0.15);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.dashboard-light[data-active="on"] {
+  background: var(--neon-green);
+  box-shadow: 0 0 16px rgba(68, 255, 200, 0.6);
+}

--- a/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.js
+++ b/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.js
@@ -1,5 +1,20 @@
 const form = document.getElementById("ftp-form");
 const board = document.getElementById("status-board");
+const flightTrack = document.querySelector(".flight-track");
+const plane = document.getElementById("flight-plane");
+const dashboard = document.querySelector(".flight-dashboard");
+const dashboardValue = document.getElementById("flight-progress");
+const dashboardLights = dashboard
+  ? dashboard.querySelectorAll(".dashboard-light")
+  : [];
+const stepLookup = {
+  open: document.querySelector('[data-command="open"]'),
+  user: document.querySelector('[data-command="user"]'),
+  passive: document.querySelector('[data-command="passive"]'),
+  cd: document.querySelector('[data-command="cd"]'),
+  put: document.querySelector('[data-command="put"]'),
+  quit: document.querySelector('[data-command="quit"]'),
+};
 
 const expectedOrder = {
   open: "1",
@@ -10,34 +25,137 @@ const expectedOrder = {
   quit: "6",
 };
 
+const orderedCommands = Object.entries(expectedOrder).sort(
+  (a, b) => Number(a[1]) - Number(b[1])
+);
+
 const updateBoard = (message, state = "idle") => {
   board.textContent = message;
   board.dataset.state = state;
 };
 
-const hasDuplicates = (values) => {
-  const used = new Set();
-  for (const value of Object.values(values)) {
+const getDuplicates = (values) => {
+  const seen = new Map();
+  const duplicates = new Set();
+  Object.entries(values).forEach(([command, value]) => {
     if (!value) {
-      continue;
+      return;
     }
-    if (used.has(value)) {
-      return true;
+    const existing = seen.get(value);
+    if (existing) {
+      duplicates.add(existing);
+      duplicates.add(command);
+    } else {
+      seen.set(value, command);
     }
-    used.add(value);
-  }
-  return false;
+  });
+  return duplicates;
 };
+
+const updateFlightVisual = (values, duplicates) => {
+  let anyInput = false;
+  let allAssigned = true;
+
+  Object.entries(stepLookup).forEach(([command, element]) => {
+    if (!element) {
+      return;
+    }
+    const slot = values[command] || "";
+    const slotDisplay = element.querySelector(".step-slot");
+    if (slotDisplay) {
+      slotDisplay.textContent = slot || "--";
+    }
+    let state = "idle";
+    if (slot) {
+      anyInput = true;
+      if (duplicates.has(command)) {
+        state = "warn";
+      } else if (slot === expectedOrder[command]) {
+        state = "good";
+      } else {
+        state = "warn";
+      }
+    } else {
+      allAssigned = false;
+    }
+    element.dataset.state = state;
+  });
+
+  let progress = 0;
+  for (const [command, slot] of orderedCommands) {
+    if (values[command] === slot && !duplicates.has(command)) {
+      progress += 1;
+    } else {
+      break;
+    }
+  }
+
+  const perfect =
+    duplicates.size === 0 &&
+    orderedCommands.every(([command, slot]) => values[command] === slot);
+
+  const ratio = progress / orderedCommands.length;
+  if (plane) {
+    plane.style.setProperty("--progress", String(ratio));
+    let planeState = "idle";
+    if (perfect) {
+      planeState = "dock";
+    } else if (ratio > 0) {
+      planeState = "taxi";
+    }
+    plane.dataset.state = planeState;
+  }
+
+  if (flightTrack) {
+    let trackState = "idle";
+    if (perfect) {
+      trackState = "good";
+    } else if (anyInput || duplicates.size) {
+      trackState = "warn";
+    }
+    flightTrack.dataset.state = trackState;
+  }
+
+  if (dashboard) {
+    dashboard.dataset.state = perfect ? "ready" : progress > 0 ? "active" : "idle";
+    if (dashboardValue) {
+      dashboardValue.textContent = `${Math.round(ratio * 100)}%`;
+    }
+  }
+  dashboardLights.forEach((light, index) => {
+    light.dataset.active = index < progress ? "on" : "off";
+  });
+
+  if (!anyInput) {
+    return "idle";
+  }
+  if (perfect) {
+    return "success";
+  }
+  if (duplicates.size || !allAssigned) {
+    return "warn";
+  }
+  return "active";
+};
+
+const extractValues = (formData) =>
+  Object.fromEntries(
+    Object.keys(expectedOrder).map((key) => [key, formData.get(key) || ""])
+  );
 
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
   const data = new FormData(form);
-  const values = Object.fromEntries(Object.keys(expectedOrder).map((key) => [key, data.get(key) || ""]));
-  if (hasDuplicates(values)) {
+  const values = extractValues(data);
+  const duplicates = getDuplicates(values);
+  updateFlightVisual(values, duplicates);
+  if (duplicates.size) {
     updateBoard("Sequence conflict detected. Remove duplicate slots.", "error");
     return;
   }
-  const mismatches = Object.entries(expectedOrder).filter(([key, value]) => values[key] !== value);
+  const mismatches = Object.entries(expectedOrder).filter(
+    ([key, value]) => values[key] !== value
+  );
   if (mismatches.length) {
     updateBoard("Transfer aborted. Adjust command ordering.", "error");
     return;
@@ -60,5 +178,24 @@ form?.addEventListener("input", () => {
   if (board.dataset.state === "success") {
     return;
   }
-  updateBoard("Transfer queue idle.");
+  const data = new FormData(form);
+  const values = extractValues(data);
+  const duplicates = getDuplicates(values);
+  const state = updateFlightVisual(values, duplicates);
+  if (state === "idle") {
+    updateBoard("Transfer queue idle.");
+  } else if (state === "success") {
+    updateBoard("Payload lined up. Ready for launch.");
+  } else if (state === "warn") {
+    updateBoard("Course deviation detected. Adjust slots.");
+  } else {
+    updateBoard("Transfer queue syncing…");
+  }
 });
+
+if (form) {
+  const initialValues = Object.fromEntries(
+    Object.keys(expectedOrder).map((key) => [key, form.elements.namedItem(key)?.value || ""])
+  );
+  updateFlightVisual(initialValues, new Set());
+}

--- a/madia.new/public/secret/net/ftp-flightdeck/index.html
+++ b/madia.new/public/secret/net/ftp-flightdeck/index.html
@@ -109,6 +109,49 @@
           <button type="submit" class="execute-button">Initiate transfer</button>
         </form>
         <div id="status-board" class="status-board" aria-live="polite">Transfer queue idle.</div>
+        <div class="flight-visual" aria-hidden="true">
+          <div class="flight-track" data-state="idle">
+            <div class="flight-step" data-command="open">
+              <span class="step-label">open</span>
+              <span class="step-slot">--</span>
+            </div>
+            <div class="flight-step" data-command="user">
+              <span class="step-label">user</span>
+              <span class="step-slot">--</span>
+            </div>
+            <div class="flight-step" data-command="passive">
+              <span class="step-label">passive</span>
+              <span class="step-slot">--</span>
+            </div>
+            <div class="flight-step" data-command="cd">
+              <span class="step-label">cd</span>
+              <span class="step-slot">--</span>
+            </div>
+            <div class="flight-step" data-command="put">
+              <span class="step-label">put</span>
+              <span class="step-slot">--</span>
+            </div>
+            <div class="flight-step" data-command="quit">
+              <span class="step-label">quit</span>
+              <span class="step-slot">--</span>
+            </div>
+            <div class="flight-plane" id="flight-plane" aria-hidden="true"></div>
+          </div>
+          <div class="flight-dashboard" aria-hidden="true">
+            <div class="dashboard-header">
+              <span class="dashboard-label">Runway clearance</span>
+              <span class="dashboard-value" id="flight-progress">0%</span>
+            </div>
+            <div class="dashboard-lights">
+              <span class="dashboard-light" data-index="0"></span>
+              <span class="dashboard-light" data-index="1"></span>
+              <span class="dashboard-light" data-index="2"></span>
+              <span class="dashboard-light" data-index="3"></span>
+              <span class="dashboard-light" data-index="4"></span>
+              <span class="dashboard-light" data-index="5"></span>
+            </div>
+          </div>
+        </div>
       </section>
     </main>
     <footer>Keep the channel clear and the payload intact.</footer>

--- a/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.css
+++ b/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.css
@@ -22,6 +22,16 @@ main {
   gap: 0.75rem;
 }
 
+.row[data-state="good"] {
+  border-color: rgba(110, 255, 210, 0.6);
+  box-shadow: 0 0 16px rgba(110, 255, 210, 0.2);
+}
+
+.row[data-state="warn"] {
+  border-color: rgba(255, 166, 0, 0.6);
+  animation: row-flicker 0.75s steps(2, jump-none) infinite;
+}
+
 label {
   display: grid;
   gap: 0.35rem;
@@ -42,4 +52,108 @@ input[type="text"] {
 .status-board[data-state="error"] {
   color: var(--status-error);
   border-color: var(--status-error);
+}
+
+.terminal-preview {
+  margin-top: 1.25rem;
+  border: 1px solid rgba(110, 255, 210, 0.3);
+  border-radius: 14px;
+  background: linear-gradient(180deg, rgba(4, 20, 26, 0.92), rgba(0, 10, 16, 0.95));
+  padding: 1rem;
+  box-shadow: inset 0 0 18px rgba(0, 0, 0, 0.5);
+}
+
+.terminal-preview pre {
+  margin: 0;
+  font-family: "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  color: rgba(186, 255, 238, 0.85);
+  letter-spacing: 0.04em;
+  animation: crt-glow 3.2s ease-in-out infinite;
+}
+
+.menu-meter {
+  margin-top: 1rem;
+  padding: 0.9rem 1.1rem 1.1rem;
+  border-radius: 14px;
+  background: rgba(0, 14, 20, 0.9);
+  border: 1px solid rgba(110, 255, 210, 0.25);
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.55);
+  --progress: 0;
+}
+
+.menu-meter[data-state="active"] {
+  border-color: rgba(110, 255, 210, 0.38);
+  box-shadow: 0 0 18px rgba(68, 255, 200, 0.22);
+}
+
+.menu-meter[data-state="ready"] {
+  border-color: rgba(110, 255, 210, 0.6);
+  box-shadow: 0 0 24px rgba(68, 255, 200, 0.26);
+}
+
+.meter-label {
+  display: block;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(198, 234, 232, 0.7);
+}
+
+.meter-track {
+  margin-top: 0.5rem;
+  position: relative;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(6, 34, 42, 0.85);
+  overflow: hidden;
+}
+
+.meter-fill {
+  position: absolute;
+  inset: 0;
+  transform-origin: left center;
+  transform: scaleX(var(--progress));
+  background: linear-gradient(90deg, rgba(68, 255, 200, 0.3), rgba(68, 255, 200, 0.85));
+  transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.meter-pips {
+  margin-top: 0.6rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.meter-pip {
+  flex: 1;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(6, 28, 36, 0.85);
+  border: 1px solid rgba(110, 255, 210, 0.25);
+  box-shadow: 0 0 0 rgba(68, 255, 200, 0.18);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.meter-pip[data-active="on"] {
+  background: var(--neon-green);
+  box-shadow: 0 0 14px rgba(68, 255, 200, 0.6);
+}
+
+@keyframes row-flicker {
+  0%,
+  100% {
+    box-shadow: 0 0 8px rgba(255, 166, 0, 0.2);
+  }
+  50% {
+    box-shadow: 0 0 0 rgba(255, 166, 0, 0.1);
+  }
+}
+
+@keyframes crt-glow {
+  0%,
+  100% {
+    text-shadow: 0 0 12px rgba(110, 255, 210, 0.2);
+  }
+  50% {
+    text-shadow: 0 0 18px rgba(110, 255, 210, 0.45);
+  }
 }

--- a/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.js
+++ b/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.js
@@ -1,5 +1,13 @@
 const form = document.getElementById("gopher-form");
 const board = document.getElementById("status-board");
+const preview = document.getElementById("gopher-preview");
+const rowLookup = {
+  banner: document.querySelector('[data-row="banner"]'),
+  catalog: document.querySelector('[data-row="catalog"]'),
+  zine: document.querySelector('[data-row="zine"]'),
+};
+const menuMeter = document.querySelector(".menu-meter");
+const meterPips = menuMeter ? menuMeter.querySelectorAll(".meter-pip") : [];
 
 const expected = {
   "banner-text": "Library Net Welcome",
@@ -16,15 +24,149 @@ const expected = {
   "zine-type": "0",
 };
 
+const rowConfig = {
+  banner: {
+    text: "banner-text",
+    selector: "banner-selector",
+    host: "banner-host",
+    type: "banner-type",
+    port: "70",
+  },
+  catalog: {
+    text: "catalog-text",
+    selector: "catalog-selector",
+    host: "catalog-host",
+    type: "catalog-type",
+    port: "70",
+  },
+  zine: {
+    text: "zine-text",
+    selector: "zine-selector",
+    host: "zine-host",
+    type: "zine-type",
+    port: "70",
+  },
+};
+
+const normalize = (name, value) => {
+  if (value == null) {
+    return "";
+  }
+  const trimmed = String(value).trim();
+  if (name.endsWith("type")) {
+    return trimmed.toLowerCase();
+  }
+  if (name.endsWith("host")) {
+    return trimmed.toLowerCase();
+  }
+  if (name.endsWith("text")) {
+    return trimmed;
+  }
+  return trimmed;
+};
+
 const updateBoard = (message, state = "idle") => {
   board.textContent = message;
   board.dataset.state = state;
 };
 
+const buildLine = (type, text, selector, host, port) => {
+  const safeType = (type || "?").slice(0, 1);
+  const safeText = text || "--";
+  const safeSelector = selector || "--";
+  const safeHost = host || "--";
+  const safePort = port || "70";
+  return `${safeType}${safeText}\t${safeSelector}\t${safeHost}\t${safePort}`;
+};
+
+const updatePreview = (formData) => {
+  const lines = [];
+  let anyInput = false;
+  let allAligned = true;
+  let alignedRows = 0;
+
+  Object.entries(rowConfig).forEach(([rowKey, config]) => {
+    const rowElement = rowLookup[rowKey];
+    const fieldValues = {
+      type: formData.get(config.type) || "",
+      text: formData.get(config.text) || "",
+      selector: formData.get(config.selector) || "",
+      host: formData.get(config.host) || "",
+    };
+
+    const normalized = {
+      type: normalize(config.type, fieldValues.type),
+      text: normalize(config.text, fieldValues.text),
+      selector: normalize(config.selector, fieldValues.selector),
+      host: normalize(config.host, fieldValues.host),
+    };
+
+    const expectedRow = {
+      type: normalize(config.type, expected[config.type]),
+      text: normalize(config.text, expected[config.text]),
+      selector: normalize(config.selector, expected[config.selector]),
+      host: normalize(config.host, expected[config.host]),
+    };
+
+    const touched = Object.values(fieldValues).some((value) => value.trim().length > 0);
+    if (touched) {
+      anyInput = true;
+    }
+
+    const matches = Object.keys(expectedRow).every(
+      (key) => normalized[key] === expectedRow[key]
+    );
+    if (!matches) {
+      allAligned = false;
+    }
+    if (matches) {
+      alignedRows += 1;
+    }
+
+    if (rowElement) {
+      let state = "idle";
+      if (touched) {
+        state = matches ? "good" : "warn";
+      }
+      rowElement.dataset.state = state;
+    }
+
+    const displayType = fieldValues.type.trim() || expected[config.type];
+    lines.push(
+      buildLine(
+        displayType,
+        fieldValues.text.trim() || "--",
+        fieldValues.selector.trim() || "--",
+        fieldValues.host.trim() || "--",
+        config.port
+      )
+    );
+  });
+
+  if (preview) {
+    preview.textContent = lines.join("\n");
+  }
+
+  const totalRows = Object.keys(rowConfig).length;
+  const ratio = totalRows ? alignedRows / totalRows : 0;
+  if (menuMeter) {
+    menuMeter.dataset.state = alignedRows === totalRows ? "ready" : alignedRows > 0 ? "active" : "idle";
+    menuMeter.style.setProperty("--progress", String(ratio));
+  }
+  meterPips.forEach((pip, index) => {
+    pip.dataset.active = index < alignedRows ? "on" : "off";
+  });
+
+  return { anyInput, allAligned };
+};
+
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
   const data = new FormData(form);
-  const errors = Object.entries(expected).filter(([name, value]) => (data.get(name) || "").trim() !== value);
+  const errors = Object.entries(expected).filter(
+    ([name, value]) => normalize(name, data.get(name)) !== normalize(name, value)
+  );
+  updatePreview(data);
   if (errors.length) {
     updateBoard("Menu mismatch. Check selector, type, and host fields.", "error");
     return;
@@ -47,5 +189,19 @@ form?.addEventListener("input", () => {
   if (board.dataset.state === "success") {
     return;
   }
-  updateBoard("Awaiting menu entries.");
+  const data = new FormData(form);
+  const { anyInput, allAligned } = updatePreview(data);
+  if (!anyInput) {
+    updateBoard("Awaiting menu entries.");
+    return;
+  }
+  if (allAligned) {
+    updateBoard("Rows aligned. Save to deploy.");
+  } else {
+    updateBoard("Drafting menu entries…");
+  }
 });
+
+if (form) {
+  updatePreview(new FormData(form));
+}

--- a/madia.new/public/secret/net/gopher-groundskeeper/index.html
+++ b/madia.new/public/secret/net/gopher-groundskeeper/index.html
@@ -103,6 +103,22 @@
           <button type="submit" class="execute-button">Save gophermap</button>
         </form>
         <div id="status-board" class="status-board" aria-live="polite">Awaiting menu entries.</div>
+        <div class="terminal-preview" aria-live="polite" aria-label="Gophermap preview">
+          <pre id="gopher-preview">i	--	--	--
+7	--	--	--
+0	--	--	--</pre>
+        </div>
+        <div class="menu-meter" aria-hidden="true">
+          <span class="meter-label">Row alignment</span>
+          <div class="meter-track">
+            <span class="meter-fill"></span>
+          </div>
+          <div class="meter-pips">
+            <span class="meter-pip" data-index="0"></span>
+            <span class="meter-pip" data-index="1"></span>
+            <span class="meter-pip" data-index="2"></span>
+          </div>
+        </div>
       </section>
     </main>
     <footer>Keep the burrows tidy and the menu crisp.</footer>

--- a/madia.new/public/secret/net/hopline-diagnostics/hopline-diagnostics.css
+++ b/madia.new/public/secret/net/hopline-diagnostics/hopline-diagnostics.css
@@ -50,3 +50,257 @@ select {
   border-color: var(--status-error);
   color: var(--status-error);
 }
+
+.trace-visual {
+  margin-top: 1.25rem;
+  position: relative;
+  border: 1px solid rgba(110, 255, 210, 0.3);
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(4, 24, 32, 0.88), rgba(0, 10, 16, 0.95));
+  padding: 1.25rem;
+  overflow: hidden;
+  min-height: 240px;
+}
+
+.trace-visual[data-flow="on"] {
+  border-color: rgba(110, 255, 210, 0.55);
+  box-shadow: 0 0 22px rgba(110, 255, 210, 0.2);
+}
+
+.net,
+.router {
+  position: absolute;
+  width: 160px;
+  padding: 0.7rem 0.85rem;
+  border-radius: 12px;
+  text-align: center;
+  background: rgba(0, 18, 26, 0.9);
+  border: 1px solid rgba(110, 255, 210, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.55);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease, color 0.3s ease;
+}
+
+.net-label,
+.router-label {
+  display: block;
+}
+
+.net[data-state="idle"],
+.router[data-state="idle"] {
+  color: rgba(198, 234, 232, 0.6);
+}
+
+.net[data-net="lab"] {
+  top: 18%;
+  left: 8%;
+}
+
+.net[data-net="studio"] {
+  top: 46%;
+  left: 8%;
+}
+
+.net[data-net="isp"] {
+  bottom: 14%;
+  left: 8%;
+}
+
+.router[data-router="edge-hub"] {
+  top: 22%;
+  right: 8%;
+}
+
+.router[data-router="studio-loop"] {
+  top: 50%;
+  right: 8%;
+}
+
+.router[data-router="metro-border"] {
+  bottom: 14%;
+  right: 8%;
+}
+
+.net[data-state="good"],
+.router[data-state="good"] {
+  border-color: rgba(110, 255, 210, 0.6);
+  box-shadow: 0 0 16px rgba(110, 255, 210, 0.2);
+  color: var(--status-success);
+}
+
+.net[data-state="warn"],
+.router[data-state="warn"] {
+  border-color: rgba(255, 166, 0, 0.6);
+  box-shadow: 0 0 12px rgba(255, 166, 0, 0.18);
+  color: rgba(255, 182, 73, 0.9);
+}
+
+.link {
+  position: absolute;
+  height: 12px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(68, 255, 200, 0.12), rgba(68, 255, 200, 0.4));
+  overflow: hidden;
+  box-shadow: 0 0 12px rgba(68, 255, 200, 0.18);
+  transition: opacity 0.3s ease, box-shadow 0.3s ease;
+}
+
+.link::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent 0%, rgba(110, 255, 210, 0.6) 50%, transparent 100%);
+  background-size: 220%;
+  transform: translateX(-100%);
+  animation: trace-flow 2.8s linear infinite;
+}
+
+.link[data-link="lab"] {
+  top: 26%;
+  left: 26%;
+  width: 45%;
+}
+
+.link[data-link="studio"] {
+  top: 54%;
+  left: 26%;
+  width: 45%;
+}
+
+.link[data-link="isp"] {
+  bottom: 20%;
+  left: 26%;
+  width: 45%;
+}
+
+.link[data-state="idle"] {
+  opacity: 0.35;
+}
+
+.link[data-state="warn"] {
+  box-shadow: 0 0 16px rgba(255, 166, 0, 0.4);
+}
+
+.link[data-state="warn"]::after {
+  background: linear-gradient(90deg, transparent 0%, rgba(255, 166, 0, 0.6) 50%, transparent 100%);
+  animation-duration: 1.6s;
+}
+
+.packet {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--neon-green);
+  box-shadow: 0 0 8px rgba(110, 255, 210, 0.5);
+  animation: hopline-packet 3.2s linear infinite;
+  opacity: 0.9;
+}
+
+.packet:nth-of-type(2) {
+  animation-delay: 1.2s;
+}
+
+.packet:nth-of-type(3) {
+  animation-delay: 2.1s;
+}
+
+.trace-visual[data-flow="off"] .packet {
+  animation-play-state: paused;
+  opacity: 0.3;
+}
+
+.trace-meter {
+  margin-top: 1rem;
+  padding: 0.9rem 1.1rem 1.1rem;
+  border-radius: 16px;
+  background: rgba(0, 14, 20, 0.9);
+  border: 1px solid rgba(110, 255, 210, 0.25);
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.55);
+  --progress: 0;
+}
+
+.trace-meter[data-state="active"] {
+  border-color: rgba(110, 255, 210, 0.36);
+  box-shadow: 0 0 18px rgba(68, 255, 200, 0.22);
+}
+
+.trace-meter[data-state="steady"] {
+  border-color: rgba(110, 255, 210, 0.6);
+  box-shadow: 0 0 24px rgba(68, 255, 200, 0.26);
+}
+
+.trace-label {
+  display: block;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(198, 234, 232, 0.72);
+}
+
+.trace-bar {
+  position: relative;
+  height: 10px;
+  margin-top: 0.5rem;
+  border-radius: 999px;
+  background: rgba(6, 34, 42, 0.85);
+  overflow: hidden;
+}
+
+.trace-fill {
+  position: absolute;
+  inset: 0;
+  transform-origin: left center;
+  transform: scaleX(var(--progress));
+  background: linear-gradient(90deg, rgba(68, 255, 200, 0.25), rgba(68, 255, 200, 0.85));
+  transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.trace-pips {
+  margin-top: 0.6rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.trace-pip {
+  flex: 1;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(6, 26, 36, 0.85);
+  border: 1px solid rgba(110, 255, 210, 0.25);
+  box-shadow: 0 0 0 rgba(68, 255, 200, 0.18);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.trace-pip[data-active="on"] {
+  background: var(--neon-green);
+  box-shadow: 0 0 14px rgba(68, 255, 200, 0.6);
+}
+
+@keyframes trace-flow {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes hopline-packet {
+  0% {
+    transform: translate(24%, 0%);
+    opacity: 0;
+  }
+  20% {
+    opacity: 0.9;
+  }
+  50% {
+    transform: translate(64%, 10%);
+  }
+  100% {
+    transform: translate(90%, 0%);
+    opacity: 0;
+  }
+}

--- a/madia.new/public/secret/net/hopline-diagnostics/hopline-diagnostics.js
+++ b/madia.new/public/secret/net/hopline-diagnostics/hopline-diagnostics.js
@@ -1,5 +1,24 @@
 const form = document.getElementById("route-form");
 const board = document.getElementById("status-board");
+const traceVisual = document.querySelector(".trace-visual");
+const netIndicators = {
+  lab: document.querySelector('[data-net="lab"]'),
+  studio: document.querySelector('[data-net="studio"]'),
+  isp: document.querySelector('[data-net="isp"]'),
+};
+const routerIndicators = {
+  "edge-hub": document.querySelector('[data-router="edge-hub"]'),
+  "studio-loop": document.querySelector('[data-router="studio-loop"]'),
+  "metro-border": document.querySelector('[data-router="metro-border"]'),
+};
+const linkIndicators = {
+  lab: document.querySelector('[data-link="lab"]'),
+  studio: document.querySelector('[data-link="studio"]'),
+  isp: document.querySelector('[data-link="isp"]'),
+};
+const traceMeter = document.querySelector(".trace-meter");
+const tracePips = traceMeter ? traceMeter.querySelectorAll(".trace-pip") : [];
+const totalRoutes = Object.keys(expected).length;
 
 const expected = {
   lab: "edge-hub",
@@ -12,10 +31,73 @@ const updateBoard = (message, state = "idle") => {
   board.dataset.state = state;
 };
 
+const setIndicatorState = (element, state) => {
+  if (!element) {
+    return;
+  }
+  element.dataset.state = state;
+};
+
+const deriveState = (value, matches) => {
+  if (!value) {
+    return "idle";
+  }
+  return matches ? "good" : "warn";
+};
+
+const updateVisual = (formData) => {
+  const routerStates = new Map(
+    Object.keys(routerIndicators).map((key) => [key, "idle"])
+  );
+  let matchCount = 0;
+
+  Object.entries(expected).forEach(([prefix, target]) => {
+    const selected = formData.get(prefix) || "";
+    const matches = selected === target;
+    setIndicatorState(netIndicators[prefix], deriveState(selected, matches));
+    setIndicatorState(linkIndicators[prefix], deriveState(selected, matches));
+    if (matches) {
+      matchCount += 1;
+    }
+    if (selected) {
+      const current = routerStates.get(selected) || "idle";
+      if (!matches || current === "warn") {
+        routerStates.set(selected, "warn");
+      } else {
+        routerStates.set(selected, "good");
+      }
+    }
+  });
+
+  routerStates.forEach((state, router) => {
+    setIndicatorState(routerIndicators[router], state);
+  });
+
+  if (traceVisual) {
+    const allCorrect = Object.entries(expected).every(
+      ([prefix, target]) => (formData.get(prefix) || "") === target
+    );
+    traceVisual.dataset.flow = allCorrect ? "on" : "off";
+  }
+
+  if (traceMeter) {
+    traceMeter.dataset.state = matchCount === totalRoutes ? "steady" : matchCount > 0 ? "active" : "idle";
+    const ratio = totalRoutes ? matchCount / totalRoutes : 0;
+    traceMeter.style.setProperty("--progress", String(ratio));
+  }
+  tracePips.forEach((pip, index) => {
+    pip.dataset.active = index < matchCount ? "on" : "off";
+  });
+};
+
+const evaluate = (formData) =>
+  Object.entries(expected).filter(([key, value]) => (formData.get(key) || "") !== value);
+
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
   const data = new FormData(form);
-  const mismatches = Object.entries(expected).filter(([key, value]) => data.get(key) !== value);
+  updateVisual(data);
+  const mismatches = evaluate(data);
   if (mismatches.length) {
     updateBoard("Traceroute still breaks. Check the mismatched prefixes.", "error");
     return;
@@ -38,5 +120,16 @@ form?.addEventListener("input", () => {
   if (board.dataset.state === "success") {
     return;
   }
-  updateBoard("Routing daemon idle.");
+  const data = new FormData(form);
+  updateVisual(data);
+  const mismatches = evaluate(data);
+  if (!mismatches.length && Object.values(expected).every((value, index) => data.get(Object.keys(expected)[index]))) {
+    updateBoard("Routes staged. Push when ready.");
+  } else {
+    updateBoard("Routing daemon idle.");
+  }
 });
+
+if (form) {
+  updateVisual(new FormData(form));
+}

--- a/madia.new/public/secret/net/hopline-diagnostics/index.html
+++ b/madia.new/public/secret/net/hopline-diagnostics/index.html
@@ -75,6 +75,43 @@ $ traceroute studio.lan
           <button type="submit" class="execute-button">Deploy routes</button>
         </form>
         <div id="status-board" class="status-board" aria-live="polite">Routing daemon idle.</div>
+        <div class="trace-visual" aria-hidden="true">
+          <div class="net" data-net="lab">
+            <span class="net-label">10.20.0.0/16</span>
+          </div>
+          <div class="net" data-net="studio">
+            <span class="net-label">172.22.40.0/21</span>
+          </div>
+          <div class="net" data-net="isp">
+            <span class="net-label">198.51.100.0/28</span>
+          </div>
+          <div class="router" data-router="edge-hub">
+            <span class="router-label">edge-hub</span>
+          </div>
+          <div class="router" data-router="studio-loop">
+            <span class="router-label">studio-loop</span>
+          </div>
+          <div class="router" data-router="metro-border">
+            <span class="router-label">metro-border</span>
+          </div>
+          <div class="link" data-link="lab"></div>
+          <div class="link" data-link="studio"></div>
+          <div class="link" data-link="isp"></div>
+          <div class="packet" aria-hidden="true"></div>
+          <div class="packet" aria-hidden="true"></div>
+          <div class="packet" aria-hidden="true"></div>
+        </div>
+        <div class="trace-meter" aria-hidden="true">
+          <span class="trace-label">Announce health</span>
+          <div class="trace-bar">
+            <span class="trace-fill"></span>
+          </div>
+          <div class="trace-pips">
+            <span class="trace-pip" data-index="0"></span>
+            <span class="trace-pip" data-index="1"></span>
+            <span class="trace-pip" data-index="2"></span>
+          </div>
+        </div>
       </section>
     </main>
     <footer>Keep the traceroute green and the pager silent.</footer>

--- a/madia.new/public/secret/net/kernel-forge-20/index.html
+++ b/madia.new/public/secret/net/kernel-forge-20/index.html
@@ -70,6 +70,35 @@
           <button type="submit" class="execute-button">make bzImage</button>
         </form>
         <div class="status-board" id="status-board" aria-live="polite">Awaiting config for make menuconfig…</div>
+        <div class="compile-visual" aria-hidden="true">
+          <div class="compile-dial" data-step="network">
+            <span class="dial-label">Routing stack</span>
+            <span class="dial-meter"></span>
+          </div>
+          <div class="compile-dial" data-step="drivers">
+            <span class="dial-label">Driver matrix</span>
+            <span class="dial-meter"></span>
+          </div>
+          <div class="compile-dial" data-step="trim">
+            <span class="dial-label">Image trim</span>
+            <span class="dial-meter"></span>
+          </div>
+          <div class="compile-progress" data-state="idle">
+            <span class="progress-label">bzImage</span>
+            <svg viewBox="0 0 120 120" role="presentation" focusable="false">
+              <circle class="progress-track" cx="60" cy="60" r="52"></circle>
+              <circle class="progress-fill" cx="60" cy="60" r="52"></circle>
+            </svg>
+          </div>
+          <div class="compile-ticker" aria-hidden="true">
+            <span class="ticker-label">Build feed</span>
+            <div class="ticker-steps">
+              <span class="ticker-step" data-ticker="network">Routing stack cold</span>
+              <span class="ticker-step" data-ticker="drivers">Drivers queued</span>
+              <span class="ticker-step" data-ticker="trim">Image trim pending</span>
+            </div>
+          </div>
+        </div>
       </section>
     </main>
     <footer>Remember to copy System.map once it boots.</footer>

--- a/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.css
+++ b/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.css
@@ -14,3 +14,252 @@ body {
 .execute-button {
   margin-top: 0.75rem;
 }
+
+.compile-visual {
+  margin-top: 1.25rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  border: 1px solid rgba(110, 255, 210, 0.3);
+  border-radius: 18px;
+  background: linear-gradient(160deg, rgba(4, 32, 38, 0.85), rgba(0, 12, 18, 0.95));
+  padding: 1.25rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.compile-visual::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle, rgba(110, 255, 210, 0.12), transparent 65%);
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.compile-dial {
+  position: relative;
+  padding: 0.85rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(110, 255, 210, 0.25);
+  background: rgba(0, 18, 24, 0.9);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.5);
+  display: grid;
+  gap: 0.5rem;
+  justify-items: center;
+  text-align: center;
+  z-index: 1;
+}
+
+.dial-label {
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(198, 234, 232, 0.75);
+}
+
+.dial-meter {
+  width: 100%;
+  height: 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(110, 255, 210, 0.35);
+  background: rgba(4, 32, 40, 0.85);
+  position: relative;
+  overflow: hidden;
+}
+
+.dial-meter::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(68, 255, 200, 0.2), rgba(68, 255, 200, 0.8));
+  transform-origin: left center;
+  transform: scaleX(var(--fill, 0));
+  transition: transform 0.4s ease;
+}
+
+.compile-dial[data-state="idle"] .dial-meter::after {
+  --fill: 0.2;
+  opacity: 0.5;
+}
+
+.compile-dial[data-state="partial"] .dial-meter::after {
+  --fill: 0.55;
+}
+
+.compile-dial[data-state="warn"] {
+  border-color: rgba(255, 166, 0, 0.6);
+}
+
+.compile-dial[data-state="warn"] .dial-meter::after {
+  --fill: 0.7;
+  background: linear-gradient(90deg, rgba(255, 166, 0, 0.2), rgba(255, 166, 0, 0.85));
+  animation: dial-flicker 0.8s steps(2, jump-none) infinite;
+}
+
+.compile-dial[data-state="good"] {
+  border-color: rgba(110, 255, 210, 0.6);
+  box-shadow: 0 0 16px rgba(110, 255, 210, 0.2);
+}
+
+.compile-dial[data-state="good"] .dial-meter::after {
+  --fill: 1;
+  animation: dial-flow 1.6s linear infinite;
+}
+
+.compile-progress {
+  position: relative;
+  grid-column: span 2;
+  place-self: center;
+  width: 160px;
+  height: 160px;
+  display: grid;
+  place-items: center;
+  z-index: 1;
+}
+
+.compile-progress svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.progress-track {
+  fill: none;
+  stroke: rgba(40, 80, 90, 0.65);
+  stroke-width: 8;
+}
+
+.progress-fill {
+  fill: none;
+  stroke: rgba(110, 255, 210, 0.8);
+  stroke-width: 8;
+  stroke-linecap: round;
+  stroke-dasharray: 326;
+  stroke-dashoffset: calc(326 - 326 * var(--progress, 0));
+  transition: stroke-dashoffset 0.6s ease;
+}
+
+.progress-label {
+  position: absolute;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  color: rgba(198, 234, 232, 0.85);
+}
+
+.compile-progress[data-state="ready"] .progress-fill {
+  stroke: rgba(110, 255, 210, 1);
+  animation: progress-glow 1.8s ease-in-out infinite;
+}
+
+.compile-progress[data-state="warn"] .progress-fill {
+  stroke: rgba(255, 166, 0, 0.85);
+}
+
+.compile-progress[data-state="warn"] .progress-label {
+  color: rgba(255, 182, 73, 0.85);
+}
+
+.compile-ticker {
+  grid-column: span 2;
+  padding: 0.8rem 1rem 1rem;
+  border-radius: 14px;
+  background: rgba(0, 14, 22, 0.9);
+  border: 1px solid rgba(110, 255, 210, 0.25);
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.5);
+  display: grid;
+  gap: 0.6rem;
+  z-index: 1;
+}
+
+.ticker-label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(198, 234, 232, 0.72);
+}
+
+.ticker-steps {
+  display: grid;
+  gap: 0.4rem;
+  font-family: var(--mono-font);
+  font-size: 0.8rem;
+}
+
+.ticker-step {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.35rem 0.4rem;
+  border-radius: 8px;
+  background: rgba(4, 28, 36, 0.85);
+  border: 1px solid rgba(110, 255, 210, 0.2);
+  color: rgba(186, 255, 238, 0.75);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease, color 0.3s ease;
+}
+
+.ticker-step::after {
+  content: attr(data-status);
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.ticker-step[data-state="good"] {
+  border-color: rgba(110, 255, 210, 0.5);
+  box-shadow: 0 0 12px rgba(110, 255, 210, 0.25);
+  color: var(--neon-green);
+}
+
+.ticker-step[data-state="warn"] {
+  border-color: rgba(255, 166, 0, 0.6);
+  box-shadow: 0 0 10px rgba(255, 166, 0, 0.2);
+  color: rgba(255, 182, 73, 0.85);
+}
+
+.ticker-step[data-state="idle"] {
+  color: rgba(186, 255, 238, 0.55);
+}
+
+.compile-ticker[data-state="ready"] {
+  border-color: rgba(110, 255, 210, 0.6);
+  box-shadow: 0 0 20px rgba(68, 255, 200, 0.25);
+}
+
+.compile-ticker[data-state="warn"] {
+  border-color: rgba(255, 166, 0, 0.55);
+  box-shadow: 0 0 18px rgba(255, 166, 0, 0.25);
+}
+
+@keyframes dial-flow {
+  0% {
+    transform: scaleX(0.4);
+  }
+  50% {
+    transform: scaleX(1);
+  }
+  100% {
+    transform: scaleX(0.4);
+  }
+}
+
+@keyframes dial-flicker {
+  0%,
+  100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes progress-glow {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 4px rgba(110, 255, 210, 0.5));
+  }
+  50% {
+    filter: drop-shadow(0 0 10px rgba(110, 255, 210, 0.7));
+  }
+}

--- a/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.js
+++ b/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.js
@@ -1,5 +1,39 @@
 const form = document.getElementById("kernel-form");
 const board = document.getElementById("status-board");
+const dialLookup = {
+  network: document.querySelector('[data-step="network"]'),
+  drivers: document.querySelector('[data-step="drivers"]'),
+  trim: document.querySelector('[data-step="trim"]'),
+};
+const progressGauge = document.querySelector(".compile-progress");
+const ticker = document.querySelector(".compile-ticker");
+const tickerSteps = ticker
+  ? {
+      network: ticker.querySelector('[data-ticker="network"]'),
+      drivers: ticker.querySelector('[data-ticker="drivers"]'),
+      trim: ticker.querySelector('[data-ticker="trim"]'),
+    }
+  : {};
+
+const tickerMessages = {
+  network: {
+    idle: "stack cold",
+    partial: "patching",
+    warn: "miswired",
+    good: "linked",
+  },
+  drivers: {
+    idle: "waiting",
+    partial: "queuing",
+    warn: "conflict",
+    good: "locked in",
+  },
+  trim: {
+    idle: "unused",
+    warn: "bloated",
+    good: "lean",
+  },
+};
 
 const REQUIRED_NETWORK = ["forwarding", "firewall"];
 const OPTIONAL_NETWORK = ["ipv6"];
@@ -39,15 +73,93 @@ const evaluateKernel = (formData) => {
     }
   });
 
-  return issues;
+  return { issues, network, drivers, nicMode };
+};
+
+const setDialState = (key, state) => {
+  const dial = dialLookup[key];
+  if (!dial) {
+    return;
+  }
+  dial.dataset.state = state;
+};
+
+const updateTickerStep = (key, state) => {
+  const element = tickerSteps[key];
+  if (!element) {
+    return;
+  }
+  element.dataset.state = state;
+  const statusMap = tickerMessages[key] || {};
+  const status = statusMap[state] || statusMap.idle || "idle";
+  element.dataset.status = status;
+};
+
+const updateCompileVisual = ({ network, drivers, nicMode }) => {
+  const hasForwarding = network.has("forwarding");
+  const hasFirewall = network.has("firewall");
+  const hasIPv6 = network.has("ipv6");
+
+  let networkState = "idle";
+  if (hasIPv6) {
+    networkState = "warn";
+  } else if (hasForwarding && hasFirewall) {
+    networkState = "good";
+  } else if (hasForwarding || hasFirewall || network.size > 0) {
+    networkState = "partial";
+  }
+  setDialState("network", networkState);
+
+  let driverState = "partial";
+  if (drivers.has("scsi") || drivers.has("sound")) {
+    driverState = "warn";
+  } else if (nicMode === REQUIRED_NIC_MODE) {
+    driverState = "good";
+  }
+  setDialState("drivers", driverState);
+
+  const trimState = drivers.has("scsi") || drivers.has("sound") ? "warn" : "good";
+  setDialState("trim", trimState);
+  updateTickerStep("network", networkState);
+  updateTickerStep("drivers", driverState);
+  updateTickerStep("trim", trimState);
+
+  const states = [networkState, driverState, trimState];
+  const goodCount = states.filter((state) => state === "good").length;
+  const warnCount = states.filter((state) => state === "warn").length;
+  const progress = goodCount / states.length;
+
+  if (progressGauge) {
+    progressGauge.style.setProperty("--progress", String(progress));
+    if (warnCount > 0) {
+      progressGauge.dataset.state = "warn";
+    } else if (goodCount === states.length) {
+      progressGauge.dataset.state = "ready";
+    } else {
+      progressGauge.dataset.state = "idle";
+    }
+  }
+
+  if (ticker) {
+    if (warnCount > 0) {
+      ticker.dataset.state = "warn";
+    } else if (goodCount === states.length) {
+      ticker.dataset.state = "ready";
+    } else if (states.some((state) => state !== "idle")) {
+      ticker.dataset.state = "active";
+    } else {
+      ticker.dataset.state = "idle";
+    }
+  }
 };
 
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
   const formData = new FormData(form);
-  const issues = evaluateKernel(formData);
-  if (issues.length) {
-    updateBoard(`Build failed: ${issues.join(", ")}.`, "error");
+  const result = evaluateKernel(formData);
+  updateCompileVisual(result);
+  if (result.issues.length) {
+    updateBoard(`Build failed: ${result.issues.join(", ")}.`, "error");
     return;
   }
   updateBoard("Kernel linked. bzImage staged in /boot.", "success");
@@ -69,10 +181,18 @@ form?.addEventListener("input", () => {
     return;
   }
   const formData = new FormData(form);
-  const issues = evaluateKernel(formData);
-  if (!issues.length) {
+  const result = evaluateKernel(formData);
+  updateCompileVisual(result);
+  if (!result.issues.length) {
     updateBoard("Config matches memo. make bzImage ready.");
+  } else if (result.issues.length < 3) {
+    updateBoard("Tuning flags… keep trimming.");
   } else {
     updateBoard("Awaiting config for make menuconfig…");
   }
 });
+
+if (form) {
+  const initial = evaluateKernel(new FormData(form));
+  updateCompileVisual(initial);
+}

--- a/madia.new/public/secret/net/modem-skunkworks/index.html
+++ b/madia.new/public/secret/net/modem-skunkworks/index.html
@@ -69,6 +69,37 @@
           <button type="submit" class="execute-button">Dial now</button>
         </form>
         <div class="status-board" id="status-board" aria-live="polite">Modem idle. Awaiting script…</div>
+        <div class="wave-visual" aria-hidden="true">
+          <div class="phase" data-phase="carrier">
+            <span class="phase-label">Carrier</span>
+            <span class="phase-line"></span>
+          </div>
+          <div class="phase" data-phase="lcp">
+            <span class="phase-label">LCP</span>
+            <span class="phase-line"></span>
+          </div>
+          <div class="phase" data-phase="auth">
+            <span class="phase-label">Auth</span>
+            <span class="phase-line"></span>
+          </div>
+          <div class="phase" data-phase="ipcp">
+            <span class="phase-label">IPCP</span>
+            <span class="phase-line"></span>
+          </div>
+          <div class="wave-track"></div>
+        </div>
+        <div class="sync-meter" aria-hidden="true">
+          <span class="sync-label">Link stability</span>
+          <div class="sync-bar">
+            <span class="sync-fill"></span>
+          </div>
+          <div class="sync-lights">
+            <span class="sync-dot" data-index="0"></span>
+            <span class="sync-dot" data-index="1"></span>
+            <span class="sync-dot" data-index="2"></span>
+            <span class="sync-dot" data-index="3"></span>
+          </div>
+        </div>
       </section>
     </main>
     <footer>Pair your 56K with a clean copper line.</footer>

--- a/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.css
+++ b/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.css
@@ -11,3 +11,216 @@ body {
 .execute-button {
   margin-top: 0.75rem;
 }
+
+.wave-visual {
+  margin-top: 1.25rem;
+  position: relative;
+  border: 1px solid rgba(110, 255, 210, 0.3);
+  border-radius: 18px;
+  background: linear-gradient(140deg, rgba(4, 28, 36, 0.85), rgba(0, 10, 16, 0.95));
+  padding: 1.25rem;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+  overflow: hidden;
+}
+
+.wave-visual[data-state="live"] {
+  border-color: rgba(110, 255, 210, 0.55);
+  box-shadow: 0 0 20px rgba(110, 255, 210, 0.2);
+}
+
+.wave-visual[data-state="warn"] {
+  border-color: rgba(255, 166, 0, 0.6);
+}
+
+.wave-visual[data-state="active"] {
+  border-color: rgba(138, 255, 219, 0.45);
+}
+
+.phase {
+  position: relative;
+  padding: 0.75rem 0.5rem 1.1rem;
+  border-radius: 12px;
+  background: rgba(0, 18, 26, 0.85);
+  border: 1px solid rgba(110, 255, 210, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.55);
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.78rem;
+  color: rgba(198, 234, 232, 0.75);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease, color 0.3s ease;
+  z-index: 1;
+}
+
+.phase-line {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: 0.7rem;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(68, 255, 200, 0.15);
+  overflow: hidden;
+}
+
+.phase-line::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(68, 255, 200, 0.25), rgba(68, 255, 200, 0.85));
+  transform-origin: left center;
+  transform: scaleX(var(--fill, 0));
+  transition: transform 0.4s ease;
+}
+
+.phase[data-state="idle"] .phase-line::after {
+  --fill: 0.2;
+  opacity: 0.45;
+}
+
+.phase[data-state="ready"] .phase-line::after {
+  --fill: 0.6;
+}
+
+.phase[data-state="warn"] {
+  border-color: rgba(255, 166, 0, 0.6);
+  color: rgba(255, 182, 73, 0.85);
+}
+
+.phase[data-state="warn"] .phase-line::after {
+  --fill: 0.8;
+  background: linear-gradient(90deg, rgba(255, 166, 0, 0.25), rgba(255, 166, 0, 0.85));
+  animation: phase-flicker 0.7s steps(2, jump-none) infinite;
+}
+
+.phase[data-state="good"] {
+  border-color: rgba(110, 255, 210, 0.65);
+  box-shadow: 0 0 14px rgba(110, 255, 210, 0.2);
+  color: var(--status-success);
+}
+
+.phase[data-state="good"] .phase-line::after {
+  --fill: 1;
+  animation: phase-flow 1.5s linear infinite;
+}
+
+.wave-track {
+  position: absolute;
+  inset: calc(50% - 4px) 1.25rem auto 1.25rem;
+  height: 8px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(68, 255, 200, 0.15), rgba(68, 255, 200, 0.35));
+  animation: carrier-wave 3.2s ease-in-out infinite;
+  opacity: 0.6;
+}
+
+.wave-visual[data-state="live"] .wave-track {
+  animation-duration: 1.6s;
+  box-shadow: 0 0 18px rgba(110, 255, 210, 0.3);
+}
+
+.wave-visual[data-state="warn"] .wave-track {
+  background: linear-gradient(90deg, rgba(255, 166, 0, 0.15), rgba(255, 166, 0, 0.4));
+  animation-duration: 1.1s;
+}
+
+.sync-meter {
+  margin-top: 1rem;
+  padding: 0.85rem 1.1rem 1.1rem;
+  border-radius: 16px;
+  background: rgba(0, 14, 20, 0.92);
+  border: 1px solid rgba(110, 255, 210, 0.25);
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.6);
+  --progress: 0;
+}
+
+.sync-meter[data-state="active"] {
+  border-color: rgba(110, 255, 210, 0.38);
+  box-shadow: 0 0 18px rgba(68, 255, 200, 0.22);
+}
+
+.sync-meter[data-state="linked"] {
+  border-color: rgba(110, 255, 210, 0.6);
+  box-shadow: 0 0 24px rgba(68, 255, 200, 0.28);
+}
+
+.sync-label {
+  display: block;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(198, 234, 232, 0.72);
+}
+
+.sync-bar {
+  position: relative;
+  height: 10px;
+  margin-top: 0.5rem;
+  border-radius: 999px;
+  background: rgba(6, 34, 42, 0.85);
+  overflow: hidden;
+}
+
+.sync-fill {
+  position: absolute;
+  inset: 0;
+  transform-origin: left center;
+  transform: scaleX(var(--progress));
+  background: linear-gradient(90deg, rgba(68, 255, 200, 0.25), rgba(68, 255, 200, 0.85));
+  transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.sync-lights {
+  margin-top: 0.6rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.sync-dot {
+  flex: 1;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(6, 26, 36, 0.85);
+  border: 1px solid rgba(110, 255, 210, 0.25);
+  box-shadow: 0 0 0 rgba(68, 255, 200, 0.18);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.sync-dot[data-active="on"] {
+  background: var(--neon-green);
+  box-shadow: 0 0 14px rgba(68, 255, 200, 0.6);
+}
+
+@keyframes phase-flow {
+  0% {
+    transform: scaleX(0.5);
+  }
+  50% {
+    transform: scaleX(1);
+  }
+  100% {
+    transform: scaleX(0.5);
+  }
+}
+
+@keyframes phase-flicker {
+  0%,
+  100% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes carrier-wave {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(4px);
+  }
+}

--- a/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.js
+++ b/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.js
@@ -1,5 +1,15 @@
 const form = document.getElementById("ppp-form");
 const board = document.getElementById("status-board");
+const waveVisual = document.querySelector(".wave-visual");
+const phaseIndicators = {
+  carrier: document.querySelector('[data-phase="carrier"]'),
+  lcp: document.querySelector('[data-phase="lcp"]'),
+  auth: document.querySelector('[data-phase="auth"]'),
+  ipcp: document.querySelector('[data-phase="ipcp"]'),
+};
+const syncMeter = document.querySelector(".sync-meter");
+const syncDots = syncMeter ? syncMeter.querySelectorAll(".sync-dot") : [];
+const totalPhases = Object.keys(expectedOrder).length;
 
 const expectedOrder = {
   carrier: "1",
@@ -13,33 +23,101 @@ const updateBoard = (message, state = "idle") => {
   board.dataset.state = state;
 };
 
-const evaluateOrder = (formData) => {
-  const values = Object.fromEntries(Object.keys(expectedOrder).map((key) => [key, formData.get(key) || ""]));
-  const duplicates = new Set();
+const extractValues = (formData) =>
+  Object.fromEntries(
+    Object.keys(expectedOrder).map((key) => [key, formData.get(key) || ""])
+  );
+
+const computeDuplicates = (values) => {
   const seen = new Map();
-  Object.entries(values).forEach(([key, value]) => {
-    if (!value) {
+  const duplicates = new Set();
+  Object.entries(values).forEach(([phase, slot]) => {
+    if (!slot) {
       return;
     }
-    if (seen.has(value)) {
-      duplicates.add(value);
+    if (seen.has(slot)) {
+      duplicates.add(phase);
+      duplicates.add(seen.get(slot));
+    } else {
+      seen.set(slot, phase);
     }
-    seen.set(value, key);
   });
-  const mismatches = Object.entries(expectedOrder).filter(([key, value]) => values[key] !== value).map(([key]) => key);
-  return { duplicates, mismatches };
+  return duplicates;
+};
+
+const updateWaveVisual = (values, duplicates) => {
+  const states = [];
+  Object.entries(phaseIndicators).forEach(([phase, element]) => {
+    if (!element) {
+      return;
+    }
+    const slot = values[phase];
+    let state = "idle";
+    if (slot) {
+      if (duplicates.has(phase)) {
+        state = "warn";
+      } else if (slot === expectedOrder[phase]) {
+        state = "good";
+      } else {
+        state = "ready";
+      }
+    }
+    element.dataset.state = state;
+    states.push(state);
+  });
+
+  const goodCount = states.filter((state) => state === "good").length;
+  const activeCount = states.filter((state) => state === "ready" || state === "good").length;
+
+  if (waveVisual) {
+    const allGood = states.length && states.every((state) => state === "good");
+    const hasWarn = states.some((state) => state === "warn");
+    const hasActive = states.some((state) => state === "ready" || state === "good");
+    if (allGood) {
+      waveVisual.dataset.state = "live";
+    } else if (hasWarn) {
+      waveVisual.dataset.state = "warn";
+    } else if (hasActive) {
+      waveVisual.dataset.state = "active";
+    } else {
+      waveVisual.dataset.state = "idle";
+    }
+  }
+
+  if (syncMeter) {
+    const ratio = totalPhases ? goodCount / totalPhases : 0;
+    syncMeter.style.setProperty("--progress", String(ratio));
+    if (goodCount === totalPhases) {
+      syncMeter.dataset.state = "linked";
+    } else if (activeCount > 0) {
+      syncMeter.dataset.state = "active";
+    } else {
+      syncMeter.dataset.state = "idle";
+    }
+  }
+  syncDots.forEach((dot, index) => {
+    dot.dataset.active = index < goodCount ? "on" : "off";
+  });
 };
 
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
   const formData = new FormData(form);
-  const { duplicates, mismatches } = evaluateOrder(formData);
+  const values = extractValues(formData);
+  const duplicates = computeDuplicates(values);
+  updateWaveVisual(values, duplicates);
   if (duplicates.size) {
-    updateBoard(`Modem error: duplicate steps ${Array.from(duplicates).join(", ")}.`, "error");
+    updateBoard(
+      `Modem error: duplicate steps ${Array.from(duplicates).join(", ")}.`,
+      "error"
+    );
     return;
   }
+  const mismatches = Object.entries(expectedOrder).filter(
+    ([phase, slot]) => values[phase] !== slot
+  );
   if (mismatches.length) {
-    updateBoard(`Negotiation failed: adjust ${mismatches.join(", ")}.`, "error");
+    updateBoard(`Negotiation failed: adjust ${mismatches.map(([phase]) => phase).join(", ")}.`, "error");
     return;
   }
   updateBoard("PPP link live. newsroom feed synchronized.", "success");
@@ -61,10 +139,24 @@ form?.addEventListener("input", () => {
     return;
   }
   const formData = new FormData(form);
-  const { duplicates, mismatches } = evaluateOrder(formData);
+  const values = extractValues(formData);
+  const duplicates = computeDuplicates(values);
+  updateWaveVisual(values, duplicates);
+  const mismatches = Object.entries(expectedOrder).filter(
+    ([phase, slot]) => values[phase] !== slot
+  );
   if (!duplicates.size && !mismatches.length) {
     updateBoard("Sequence locked. Dial when ready.");
+  } else if (duplicates.size) {
+    updateBoard("Handshake colliding. Clear duplicates.");
+  } else if (Object.values(values).some(Boolean)) {
+    updateBoard("Negotiation tuning…");
   } else {
     updateBoard("Modem idle. Awaiting script…");
   }
 });
+
+if (form) {
+  const initialValues = extractValues(new FormData(form));
+  updateWaveVisual(initialValues, new Set());
+}

--- a/madia.new/public/secret/net/root-zone-relay/index.html
+++ b/madia.new/public/secret/net/root-zone-relay/index.html
@@ -88,6 +88,31 @@
           <button type="submit" class="execute-button">Push zone live</button>
         </form>
         <div class="status-board" id="status-board" aria-live="polite">Awaiting alignment…</div>
+        <div class="zone-visual" aria-hidden="true">
+          <div class="zone-tile" data-record="www">
+            <span class="tile-label">www</span>
+            <span class="tile-value">A</span>
+          </div>
+          <div class="zone-tile" data-record="mail">
+            <span class="tile-label">mail</span>
+            <span class="tile-value">MX</span>
+          </div>
+          <div class="zone-tile" data-record="root">
+            <span class="tile-label">@</span>
+            <span class="tile-value">NS</span>
+          </div>
+        </div>
+        <div class="propagation-meter" aria-hidden="true">
+          <span class="propagation-label">Propagation window</span>
+          <div class="propagation-bar">
+            <span class="propagation-fill"></span>
+          </div>
+          <div class="propagation-pips">
+            <span class="propagation-pip" data-index="0"></span>
+            <span class="propagation-pip" data-index="1"></span>
+            <span class="propagation-pip" data-index="2"></span>
+          </div>
+        </div>
       </section>
     </main>
     <footer>Based on IETF RFCs that kept the '96 backbone humming.</footer>

--- a/madia.new/public/secret/net/root-zone-relay/root-zone-relay.css
+++ b/madia.new/public/secret/net/root-zone-relay/root-zone-relay.css
@@ -15,3 +15,136 @@ body {
 .execute-button {
   margin-top: 0.25rem;
 }
+
+.zone-visual {
+  margin-top: 1.2rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+  border: 1px solid rgba(110, 255, 210, 0.3);
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(4, 30, 36, 0.85), rgba(0, 12, 18, 0.95));
+  padding: 1.25rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.zone-visual::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle, rgba(110, 255, 210, 0.1), transparent 70%);
+  pointer-events: none;
+}
+
+.zone-visual[data-state="aligned"] {
+  box-shadow: 0 0 18px rgba(110, 255, 210, 0.2);
+}
+
+.zone-tile {
+  position: relative;
+  padding: 1rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(110, 255, 210, 0.2);
+  background: rgba(0, 20, 26, 0.88);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.55);
+  text-align: center;
+  display: grid;
+  gap: 0.5rem;
+  z-index: 1;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.tile-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(198, 234, 232, 0.75);
+}
+
+.tile-value {
+  font-size: 1.5rem;
+  letter-spacing: 0.12em;
+  color: rgba(110, 255, 210, 0.8);
+}
+
+.zone-tile[data-state="good"] {
+  border-color: rgba(110, 255, 210, 0.6);
+  box-shadow: 0 0 16px rgba(110, 255, 210, 0.18);
+}
+
+.zone-tile[data-state="warn"] {
+  border-color: rgba(255, 166, 0, 0.6);
+  box-shadow: 0 0 14px rgba(255, 166, 0, 0.2);
+}
+
+.zone-tile[data-state="warn"] .tile-value {
+  color: rgba(255, 182, 73, 0.9);
+}
+
+.propagation-meter {
+  margin-top: 1rem;
+  padding: 0.9rem 1.1rem 1.1rem;
+  border-radius: 16px;
+  background: rgba(0, 14, 20, 0.9);
+  border: 1px solid rgba(110, 255, 210, 0.25);
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.55);
+  --progress: 0;
+}
+
+.propagation-meter[data-state="warming"] {
+  border-color: rgba(110, 255, 210, 0.38);
+  box-shadow: 0 0 18px rgba(68, 255, 200, 0.22);
+}
+
+.propagation-meter[data-state="ready"] {
+  border-color: rgba(110, 255, 210, 0.6);
+  box-shadow: 0 0 24px rgba(68, 255, 200, 0.26);
+}
+
+.propagation-label {
+  display: block;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(198, 234, 232, 0.72);
+}
+
+.propagation-bar {
+  position: relative;
+  height: 10px;
+  margin-top: 0.5rem;
+  border-radius: 999px;
+  background: rgba(6, 34, 42, 0.85);
+  overflow: hidden;
+}
+
+.propagation-fill {
+  position: absolute;
+  inset: 0;
+  transform-origin: left center;
+  transform: scaleX(var(--progress));
+  background: linear-gradient(90deg, rgba(68, 255, 200, 0.25), rgba(68, 255, 200, 0.85));
+  transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.propagation-pips {
+  margin-top: 0.6rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.propagation-pip {
+  flex: 1;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(6, 26, 36, 0.85);
+  border: 1px solid rgba(110, 255, 210, 0.25);
+  box-shadow: 0 0 0 rgba(68, 255, 200, 0.18);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.propagation-pip[data-active="on"] {
+  background: var(--neon-green);
+  box-shadow: 0 0 14px rgba(68, 255, 200, 0.6);
+}

--- a/madia.new/public/secret/net/stream-parser-depot/index.html
+++ b/madia.new/public/secret/net/stream-parser-depot/index.html
@@ -69,6 +69,30 @@ rad_reply: Access-Reject packet
           <button type="submit" class="execute-button">Run pipeline</button>
         </form>
         <div id="status-board" class="status-board" aria-live="polite">Awaiting command pair.</div>
+        <div class="pipeline-visual" aria-hidden="true">
+          <div class="pipeline-stage" data-stage="filter">
+            <span class="stage-label">Filter</span>
+            <span class="stage-code" data-code="filter">--</span>
+          </div>
+          <div class="pipeline-stage" data-stage="format">
+            <span class="stage-label">Format</span>
+            <span class="stage-code" data-code="format">--</span>
+          </div>
+          <div class="pipeline-output">
+            <span class="output-label">Sample output</span>
+            <span class="output-line" id="pipeline-output">--</span>
+          </div>
+        </div>
+        <div class="pipeline-meter" aria-hidden="true">
+          <span class="meter-label">Pipeline integrity</span>
+          <div class="meter-bar">
+            <span class="meter-fill"></span>
+          </div>
+          <div class="meter-pips">
+            <span class="meter-pip" data-index="0"></span>
+            <span class="meter-pip" data-index="1"></span>
+          </div>
+        </div>
       </section>
     </main>
     <footer>Keep the pager brief and the regex sharp.</footer>

--- a/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.css
+++ b/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.css
@@ -43,3 +43,172 @@ select {
   color: var(--status-error);
   border-color: var(--status-error);
 }
+
+.pipeline-visual {
+  margin-top: 1.25rem;
+  border: 1px solid rgba(138, 255, 219, 0.35);
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(4, 24, 32, 0.85), rgba(0, 10, 16, 0.95));
+  padding: 1.25rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  overflow: hidden;
+  position: relative;
+}
+
+.pipeline-visual[data-state="good"] {
+  border-color: rgba(110, 255, 210, 0.6);
+  box-shadow: 0 0 20px rgba(110, 255, 210, 0.18);
+}
+
+.pipeline-visual[data-state="warn"] {
+  border-color: rgba(255, 166, 0, 0.6);
+}
+
+.pipeline-visual[data-state="active"] {
+  border-color: rgba(138, 255, 219, 0.45);
+}
+
+.pipeline-stage {
+  position: relative;
+  padding: 0.85rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(138, 255, 219, 0.25);
+  background: rgba(0, 18, 26, 0.9);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.55);
+  display: grid;
+  gap: 0.6rem;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  font-size: 0.8rem;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.stage-code {
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  background: rgba(0, 24, 32, 0.85);
+  border-radius: 8px;
+  padding: 0.35rem 0.5rem;
+  color: rgba(198, 234, 232, 0.75);
+}
+
+.pipeline-stage[data-state="selected"] {
+  border-color: rgba(138, 255, 219, 0.45);
+  box-shadow: 0 0 14px rgba(138, 255, 219, 0.18);
+}
+
+.pipeline-stage[data-state="good"] {
+  border-color: rgba(110, 255, 210, 0.65);
+  box-shadow: 0 0 16px rgba(110, 255, 210, 0.25);
+}
+
+.pipeline-stage[data-state="warn"] {
+  border-color: rgba(255, 166, 0, 0.6);
+  box-shadow: 0 0 16px rgba(255, 166, 0, 0.2);
+}
+
+.pipeline-output {
+  grid-column: span 2;
+  padding: 0.9rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(138, 255, 219, 0.3);
+  background: rgba(0, 16, 24, 0.9);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.5);
+  display: grid;
+  gap: 0.4rem;
+  align-content: start;
+}
+
+.output-label {
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  color: rgba(198, 234, 232, 0.7);
+}
+
+.output-line {
+  font-family: "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  color: rgba(186, 255, 238, 0.85);
+  letter-spacing: 0.03em;
+  animation: pipeline-glow 2.4s ease-in-out infinite;
+}
+
+.pipeline-meter {
+  margin-top: 1rem;
+  padding: 0.85rem 1.1rem 1.1rem;
+  border-radius: 16px;
+  background: rgba(0, 14, 20, 0.9);
+  border: 1px solid rgba(138, 255, 219, 0.25);
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.55);
+  --progress: 0;
+}
+
+.pipeline-meter[data-state="active"] {
+  border-color: rgba(138, 255, 219, 0.38);
+  box-shadow: 0 0 18px rgba(138, 255, 219, 0.22);
+}
+
+.pipeline-meter[data-state="ready"] {
+  border-color: rgba(110, 255, 210, 0.6);
+  box-shadow: 0 0 24px rgba(110, 255, 210, 0.26);
+}
+
+.meter-label {
+  display: block;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(198, 234, 232, 0.72);
+}
+
+.meter-bar {
+  position: relative;
+  height: 10px;
+  margin-top: 0.5rem;
+  border-radius: 999px;
+  background: rgba(6, 34, 42, 0.85);
+  overflow: hidden;
+}
+
+.meter-fill {
+  position: absolute;
+  inset: 0;
+  transform-origin: left center;
+  transform: scaleX(var(--progress));
+  background: linear-gradient(90deg, rgba(138, 255, 219, 0.25), rgba(138, 255, 219, 0.85));
+  transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.meter-pips {
+  margin-top: 0.6rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.meter-pip {
+  flex: 1;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(6, 26, 36, 0.85);
+  border: 1px solid rgba(138, 255, 219, 0.25);
+  box-shadow: 0 0 0 rgba(138, 255, 219, 0.18);
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.meter-pip[data-active="on"] {
+  background: rgba(138, 255, 219, 1);
+  box-shadow: 0 0 14px rgba(138, 255, 219, 0.6);
+}
+
+@keyframes pipeline-glow {
+  0%,
+  100% {
+    text-shadow: 0 0 10px rgba(138, 255, 219, 0.25);
+  }
+  50% {
+    text-shadow: 0 0 16px rgba(138, 255, 219, 0.5);
+  }
+}

--- a/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.js
+++ b/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.js
@@ -1,5 +1,20 @@
 const form = document.getElementById("parser-form");
 const board = document.getElementById("status-board");
+const filterSelect = form?.elements.namedItem("filter");
+const formatSelect = form?.elements.namedItem("format");
+const stageLookup = {
+  filter: document.querySelector('[data-stage="filter"]'),
+  format: document.querySelector('[data-stage="format"]'),
+};
+const codeLookup = {
+  filter: document.querySelector('[data-code="filter"]'),
+  format: document.querySelector('[data-code="format"]'),
+};
+const pipelineContainer = document.querySelector(".pipeline-visual");
+const outputPreview = document.getElementById("pipeline-output");
+const pipelineMeter = document.querySelector(".pipeline-meter");
+const meterPips = pipelineMeter ? pipelineMeter.querySelectorAll(".meter-pip") : [];
+const totalStages = Object.keys(stageLookup).length;
 
 const expected = {
   filter: "sed-block",
@@ -11,11 +26,98 @@ const updateBoard = (message, state = "idle") => {
   board.dataset.state = state;
 };
 
+const stageState = (value, target) => {
+  if (!value) {
+    return "idle";
+  }
+  if (value === target) {
+    return "good";
+  }
+  return "selected";
+};
+
+const updateStage = (stage, value, target, label) => {
+  const element = stageLookup[stage];
+  const code = codeLookup[stage];
+  if (!element || !code) {
+    return;
+  }
+  const optionText = label || "--";
+  code.textContent = value ? optionText : "--";
+  element.dataset.state = stageState(value, target);
+};
+
+const computePreview = (filter, format) => {
+  if (!filter && !format) {
+    return "--";
+  }
+  if (!filter || !format) {
+    return "Incomplete pipeline";
+  }
+  if (filter === expected.filter && format === expected.format) {
+    return "dli CONNECT 64000/ARQ/V34/LAPM/V42BIS";
+  }
+  if (filter === expected.filter) {
+    return "dli … (needs formatting)";
+  }
+  if (format === expected.format) {
+    return "garbled input → CONNECT";
+  }
+  return "Noise: rad_recv ???";
+};
+
+const updatePipelineVisual = (filter, format) => {
+  updateStage(
+    "filter",
+    filter,
+    expected.filter,
+    filterSelect?.selectedOptions?.[0]?.textContent?.trim() || ""
+  );
+  updateStage(
+    "format",
+    format,
+    expected.format,
+    formatSelect?.selectedOptions?.[0]?.textContent?.trim() || ""
+  );
+  if (outputPreview) {
+    outputPreview.textContent = computePreview(filter, format);
+  }
+  if (pipelineContainer) {
+    const states = [stageLookup.filter?.dataset.state, stageLookup.format?.dataset.state];
+    if (states.every((state) => state === "good")) {
+      pipelineContainer.dataset.state = "good";
+    } else if (states.some((state) => state === "warn")) {
+      pipelineContainer.dataset.state = "warn";
+    } else if (states.some((state) => state && state !== "idle")) {
+      pipelineContainer.dataset.state = "active";
+    } else {
+      pipelineContainer.dataset.state = "idle";
+    }
+    const goodCount = states.filter((state) => state === "good").length;
+    const activeCount = states.filter((state) => state && state !== "idle").length;
+    if (pipelineMeter) {
+      const ratio = totalStages ? goodCount / totalStages : 0;
+      pipelineMeter.style.setProperty("--progress", String(ratio));
+      if (goodCount === totalStages) {
+        pipelineMeter.dataset.state = "ready";
+      } else if (activeCount > 0) {
+        pipelineMeter.dataset.state = "active";
+      } else {
+        pipelineMeter.dataset.state = "idle";
+      }
+    }
+    meterPips.forEach((pip, index) => {
+      pip.dataset.active = index < goodCount ? "on" : "off";
+    });
+  }
+};
+
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
   const data = new FormData(form);
   const filter = data.get("filter");
   const format = data.get("format");
+  updatePipelineVisual(filter, format);
   if (filter !== expected.filter || format !== expected.format) {
     updateBoard("Output still messy. Try a tighter selector or trim.", "error");
     return;
@@ -39,9 +141,18 @@ form?.addEventListener("input", () => {
     return;
   }
   const data = new FormData(form);
-  if (data.get("filter") && data.get("format")) {
+  const filter = data.get("filter");
+  const format = data.get("format");
+  updatePipelineVisual(filter, format);
+  if (filter === expected.filter && format === expected.format) {
+    updateBoard("Pipeline locked. Dispatch when ready.");
+  } else if (filter || format) {
     updateBoard("Preview pipeline staged.");
   } else {
     updateBoard("Awaiting command pair.");
   }
 });
+
+if (form) {
+  updatePipelineVisual(filterSelect?.value || "", formatSelect?.value || "");
+}


### PR DESCRIPTION
## Summary
- add themed telemetry widgets to each Net cabinet game so players get live progress feedback while configuring routes, caches, racks, planes, menus, and pipelines
- extend each minigame script to compute completion counts and drive the new HUD states so animations tighten as solutions approach
- polish supporting styles so the new meters glow, pulse, and scale consistently with the mid-90s Net aesthetic

## Testing
- no automated tests (static HTML/JS only)


------
https://chatgpt.com/codex/tasks/task_e_68e5a3becb588328bdfd3199d63b252e