### PR TITLE
feat: add animated feedback to net minigames

### DIFF
--- a/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.css
+++ b/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.css
@@ -5,3 +5,179 @@ body {
 .execute-button {
   margin-top: 0.75rem;
 }
+
+.topology-panel {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.topology {
+  position: relative;
+  min-height: 14rem;
+  border: 1px solid rgba(102, 255, 198, 0.4);
+  background: linear-gradient(135deg, rgba(0, 32, 32, 0.8), rgba(0, 12, 24, 0.9));
+  overflow: hidden;
+}
+
+.topology::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(rgba(64, 154, 106, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(64, 154, 106, 0.08) 1px, transparent 1px);
+  background-size: 32px 32px;
+  mix-blend-mode: screen;
+}
+
+.node {
+  position: absolute;
+  width: 7rem;
+  height: 7rem;
+  border: 1px solid rgba(132, 255, 210, 0.7);
+  background: rgba(0, 48, 44, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 0.5rem;
+  border-radius: 50%;
+  box-shadow: 0 0 15px rgba(38, 255, 186, 0.25);
+  animation: idleGlow 4s linear infinite;
+}
+
+.node[data-node="backbone"] {
+  left: 1.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.node[data-node="fiber-ring"] {
+  right: 2rem;
+  top: 2rem;
+}
+
+.node[data-node="frame-relay"] {
+  right: 2rem;
+  bottom: 2rem;
+}
+
+.node[data-state="active"] {
+  border-color: var(--status-success);
+  box-shadow: 0 0 25px rgba(78, 255, 206, 0.5);
+}
+
+.node[data-state="warning"] {
+  border-color: var(--status-warning);
+  box-shadow: 0 0 20px rgba(255, 190, 80, 0.5);
+  animation: alarmBlink 0.8s linear infinite;
+}
+
+.node[data-state="offline"] {
+  border-color: rgba(80, 80, 80, 0.8);
+  background: rgba(10, 10, 12, 0.9);
+  box-shadow: none;
+  animation: none;
+  opacity: 0.7;
+}
+
+.node-label {
+  font-size: 0.9rem;
+  line-height: 1.2;
+}
+
+.link {
+  position: absolute;
+  height: 4px;
+  background: linear-gradient(90deg, rgba(46, 192, 168, 0.9), rgba(128, 255, 220, 0.4));
+  box-shadow: 0 0 12px rgba(56, 192, 160, 0.45);
+  transform-origin: left center;
+  animation: signalFlow 1.6s linear infinite;
+}
+
+.link[data-link="primary"] {
+  left: 7.5rem;
+  top: 5rem;
+  width: 11rem;
+  transform: rotate(-12deg);
+}
+
+.link[data-link="backup"] {
+  left: 7.5rem;
+  bottom: 5rem;
+  width: 11rem;
+  transform: rotate(12deg);
+}
+
+.link[data-state="congested"] {
+  background: linear-gradient(90deg, rgba(255, 120, 120, 0.9), rgba(255, 196, 120, 0.5));
+  box-shadow: 0 0 14px rgba(255, 120, 120, 0.6);
+  animation-duration: 0.8s;
+}
+
+.link[data-state="idle"] {
+  opacity: 0.6;
+  animation-duration: 2.4s;
+}
+
+.event-feed {
+  margin: 0;
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+  max-height: 9rem;
+  overflow: auto;
+}
+
+.event-feed li {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.event-feed li::before {
+  content: "▶";
+  color: rgba(102, 255, 198, 0.75);
+  font-size: 0.75rem;
+}
+
+.event-feed li[data-variant="error"] {
+  color: var(--status-error);
+}
+
+.event-feed li[data-variant="success"] {
+  color: var(--status-success);
+}
+
+@keyframes signalFlow {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 10rem 0;
+  }
+}
+
+@keyframes idleGlow {
+  0%,
+  100% {
+    box-shadow: 0 0 12px rgba(56, 192, 160, 0.35);
+  }
+  50% {
+    box-shadow: 0 0 20px rgba(98, 255, 208, 0.55);
+  }
+}
+
+@keyframes alarmBlink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}

--- a/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.js
+++ b/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.js
@@ -1,5 +1,15 @@
 const form = document.getElementById("bgp-form");
 const board = document.getElementById("status-board");
+const eventFeed = document.getElementById("event-feed");
+const nodes = {
+  backbone: document.querySelector('[data-node="backbone"]'),
+  fiber: document.querySelector('[data-node="fiber-ring"]'),
+  frame: document.querySelector('[data-node="frame-relay"]'),
+};
+const links = {
+  primary: document.querySelector('[data-link="primary"]'),
+  backup: document.querySelector('[data-link="backup"]'),
+};
 
 const expected = {
   "local-pref": "raise",
@@ -7,9 +17,95 @@ const expected = {
   community: "blackhole",
 };
 
-const updateBoard = (message, state = "idle") => {
+let lastBoardMessage = "";
+let lastEventSignature = "";
+
+const trimEventFeed = () => {
+  if (!eventFeed) {
+    return;
+  }
+  const maxEntries = 8;
+  while (eventFeed.children.length > maxEntries) {
+    eventFeed.removeChild(eventFeed.firstElementChild);
+  }
+};
+
+const logEvent = (message, variant = "info") => {
+  if (!eventFeed) {
+    return;
+  }
+  const signature = `${variant}:${message}`;
+  if (signature === lastEventSignature) {
+    return;
+  }
+  const item = document.createElement("li");
+  item.textContent = message;
+  if (variant !== "info") {
+    item.dataset.variant = variant;
+  }
+  eventFeed.append(item);
+  trimEventFeed();
+  eventFeed.scrollTop = eventFeed.scrollHeight;
+  lastEventSignature = signature;
+};
+
+const applyState = (element, state) => {
+  if (!element) {
+    return;
+  }
+  if (state) {
+    element.dataset.state = state;
+  } else {
+    delete element.dataset.state;
+  }
+};
+
+const applyTopologyState = (formData) => {
+  const localPref = formData.get("local-pref") || "";
+  const asPath = formData.get("as-path") || "";
+  const community = formData.get("community") || "";
+
+  if (!nodes.backbone || !nodes.fiber || !nodes.frame) {
+    return;
+  }
+
+  applyState(nodes.backbone, !localPref ? "" : localPref === expected["local-pref"] ? "active" : "warning");
+  applyState(nodes.fiber, localPref === expected["local-pref"] ? "active" : localPref ? "warning" : "");
+  if (community === expected.community && asPath === expected["as-path"]) {
+    applyState(nodes.frame, "offline");
+  } else if (!community && !asPath) {
+    applyState(nodes.frame, "");
+  } else {
+    applyState(nodes.frame, "warning");
+  }
+
+  if (links.primary) {
+    applyState(
+      links.primary,
+      !localPref ? "idle" : localPref === expected["local-pref"] ? "" : "congested"
+    );
+  }
+  if (links.backup) {
+    const backupState =
+      !asPath && !community
+        ? ""
+        : asPath === expected["as-path"] && community === expected.community
+        ? "idle"
+        : "congested";
+    applyState(links.backup, backupState);
+  }
+};
+
+const updateBoard = (message, state = "idle", variant = "info") => {
+  if (!board) {
+    return;
+  }
   board.textContent = message;
   board.dataset.state = state;
+  if (message !== lastBoardMessage && (state === "success" || state === "error" || variant !== "info")) {
+    logEvent(message, state === "error" ? "error" : state === "success" ? "success" : variant);
+  }
+  lastBoardMessage = message;
 };
 
 const evaluatePolicy = (formData) => {
@@ -22,12 +118,15 @@ const evaluatePolicy = (formData) => {
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
   const formData = new FormData(form);
+  applyTopologyState(formData);
   const mismatches = evaluatePolicy(formData);
   if (mismatches.length) {
     updateBoard(`Route map rejected: fix ${mismatches.join(", ")}.`, "error");
+    logEvent("Backup path still leaky. Rein in the policy table.", "error");
     return;
   }
   updateBoard("Policies live. Backbone prefers fiber ring.", "success");
+  logEvent("Traffic converged on fiber ring. Frame relay damped.", "success");
   window.parent?.postMessage(
     {
       type: "net:level-complete",
@@ -46,10 +145,17 @@ form?.addEventListener("input", () => {
     return;
   }
   const formData = new FormData(form);
+  applyTopologyState(formData);
   const mismatches = evaluatePolicy(formData);
   if (!mismatches.length) {
-    updateBoard("Policy ready. Deploy to routers.");
+    updateBoard("Policy ready. Deploy to routers.", "idle", "info");
+    logEvent("Route-map staged. Awaiting commit.");
   } else {
     updateBoard("Session flapping. Apply damping plan…");
   }
 });
+
+if (form) {
+  logEvent("Monitoring BGP session for leaks.");
+  applyTopologyState(new FormData(form));
+}

--- a/madia.new/public/secret/net/borderline-broadcast/index.html
+++ b/madia.new/public/secret/net/borderline-broadcast/index.html
@@ -50,6 +50,23 @@
           </label>
           <button type="submit" class="execute-button">Deploy policies</button>
         </form>
+        <div class="topology-panel" aria-labelledby="topology-heading">
+          <h3 id="topology-heading">Backbone topology monitor</h3>
+          <div class="topology" role="presentation">
+            <div class="node" data-node="backbone">
+              <span class="node-label">Backbone-1</span>
+            </div>
+            <div class="node" data-node="fiber-ring">
+              <span class="node-label">Fiber Ring</span>
+            </div>
+            <div class="node" data-node="frame-relay">
+              <span class="node-label">Frame Relay</span>
+            </div>
+            <div class="link" data-link="primary"></div>
+            <div class="link" data-link="backup"></div>
+          </div>
+          <ul id="event-feed" class="event-feed" aria-live="polite" aria-label="Routing event log"></ul>
+        </div>
         <div class="status-board" id="status-board" aria-live="polite">Session flapping. Apply damping plan…</div>
       </section>
     </main>

--- a/madia.new/public/secret/net/common.css
+++ b/madia.new/public/secret/net/common.css
@@ -8,6 +8,12 @@
   --net-text: #e2fbe2;
   --net-muted: rgba(148, 197, 183, 0.78);
   --net-danger: #ff5f6d;
+  --text-primary: var(--net-text);
+  --text-muted: var(--net-muted);
+  --font-mono: "IBM Plex Mono", "Fira Code", "Menlo", monospace;
+  --status-success: #48ffb8;
+  --status-error: #ff5f6d;
+  --status-warning: #f4b400;
   font-family: "IBM Plex Mono", "Fira Code", "Menlo", monospace;
 }
 

--- a/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.css
+++ b/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.css
@@ -9,6 +9,18 @@ main {
   color: var(--text-muted);
 }
 
+.deck-layout {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 980px) {
+  .deck-layout {
+    grid-template-columns: 1.3fr 1fr;
+    align-items: start;
+  }
+}
+
 .command-grid {
   display: grid;
   gap: 1rem;
@@ -27,6 +39,158 @@ select {
   padding: 0.4rem 0.6rem;
 }
 
+.flight-visualizer {
+  border: 1px solid rgba(102, 255, 210, 0.4);
+  background: linear-gradient(160deg, rgba(6, 18, 32, 0.9), rgba(4, 10, 24, 0.95));
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.flight-visualizer h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: rgba(128, 255, 226, 0.85);
+}
+
+.radar-screen {
+  position: relative;
+  border: 1px solid rgba(102, 255, 210, 0.35);
+  border-radius: 50%;
+  aspect-ratio: 1 / 1;
+  background: radial-gradient(circle, rgba(12, 72, 100, 0.3), rgba(0, 20, 28, 0.95));
+  overflow: hidden;
+  box-shadow: 0 0 18px rgba(40, 200, 180, 0.25);
+}
+
+.radar-screen::before,
+.radar-screen::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+}
+
+.radar-screen::before {
+  background: radial-gradient(circle, rgba(128, 255, 210, 0.12), transparent 60%);
+}
+
+.radar-screen::after {
+  background-image: linear-gradient(rgba(72, 255, 210, 0.08) 2px, transparent 2px),
+    linear-gradient(90deg, rgba(72, 255, 210, 0.08) 2px, transparent 2px);
+  background-size: 28px 28px;
+  mix-blend-mode: screen;
+}
+
+.radar-sweep {
+  position: absolute;
+  inset: 0;
+  background: conic-gradient(rgba(128, 255, 226, 0.25), transparent 55%);
+  transform-origin: center;
+  animation: radarSweep 4s linear infinite;
+}
+
+.radar-blip {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(128, 255, 226, 0.9);
+  top: 18%;
+  left: 60%;
+  transform: translate(-50%, -50%);
+  animation: blipPulse 2s ease-in-out infinite;
+}
+
+.radar-screen[data-state="idle"] .radar-sweep {
+  animation-duration: 6s;
+  opacity: 0.6;
+}
+
+.radar-screen[data-state="warning"] {
+  box-shadow: 0 0 20px rgba(255, 120, 120, 0.35);
+}
+
+.radar-screen[data-state="warning"] .radar-blip {
+  background: rgba(255, 140, 120, 0.9);
+  animation-duration: 1s;
+}
+
+.radar-screen[data-state="success"] {
+  box-shadow: 0 0 26px rgba(98, 255, 210, 0.4);
+}
+
+.queue-readout {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(160, 255, 230, 0.9);
+}
+
+.transfer-meter {
+  height: 0.75rem;
+  border: 1px solid rgba(102, 255, 210, 0.45);
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(0, 22, 28, 0.8);
+}
+
+.transfer-fill {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, rgba(102, 255, 210, 0.75), rgba(30, 144, 255, 0.65));
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.35s ease;
+}
+
+.command-track {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.command-track li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  border: 1px solid rgba(102, 255, 210, 0.25);
+  background: rgba(0, 14, 26, 0.7);
+  padding: 0.45rem 0.6rem;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.command-track li[data-state="locked"] {
+  border-color: rgba(102, 255, 210, 0.8);
+  box-shadow: 0 0 16px rgba(102, 255, 210, 0.3);
+}
+
+.command-track li[data-state="queued"] {
+  border-color: rgba(244, 180, 0, 0.6);
+}
+
+.command-track li[data-state="complete"] {
+  border-color: rgba(78, 255, 196, 0.9);
+  box-shadow: 0 0 20px rgba(78, 255, 196, 0.35);
+  background: rgba(0, 30, 38, 0.9);
+}
+
+.command-track li[data-error] {
+  border-color: rgba(255, 120, 120, 0.8);
+  box-shadow: 0 0 18px rgba(255, 120, 120, 0.3);
+}
+
+.command-label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(128, 255, 226, 0.8);
+  font-size: 0.7rem;
+}
+
 .status-board[data-state="success"] {
   color: var(--status-success);
   border-color: var(--status-success);
@@ -35,4 +199,25 @@ select {
 .status-board[data-state="error"] {
   color: var(--status-error);
   border-color: var(--status-error);
+}
+
+@keyframes radarSweep {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes blipPulse {
+  0%,
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 0.9;
+  }
+  50% {
+    transform: translate(-50%, -50%) scale(1.4);
+    opacity: 0.4;
+  }
 }

--- a/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.js
+++ b/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.js
@@ -1,5 +1,13 @@
 const form = document.getElementById("ftp-form");
 const board = document.getElementById("status-board");
+const radar = document.getElementById("radar-screen");
+const readout = document.getElementById("queue-readout");
+const track = document.getElementById("command-track");
+const transferMeter = document.getElementById("transfer-meter");
+const transferFill = transferMeter?.querySelector(".transfer-fill");
+const trackItems = new Map(
+  Array.from(track?.querySelectorAll("[data-command]") || []).map((item) => [item.dataset.command || "", item])
+);
 
 const expectedOrder = {
   open: "1",
@@ -15,34 +23,102 @@ const updateBoard = (message, state = "idle") => {
   board.dataset.state = state;
 };
 
-const hasDuplicates = (values) => {
-  const used = new Set();
-  for (const value of Object.values(values)) {
-    if (!value) {
-      continue;
-    }
-    if (used.has(value)) {
-      return true;
-    }
-    used.add(value);
+const setRadarState = (state) => {
+  if (!radar) {
+    return;
   }
-  return false;
+  radar.dataset.state = state;
+};
+
+const setReadout = (message) => {
+  if (!readout) {
+    return;
+  }
+  readout.textContent = message;
+};
+
+const findDuplicateSlots = (values) => {
+  const used = new Map();
+  const duplicates = new Set();
+  Object.entries(values).forEach(([command, value]) => {
+    if (!value) {
+      return;
+    }
+    if (used.has(value) && used.get(value) !== command) {
+      duplicates.add(value);
+    } else {
+      used.set(value, command);
+    }
+  });
+  return duplicates;
+};
+
+const updateVisualization = (values, duplicates = new Set()) => {
+  let correctCount = 0;
+  trackItems.forEach((item, command) => {
+    if (!command) {
+      return;
+    }
+    const order = values[command];
+    if (!order) {
+      delete item.dataset.state;
+      delete item.dataset.error;
+      return;
+    }
+    if (duplicates.has(order)) {
+      item.dataset.state = "queued";
+      item.dataset.error = "true";
+      return;
+    }
+    delete item.dataset.error;
+    if (order === expectedOrder[command]) {
+      item.dataset.state = "locked";
+      correctCount += 1;
+    } else {
+      item.dataset.state = "queued";
+    }
+  });
+
+  if (transferMeter && transferFill) {
+    const progress = correctCount / Object.keys(expectedOrder).length;
+    transferFill.style.transform = `scaleX(${progress})`;
+    transferMeter.setAttribute("aria-valuenow", correctCount.toString());
+  }
+
+  return correctCount;
 };
 
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
   const data = new FormData(form);
   const values = Object.fromEntries(Object.keys(expectedOrder).map((key) => [key, data.get(key) || ""]));
-  if (hasDuplicates(values)) {
+  const duplicates = findDuplicateSlots(values);
+  updateVisualization(values, duplicates);
+  if (duplicates.size) {
+    const slots = Array.from(duplicates).join(", ");
     updateBoard("Sequence conflict detected. Remove duplicate slots.", "error");
+    setReadout(`Conflict on slot ${slots}. Reorder before launch.`);
+    setRadarState("warning");
     return;
   }
   const mismatches = Object.entries(expectedOrder).filter(([key, value]) => values[key] !== value);
   if (mismatches.length) {
     updateBoard("Transfer aborted. Adjust command ordering.", "error");
+    setReadout("Autopilot rejected queue. Align commands with flight plan.");
+    setRadarState("warning");
     return;
   }
   updateBoard("Payload delivered. QA has their bits.", "success");
+  setReadout("Sequence locked. Uplink humming.");
+  setRadarState("success");
+  trackItems.forEach((item) => {
+    item.dataset.state = "complete";
+    delete item.dataset.error;
+  });
+  if (transferMeter && transferFill) {
+    transferFill.style.transform = "scaleX(1)";
+    transferMeter.setAttribute("aria-valuenow", Object.keys(expectedOrder).length.toString());
+  }
   window.parent?.postMessage(
     {
       type: "net:level-complete",
@@ -60,5 +136,33 @@ form?.addEventListener("input", () => {
   if (board.dataset.state === "success") {
     return;
   }
-  updateBoard("Transfer queue idle.");
+  const data = new FormData(form);
+  const values = Object.fromEntries(Object.keys(expectedOrder).map((key) => [key, data.get(key) || ""]));
+  const duplicates = findDuplicateSlots(values);
+  const correctCount = updateVisualization(values, duplicates);
+  if (duplicates.size) {
+    const slots = Array.from(duplicates).join(", ");
+    updateBoard("Transfer queue idle.");
+    setReadout(`Queue conflict at slot ${slots}.`);
+    setRadarState("warning");
+    return;
+  }
+  if (correctCount === Object.keys(expectedOrder).length) {
+    updateBoard("Sequence aligned. Initiate transfer.");
+    setReadout("Flight plan green across the board.");
+    setRadarState("active");
+  } else if (correctCount > 0) {
+    updateBoard("Transfer queue idle.");
+    setReadout("Queue warming up. Assign remaining slots.");
+    setRadarState("active");
+  } else {
+    updateBoard("Transfer queue idle.");
+    setReadout("Queue awaiting commands…");
+    setRadarState("idle");
+  }
 });
+
+if (form) {
+  setReadout("Queue awaiting commands…");
+  setRadarState("idle");
+}

--- a/madia.new/public/secret/net/ftp-flightdeck/index.html
+++ b/madia.new/public/secret/net/ftp-flightdeck/index.html
@@ -28,86 +28,133 @@
       <section class="control-panel" aria-labelledby="command-heading">
         <h2 id="command-heading">Command queue</h2>
         <p>Assign an execution order to each command. No duplicates.</p>
-        <form id="ftp-form" class="form-grid">
-          <fieldset>
-            <legend>Sequencing</legend>
-            <div class="command-grid">
-              <label>
-                <code>open staging.wired.lan</code>
-                <select name="open">
-                  <option value="">--</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                  <option value="5">5</option>
-                  <option value="6">6</option>
-                </select>
-              </label>
-              <label>
-                <code>user deploy</code>
-                <select name="user">
-                  <option value="">--</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                  <option value="5">5</option>
-                  <option value="6">6</option>
-                </select>
-              </label>
-              <label>
-                <code>passive</code>
-                <select name="passive">
-                  <option value="">--</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                  <option value="5">5</option>
-                  <option value="6">6</option>
-                </select>
-              </label>
-              <label>
-                <code>cd /var/www/releases</code>
-                <select name="cd">
-                  <option value="">--</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                  <option value="5">5</option>
-                  <option value="6">6</option>
-                </select>
-              </label>
-              <label>
-                <code>put build.tar.gz</code>
-                <select name="put">
-                  <option value="">--</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                  <option value="5">5</option>
-                  <option value="6">6</option>
-                </select>
-              </label>
-              <label>
-                <code>quit</code>
-                <select name="quit">
-                  <option value="">--</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                  <option value="5">5</option>
-                  <option value="6">6</option>
-                </select>
-              </label>
+        <div class="deck-layout">
+          <form id="ftp-form" class="form-grid">
+            <fieldset>
+              <legend>Sequencing</legend>
+              <div class="command-grid">
+                <label>
+                  <code>open staging.wired.lan</code>
+                  <select name="open">
+                    <option value="">--</option>
+                    <option value="1">1</option>
+                    <option value="2">2</option>
+                    <option value="3">3</option>
+                    <option value="4">4</option>
+                    <option value="5">5</option>
+                    <option value="6">6</option>
+                  </select>
+                </label>
+                <label>
+                  <code>user deploy</code>
+                  <select name="user">
+                    <option value="">--</option>
+                    <option value="1">1</option>
+                    <option value="2">2</option>
+                    <option value="3">3</option>
+                    <option value="4">4</option>
+                    <option value="5">5</option>
+                    <option value="6">6</option>
+                  </select>
+                </label>
+                <label>
+                  <code>passive</code>
+                  <select name="passive">
+                    <option value="">--</option>
+                    <option value="1">1</option>
+                    <option value="2">2</option>
+                    <option value="3">3</option>
+                    <option value="4">4</option>
+                    <option value="5">5</option>
+                    <option value="6">6</option>
+                  </select>
+                </label>
+                <label>
+                  <code>cd /var/www/releases</code>
+                  <select name="cd">
+                    <option value="">--</option>
+                    <option value="1">1</option>
+                    <option value="2">2</option>
+                    <option value="3">3</option>
+                    <option value="4">4</option>
+                    <option value="5">5</option>
+                    <option value="6">6</option>
+                  </select>
+                </label>
+                <label>
+                  <code>put build.tar.gz</code>
+                  <select name="put">
+                    <option value="">--</option>
+                    <option value="1">1</option>
+                    <option value="2">2</option>
+                    <option value="3">3</option>
+                    <option value="4">4</option>
+                    <option value="5">5</option>
+                    <option value="6">6</option>
+                  </select>
+                </label>
+                <label>
+                  <code>quit</code>
+                  <select name="quit">
+                    <option value="">--</option>
+                    <option value="1">1</option>
+                    <option value="2">2</option>
+                    <option value="3">3</option>
+                    <option value="4">4</option>
+                    <option value="5">5</option>
+                    <option value="6">6</option>
+                  </select>
+                </label>
+              </div>
+            </fieldset>
+            <button type="submit" class="execute-button">Initiate transfer</button>
+          </form>
+          <aside class="flight-visualizer" aria-live="polite">
+            <h3 id="radar-heading">Transfer radar</h3>
+            <div id="radar-screen" class="radar-screen" role="presentation" aria-labelledby="radar-heading">
+              <div class="radar-sweep"></div>
+              <div class="radar-blip"></div>
             </div>
-          </fieldset>
-          <button type="submit" class="execute-button">Initiate transfer</button>
-        </form>
+            <p id="queue-readout" class="queue-readout">Queue awaiting commands…</p>
+            <div
+              id="transfer-meter"
+              class="transfer-meter"
+              role="progressbar"
+              aria-valuemin="0"
+              aria-valuemax="6"
+              aria-valuenow="0"
+              aria-label="Commands sequenced"
+            >
+              <div class="transfer-fill"></div>
+            </div>
+            <ol id="command-track" class="command-track">
+              <li data-command="open">
+                <span class="command-label">Link</span>
+                <code>open staging.wired.lan</code>
+              </li>
+              <li data-command="user">
+                <span class="command-label">Auth</span>
+                <code>user deploy</code>
+              </li>
+              <li data-command="passive">
+                <span class="command-label">Mode</span>
+                <code>passive</code>
+              </li>
+              <li data-command="cd">
+                <span class="command-label">Path</span>
+                <code>cd /var/www/releases</code>
+              </li>
+              <li data-command="put">
+                <span class="command-label">Payload</span>
+                <code>put build.tar.gz</code>
+              </li>
+              <li data-command="quit">
+                <span class="command-label">Exit</span>
+                <code>quit</code>
+              </li>
+            </ol>
+          </aside>
+        </div>
         <div id="status-board" class="status-board" aria-live="polite">Transfer queue idle.</div>
       </section>
     </main>

--- a/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.css
+++ b/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.css
@@ -9,6 +9,17 @@ main {
   color: var(--text-muted);
 }
 
+.composer-layout {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 960px) {
+  .composer-layout {
+    grid-template-columns: 1.4fr 1fr;
+  }
+}
+
 .gopher-grid {
   display: grid;
   gap: 1.5rem;
@@ -20,6 +31,18 @@ main {
   background: rgba(3, 18, 24, 0.8);
   display: grid;
   gap: 0.75rem;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.row[data-state="editing"] {
+  border-color: rgba(244, 180, 0, 0.6);
+  box-shadow: 0 0 18px rgba(244, 180, 0, 0.25);
+}
+
+.row[data-state="complete"] {
+  border-color: rgba(72, 255, 184, 0.85);
+  box-shadow: 0 0 22px rgba(72, 255, 184, 0.35);
+  animation: pulseComplete 1.4s ease-in-out infinite;
 }
 
 label {
@@ -34,6 +57,81 @@ input[type="text"] {
   padding: 0.4rem 0.6rem;
 }
 
+.terminal-panel {
+  border: 1px solid rgba(102, 252, 202, 0.4);
+  background: radial-gradient(circle at top right, rgba(60, 128, 140, 0.15), rgba(5, 18, 24, 0.92));
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+  align-content: start;
+}
+
+.terminal-panel h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: rgba(102, 255, 198, 0.85);
+}
+
+#preview-output {
+  margin: 0;
+  background: rgba(0, 12, 18, 0.9);
+  border: 1px solid rgba(102, 255, 198, 0.35);
+  padding: 0.75rem;
+  max-height: 9.5rem;
+  overflow: auto;
+  color: rgba(180, 255, 238, 0.85);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  position: relative;
+}
+
+#preview-output::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(180deg, rgba(56, 248, 122, 0.05) 0, rgba(56, 248, 122, 0.05) 2px, transparent 2px, transparent 4px);
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+#preview-output code {
+  display: block;
+  white-space: pre;
+}
+
+#preview-output span[data-state="empty"] {
+  color: rgba(255, 196, 120, 0.6);
+}
+
+#preview-output span[data-state="editing"] {
+  color: rgba(244, 180, 0, 0.75);
+}
+
+#preview-output span[data-state="complete"] {
+  color: rgba(72, 255, 184, 0.9);
+}
+
+.progress-meter {
+  height: 0.75rem;
+  border: 1px solid rgba(102, 255, 198, 0.4);
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(0, 24, 26, 0.85);
+}
+
+.progress-fill {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, rgba(72, 255, 184, 0.75), rgba(24, 140, 220, 0.55));
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.35s ease;
+}
+
+#preview-output[data-state="complete"] {
+  box-shadow: 0 0 22px rgba(72, 255, 184, 0.35);
+}
+
 .status-board[data-state="success"] {
   color: var(--status-success);
   border-color: var(--status-success);
@@ -42,4 +140,14 @@ input[type="text"] {
 .status-board[data-state="error"] {
   color: var(--status-error);
   border-color: var(--status-error);
+}
+
+@keyframes pulseComplete {
+  0%,
+  100% {
+    box-shadow: 0 0 18px rgba(72, 255, 184, 0.2);
+  }
+  50% {
+    box-shadow: 0 0 28px rgba(72, 255, 184, 0.35);
+  }
 }

--- a/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.js
+++ b/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.js
@@ -1,5 +1,14 @@
 const form = document.getElementById("gopher-form");
 const board = document.getElementById("status-board");
+const preview = document.getElementById("preview-output");
+const progressMeter = document.getElementById("progress-meter");
+const progressFill = progressMeter?.querySelector(".progress-fill");
+const rows = Array.from(document.querySelectorAll(".row"));
+const previewRows = {
+  banner: document.querySelector('[data-preview-row="banner"]'),
+  catalog: document.querySelector('[data-preview-row="catalog"]'),
+  zine: document.querySelector('[data-preview-row="zine"]'),
+};
 
 const expected = {
   "banner-text": "Library Net Welcome",
@@ -21,9 +30,69 @@ const updateBoard = (message, state = "idle") => {
   board.dataset.state = state;
 };
 
+const formatValue = (value) => {
+  const trimmed = (value || "").trim();
+  return trimmed ? trimmed : "???";
+};
+
+const rowFieldMap = {
+  banner: ["banner-type", "banner-text", "banner-selector", "banner-host"],
+  catalog: ["catalog-type", "catalog-text", "catalog-selector", "catalog-host"],
+  zine: ["zine-type", "zine-text", "zine-selector", "zine-host"],
+};
+
+const updateRowStates = (formData) => {
+  let completeCount = 0;
+  rows.forEach((row) => {
+    const key = row.dataset.row;
+    if (!key) {
+      return;
+    }
+    const fields = rowFieldMap[key];
+    if (!fields) {
+      return;
+    }
+    const values = fields.map((name) => (formData.get(name) || "").trim());
+    const filled = values.some(Boolean);
+    const matches = fields.every((name) => (formData.get(name) || "").trim() === expected[name]);
+    if (matches) {
+      row.dataset.state = "complete";
+      completeCount += 1;
+    } else if (filled) {
+      row.dataset.state = "editing";
+    } else {
+      delete row.dataset.state;
+    }
+    const previewRow = previewRows[key];
+    if (previewRow) {
+      const [typeField, textField, selectorField, hostField] = fields;
+      const type = formatValue(formData.get(typeField));
+      const display = formatValue(formData.get(textField));
+      const selector = formatValue(formData.get(selectorField));
+      const host = formatValue(formData.get(hostField));
+      const port = key === "zine" ? "70" : "70";
+      previewRow.textContent = `${type}${display}\t${selector}\t${host}\t${port}`;
+      previewRow.dataset.state = matches ? "complete" : filled ? "editing" : "empty";
+    }
+  });
+
+  if (progressMeter && progressFill) {
+    const progressValue = completeCount;
+    const progressPercent = completeCount / rows.length;
+    progressFill.style.setProperty("--progress", progressPercent.toString());
+    progressFill.style.transform = `scaleX(${progressPercent})`;
+    progressMeter.setAttribute("aria-valuenow", progressValue.toString());
+  }
+
+  if (preview) {
+    preview.dataset.state = completeCount === rows.length ? "complete" : "editing";
+  }
+};
+
 form?.addEventListener("submit", (event) => {
   event.preventDefault();
   const data = new FormData(form);
+  updateRowStates(data);
   const errors = Object.entries(expected).filter(([name, value]) => (data.get(name) || "").trim() !== value);
   if (errors.length) {
     updateBoard("Menu mismatch. Check selector, type, and host fields.", "error");
@@ -47,5 +116,11 @@ form?.addEventListener("input", () => {
   if (board.dataset.state === "success") {
     return;
   }
+  const data = new FormData(form);
+  updateRowStates(data);
   updateBoard("Awaiting menu entries.");
 });
+
+if (form) {
+  updateRowStates(new FormData(form));
+}

--- a/madia.new/public/secret/net/gopher-groundskeeper/index.html
+++ b/madia.new/public/secret/net/gopher-groundskeeper/index.html
@@ -37,71 +37,92 @@
       <section class="control-panel" aria-labelledby="gopher-heading">
         <h2 id="gopher-heading">Gophermap composer</h2>
         <p>Complete each row. Leave port blank to default to 70.</p>
-        <form id="gopher-form" class="form-grid">
-          <fieldset>
-            <legend>Menu rows</legend>
-            <div class="gopher-grid">
-              <div class="row" data-row="banner">
-                <h3>Welcome banner</h3>
-                <label>
-                  Display text
-                  <input type="text" name="banner-text" />
-                </label>
-                <label>
-                  Selector
-                  <input type="text" name="banner-selector" />
-                </label>
-                <label>
-                  Host
-                  <input type="text" name="banner-host" />
-                </label>
-                <label>
-                  Type
-                  <input type="text" name="banner-type" maxlength="1" />
-                </label>
+        <div class="composer-layout">
+          <form id="gopher-form" class="form-grid">
+            <fieldset>
+              <legend>Menu rows</legend>
+              <div class="gopher-grid">
+                <div class="row" data-row="banner">
+                  <h3>Welcome banner</h3>
+                  <label>
+                    Display text
+                    <input type="text" name="banner-text" />
+                  </label>
+                  <label>
+                    Selector
+                    <input type="text" name="banner-selector" />
+                  </label>
+                  <label>
+                    Host
+                    <input type="text" name="banner-host" />
+                  </label>
+                  <label>
+                    Type
+                    <input type="text" name="banner-type" maxlength="1" />
+                  </label>
+                </div>
+                <div class="row" data-row="catalog">
+                  <h3>Catalog search</h3>
+                  <label>
+                    Display text
+                    <input type="text" name="catalog-text" />
+                  </label>
+                  <label>
+                    Selector
+                    <input type="text" name="catalog-selector" />
+                  </label>
+                  <label>
+                    Host
+                    <input type="text" name="catalog-host" />
+                  </label>
+                  <label>
+                    Type
+                    <input type="text" name="catalog-type" maxlength="1" />
+                  </label>
+                </div>
+                <div class="row" data-row="zine">
+                  <h3>Weekly zine</h3>
+                  <label>
+                    Display text
+                    <input type="text" name="zine-text" />
+                  </label>
+                  <label>
+                    Selector
+                    <input type="text" name="zine-selector" />
+                  </label>
+                  <label>
+                    Host
+                    <input type="text" name="zine-host" />
+                  </label>
+                  <label>
+                    Type
+                    <input type="text" name="zine-type" maxlength="1" />
+                  </label>
+                </div>
               </div>
-              <div class="row" data-row="catalog">
-                <h3>Catalog search</h3>
-                <label>
-                  Display text
-                  <input type="text" name="catalog-text" />
-                </label>
-                <label>
-                  Selector
-                  <input type="text" name="catalog-selector" />
-                </label>
-                <label>
-                  Host
-                  <input type="text" name="catalog-host" />
-                </label>
-                <label>
-                  Type
-                  <input type="text" name="catalog-type" maxlength="1" />
-                </label>
-              </div>
-              <div class="row" data-row="zine">
-                <h3>Weekly zine</h3>
-                <label>
-                  Display text
-                  <input type="text" name="zine-text" />
-                </label>
-                <label>
-                  Selector
-                  <input type="text" name="zine-selector" />
-                </label>
-                <label>
-                  Host
-                  <input type="text" name="zine-host" />
-                </label>
-                <label>
-                  Type
-                  <input type="text" name="zine-type" maxlength="1" />
-                </label>
-              </div>
+            </fieldset>
+            <button type="submit" class="execute-button">Save gophermap</button>
+          </form>
+          <aside class="terminal-panel" aria-live="polite">
+            <h3 id="preview-heading">Live gophermap preview</h3>
+            <pre id="preview-output" aria-labelledby="preview-heading"><code>
+<span data-preview-row="banner">i???&#9;???&#9;???&#9;70</span>
+<span data-preview-row="catalog">???&#9;???&#9;???&#9;70</span>
+<span data-preview-row="zine">???&#9;???&#9;???&#9;70</span>
+            </code></pre>
+            <div
+              id="progress-meter"
+              class="progress-meter"
+              role="progressbar"
+              aria-valuemin="0"
+              aria-valuemax="3"
+              aria-valuenow="0"
+              aria-label="Completed menu rows"
+            >
+              <div class="progress-fill"></div>
             </div>
-          </fieldset>
-          <button type="submit" class="execute-button">Save gophermap</button>
-        </form>
+          </aside>
+        </div>
         <div id="status-board" class="status-board" aria-live="polite">Awaiting menu entries.</div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- add a topology monitor with animated status lines and event log to Borderline Broadcast
- add a live gophermap preview, progress meter, and animated row feedback to Gopher Groundskeeper
- add a transfer radar, command track visualization, and queue readout to FTP Flightdeck, along with shared Net UI tokens

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e5a3becb588328bdfd3199d63b252e