### PR TITLE
feat: surface richer Net cabinet progress summary

### DIFF
--- a/madia.new/public/secret/net/index.html
+++ b/madia.new/public/secret/net/index.html
@@ -21,14 +21,29 @@
           clean DNS zones, razor-sharp daemons, kernels stitched by hand. Each cabinet is a scenario pulled from late-night
           message boards and pager alerts.
         </p>
-        <p
-          id="progress-summary"
-          class="progress-summary"
-          role="status"
-          aria-live="polite"
-        >
-          Cabinets stabilized: 0 / --. Boot a cabinet to start logging uptime.
-        </p>
+        <dl class="progress-summary" id="progress-summary" aria-live="polite">
+          <div class="progress-summary__item">
+            <dt>Cabinets stabilized</dt>
+            <dd>
+              <span class="summary-primary" id="progress-count-value">0 / --</span>
+              <span class="summary-secondary" id="progress-count-meta">Boot a cabinet to start logging uptime.</span>
+            </dd>
+          </div>
+          <div class="progress-summary__item">
+            <dt>Highest throughput</dt>
+            <dd>
+              <span class="summary-primary" id="progress-top-score-value">—</span>
+              <span class="summary-secondary" id="progress-top-score-meta">Lock in a run to register throughput.</span>
+            </dd>
+          </div>
+          <div class="progress-summary__item">
+            <dt>Latest relay</dt>
+            <dd>
+              <span class="summary-primary" id="progress-last-run-value">—</span>
+              <span class="summary-secondary" id="progress-last-run-meta">Run a cabinet to update the relay log.</span>
+            </dd>
+          </div>
+        </dl>
         <button type="button" id="reset-progress" class="reset-button">Reset cabinet memory</button>
       </section>
       <section class="net-grid" id="node-grid" aria-label="Cabinet selection"></section>

--- a/madia.new/public/secret/net/net.css
+++ b/madia.new/public/secret/net/net.css
@@ -117,20 +117,51 @@ main {
 
 .progress-summary {
   margin: 0;
-  padding: 0.65rem 0.85rem;
+  padding: clamp(0.75rem, 2.5vw, 1.25rem);
   border: 1px solid rgba(56, 248, 122, 0.2);
   border-radius: 12px;
-  background: rgba(5, 12, 22, 0.6);
-  color: var(--muted);
-  font-size: 0.9rem;
-  line-height: 1.5;
-  letter-spacing: 0.05em;
-  transition: border-color 0.2s ease, color 0.2s ease;
+  background: rgba(4, 12, 22, 0.78);
+  display: grid;
+  gap: 1rem 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
 }
 
 .progress-summary[data-state="active"] {
-  border-color: rgba(56, 248, 122, 0.45);
-  color: var(--accent);
+  border-color: rgba(56, 248, 122, 0.4);
+  box-shadow: 0 12px 28px rgba(56, 248, 122, 0.18);
+}
+
+.progress-summary__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.progress-summary dt {
+  margin: 0;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.progress-summary dd {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.summary-primary {
+  font-size: clamp(1.1rem, 2.8vw, 1.35rem);
+  font-weight: 600;
+  color: var(--text);
+}
+
+.summary-secondary {
+  font-size: 0.85rem;
+  color: var(--muted);
 }
 
 .reset-button {


### PR DESCRIPTION
## Summary
- replace the single-line Net progress banner with a multi-metric dashboard summarizing cabinet count, top throughput, and recent activity
- add dedicated styling for the new summary layout to match the Net aesthetic
- enhance launcher logic to format scores/timestamps and keep the dashboard live as runs are recorded or reset

## Testing
- python -m http.server 5000 (manually inspected http://localhost:5000/secret/net/)


------
https://chatgpt.com/codex/tasks/task_e_68e66f9ba8788328bcab5746c22c7f7e