### PR TITLE
Add fullscreen toggles to Net minigames

### DIFF
--- a/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.js
+++ b/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.js
@@ -1,3 +1,7 @@
+import { initFullscreenToggle } from "../fullscreen.js";
+
+initFullscreenToggle();
+
 const form = document.getElementById("bgp-form");
 const board = document.getElementById("status-board");
 const routeMap = document.querySelector(".route-map");

--- a/madia.new/public/secret/net/borderline-broadcast/index.html
+++ b/madia.new/public/secret/net/borderline-broadcast/index.html
@@ -9,8 +9,26 @@
   </head>
   <body>
     <header>
-      <p>Layer 03 · Routing Core</p>
-      <h1>Borderline Broadcast</h1>
+      <div class="header-bar">
+        <div class="header-text">
+          <p>Layer 03 · Routing Core</p>
+          <h1>Borderline Broadcast</h1>
+        </div>
+        <button
+          type="button"
+          class="fullscreen-toggle"
+          data-role="fullscreen-toggle"
+          data-fullscreen="false"
+          aria-pressed="false"
+        >
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--enter" data-state="enter"
+            >Enter full screen</span
+          >
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--exit" data-state="exit"
+            >Exit full screen</span
+          >
+        </button>
+      </div>
       <p>
         The frame relay backup is leaking default routes into your backbone. Apply the routing memo so traffic prefers the fiber
         ring and quarantines the noisy neighbor.

--- a/madia.new/public/secret/net/cache-cascade/cache-cascade.js
+++ b/madia.new/public/secret/net/cache-cascade/cache-cascade.js
@@ -1,3 +1,7 @@
+import { initFullscreenToggle } from "../fullscreen.js";
+
+initFullscreenToggle();
+
 const form = document.getElementById("cache-form");
 const board = document.getElementById("status-board");
 const streamVisuals = new Map(

--- a/madia.new/public/secret/net/cache-cascade/index.html
+++ b/madia.new/public/secret/net/cache-cascade/index.html
@@ -9,8 +9,22 @@
   </head>
   <body>
     <header>
-      <p>Layer 02 · Proxy Works</p>
-      <h1>Cache Cascade</h1>
+      <div class="header-bar">
+        <div class="header-text">
+          <p>Layer 02 · Proxy Works</p>
+          <h1>Cache Cascade</h1>
+        </div>
+        <button
+          type="button"
+          class="fullscreen-toggle"
+          data-role="fullscreen-toggle"
+          data-fullscreen="false"
+          aria-pressed="false"
+        >
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--enter" data-state="enter">Enter full screen</span>
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--exit" data-state="exit">Exit full screen</span>
+        </button>
+      </div>
       <p>
         Squid 1.1 is choking on a late-night software launch. Route requests through the right parents and set TTLs so the dial-up
         crowd stays fast while origin servers survive.

--- a/madia.new/public/secret/net/common.css
+++ b/madia.new/public/secret/net/common.css
@@ -36,6 +36,19 @@ header {
   letter-spacing: 0.05em;
 }
 
+.header-bar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.header-text {
+  flex: 1 1 auto;
+  min-width: 14rem;
+}
+
 header h1 {
   margin: 0.5rem 0 0;
   font-size: clamp(1.75rem, 4vw, 2.75rem);
@@ -45,6 +58,42 @@ header p {
   margin: 0.25rem 0 0;
   font-size: clamp(0.85rem, 2.5vw, 1rem);
   color: var(--net-muted);
+}
+
+.fullscreen-toggle {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.9rem;
+  font-size: 0.75rem;
+  text-transform: none;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, rgba(56, 248, 122, 0.25), rgba(56, 248, 122, 0.4));
+}
+
+.fullscreen-toggle[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.fullscreen-toggle__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.fullscreen-toggle__label--exit {
+  display: none;
+}
+
+.fullscreen-toggle[data-fullscreen="true"] .fullscreen-toggle__label--enter {
+  display: none;
+}
+
+.fullscreen-toggle[data-fullscreen="true"] .fullscreen-toggle__label--exit {
+  display: inline-flex;
 }
 
 main {

--- a/madia.new/public/secret/net/daemon-handshake/daemon-handshake.js
+++ b/madia.new/public/secret/net/daemon-handshake/daemon-handshake.js
@@ -1,3 +1,7 @@
+import { initFullscreenToggle } from "../fullscreen.js";
+
+initFullscreenToggle();
+
 const form = document.getElementById("daemon-form");
 const board = document.getElementById("status-board");
 const rack = document.querySelector(".rack-visual");

--- a/madia.new/public/secret/net/daemon-handshake/index.html
+++ b/madia.new/public/secret/net/daemon-handshake/index.html
@@ -9,8 +9,22 @@
   </head>
   <body>
     <header>
-      <p>Layer 06 · Web Stack</p>
-      <h1>Daemon Handshake</h1>
+      <div class="header-bar">
+        <div class="header-text">
+          <p>Layer 06 · Web Stack</p>
+          <h1>Daemon Handshake</h1>
+        </div>
+        <button
+          type="button"
+          class="fullscreen-toggle"
+          data-role="fullscreen-toggle"
+          data-fullscreen="false"
+          aria-pressed="false"
+        >
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--enter" data-state="enter">Enter full screen</span>
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--exit" data-state="exit">Exit full screen</span>
+        </button>
+      </div>
       <p>
         You're on-call for the student newspaper. Apache won't stay up, the server certificate is expiring, and traffic spikes at
         dawn. Configure the daemon exactly as the ops checklist demands.

--- a/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.js
+++ b/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.js
@@ -1,3 +1,7 @@
+import { initFullscreenToggle } from "../fullscreen.js";
+
+initFullscreenToggle();
+
 const form = document.getElementById("ftp-form");
 const board = document.getElementById("status-board");
 const flightPath = document.querySelector(".flight-path");

--- a/madia.new/public/secret/net/ftp-flightdeck/index.html
+++ b/madia.new/public/secret/net/ftp-flightdeck/index.html
@@ -9,8 +9,22 @@
   </head>
   <body>
     <header>
-      <p>Layer 01 · Transfer Bay</p>
-      <h1>FTP Flightdeck</h1>
+      <div class="header-bar">
+        <div class="header-text">
+          <p>Layer 01 · Transfer Bay</p>
+          <h1>FTP Flightdeck</h1>
+        </div>
+        <button
+          type="button"
+          class="fullscreen-toggle"
+          data-role="fullscreen-toggle"
+          data-fullscreen="false"
+          aria-pressed="false"
+        >
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--enter" data-state="enter">Enter full screen</span>
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--exit" data-state="exit">Exit full screen</span>
+        </button>
+      </div>
       <p>
         Your overnight build has to land on the staging server before QA clocks in. Queue the FTP commands in the right
         order so the upload script doesn't bail.

--- a/madia.new/public/secret/net/fullscreen.js
+++ b/madia.new/public/secret/net/fullscreen.js
@@ -1,0 +1,61 @@
+export function initFullscreenToggle({
+  target = document.documentElement,
+  buttonSelector = "[data-role=\"fullscreen-toggle\"]",
+} = {}) {
+  const button = document.querySelector(buttonSelector);
+  if (!button || !target) {
+    return;
+  }
+
+  const supportsFullscreen =
+    typeof target.requestFullscreen === "function" &&
+    typeof document.exitFullscreen === "function";
+
+  const enterLabel = button.querySelector('[data-state="enter"]');
+  const exitLabel = button.querySelector('[data-state="exit"]');
+
+  const syncLabels = (isActive) => {
+    if (enterLabel) {
+      enterLabel.hidden = isActive;
+    }
+    if (exitLabel) {
+      exitLabel.hidden = !isActive;
+    }
+  };
+
+  const syncState = () => {
+    const fullscreenElement = document.fullscreenElement;
+    const isActive = Boolean(
+      fullscreenElement &&
+        (fullscreenElement === target ||
+          fullscreenElement === document.documentElement ||
+          fullscreenElement === document.body)
+    );
+    button.dataset.fullscreen = isActive ? "true" : "false";
+    button.setAttribute("aria-pressed", isActive ? "true" : "false");
+    syncLabels(isActive);
+  };
+
+  if (!supportsFullscreen) {
+    button.disabled = true;
+    button.title = "Fullscreen is not supported in this browser";
+    syncLabels(false);
+    return;
+  }
+
+  button.addEventListener("click", async () => {
+    const isActive = button.dataset.fullscreen === "true";
+    try {
+      if (isActive) {
+        await document.exitFullscreen();
+      } else {
+        await target.requestFullscreen();
+      }
+    } catch (error) {
+      console.warn("Fullscreen toggle failed", error);
+    }
+  });
+
+  document.addEventListener("fullscreenchange", syncState);
+  syncState();
+}

--- a/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.js
+++ b/madia.new/public/secret/net/gopher-groundskeeper/gopher-groundskeeper.js
@@ -1,3 +1,7 @@
+import { initFullscreenToggle } from "../fullscreen.js";
+
+initFullscreenToggle();
+
 const form = document.getElementById("gopher-form");
 const board = document.getElementById("status-board");
 const terminalLines = new Map(

--- a/madia.new/public/secret/net/gopher-groundskeeper/index.html
+++ b/madia.new/public/secret/net/gopher-groundskeeper/index.html
@@ -9,8 +9,22 @@
   </head>
   <body>
     <header>
-      <p>Layer 02 · Campus Content</p>
-      <h1>Gopher Groundskeeper</h1>
+      <div class="header-bar">
+        <div class="header-text">
+          <p>Layer 02 · Campus Content</p>
+          <h1>Gopher Groundskeeper</h1>
+        </div>
+        <button
+          type="button"
+          class="fullscreen-toggle"
+          data-role="fullscreen-toggle"
+          data-fullscreen="false"
+          aria-pressed="false"
+        >
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--enter" data-state="enter">Enter full screen</span>
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--exit" data-state="exit">Exit full screen</span>
+        </button>
+      </div>
       <p>
         Library staff wants a menu that matches their printed index. Fill in the gophermap entries so selectors, types,
         and hosts match the spec sheet.

--- a/madia.new/public/secret/net/hopline-diagnostics/hopline-diagnostics.js
+++ b/madia.new/public/secret/net/hopline-diagnostics/hopline-diagnostics.js
@@ -1,3 +1,7 @@
+import { initFullscreenToggle } from "../fullscreen.js";
+
+initFullscreenToggle();
+
 const form = document.getElementById("route-form");
 const board = document.getElementById("status-board");
 const topologyMap = document.querySelector(".topology-map");

--- a/madia.new/public/secret/net/hopline-diagnostics/index.html
+++ b/madia.new/public/secret/net/hopline-diagnostics/index.html
@@ -9,8 +9,22 @@
   </head>
   <body>
     <header>
-      <p>Layer 08 · Backbone Pulse</p>
-      <h1>Hopline Diagnostics</h1>
+      <div class="header-bar">
+        <div class="header-text">
+          <p>Layer 08 · Backbone Pulse</p>
+          <h1>Hopline Diagnostics</h1>
+        </div>
+        <button
+          type="button"
+          class="fullscreen-toggle"
+          data-role="fullscreen-toggle"
+          data-fullscreen="false"
+          aria-pressed="false"
+        >
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--enter" data-state="enter">Enter full screen</span>
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--exit" data-state="exit">Exit full screen</span>
+        </button>
+      </div>
       <p>
         A campus office says uploads are timing out. You already ran ping and traceroute from the NOC.
         Match each network to the router that should advertise it so the packets stay on-net.

--- a/madia.new/public/secret/net/kernel-forge-20/index.html
+++ b/madia.new/public/secret/net/kernel-forge-20/index.html
@@ -9,8 +9,22 @@
   </head>
   <body>
     <header>
-      <p>Layer 05 · Kernel Lab</p>
-      <h1>Kernel Forge 2.0</h1>
+      <div class="header-bar">
+        <div class="header-text">
+          <p>Layer 05 · Kernel Lab</p>
+          <h1>Kernel Forge 2.0</h1>
+        </div>
+        <button
+          type="button"
+          class="fullscreen-toggle"
+          data-role="fullscreen-toggle"
+          data-fullscreen="false"
+          aria-pressed="false"
+        >
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--enter" data-state="enter">Enter full screen</span>
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--exit" data-state="exit">Exit full screen</span>
+        </button>
+      </div>
       <p>
         The colo is rolling out dual-homed routers. Your kernel must be lean, route packets fast, and boot without SCSI baggage.
         Toggle features to match the deployment memo.

--- a/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.js
+++ b/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.js
@@ -1,3 +1,7 @@
+import { initFullscreenToggle } from "../fullscreen.js";
+
+initFullscreenToggle();
+
 const form = document.getElementById("kernel-form");
 const board = document.getElementById("status-board");
 const monitor = document.querySelector(".forge-monitor");

--- a/madia.new/public/secret/net/modem-skunkworks/index.html
+++ b/madia.new/public/secret/net/modem-skunkworks/index.html
@@ -9,8 +9,22 @@
   </head>
   <body>
     <header>
-      <p>Layer 04 · Dial-Up Ops</p>
-      <h1>Modem Skunkworks</h1>
+      <div class="header-bar">
+        <div class="header-text">
+          <p>Layer 04 · Dial-Up Ops</p>
+          <h1>Modem Skunkworks</h1>
+        </div>
+        <button
+          type="button"
+          class="fullscreen-toggle"
+          data-role="fullscreen-toggle"
+          data-fullscreen="false"
+          aria-pressed="false"
+        >
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--enter" data-state="enter">Enter full screen</span>
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--exit" data-state="exit">Exit full screen</span>
+        </button>
+      </div>
       <p>
         The overnight newsroom needs a clean PPP session. Sequence the handshake so their dialer script negotiates without redials
         and the newsroom feed syncs on the first try.

--- a/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.js
+++ b/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.js
@@ -1,3 +1,7 @@
+import { initFullscreenToggle } from "../fullscreen.js";
+
+initFullscreenToggle();
+
 const form = document.getElementById("ppp-form");
 const board = document.getElementById("status-board");
 const handshakeVisual = document.querySelector(".handshake-visual");

--- a/madia.new/public/secret/net/root-zone-relay/index.html
+++ b/madia.new/public/secret/net/root-zone-relay/index.html
@@ -9,8 +9,22 @@
   </head>
   <body>
     <header>
-      <p>Layer 07 · DNS Authority</p>
-      <h1>Root Zone Relay</h1>
+      <div class="header-bar">
+        <div class="header-text">
+          <p>Layer 07 · DNS Authority</p>
+          <h1>Root Zone Relay</h1>
+        </div>
+        <button
+          type="button"
+          class="fullscreen-toggle"
+          data-role="fullscreen-toggle"
+          data-fullscreen="false"
+          aria-pressed="false"
+        >
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--enter" data-state="enter">Enter full screen</span>
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--exit" data-state="exit">Exit full screen</span>
+        </button>
+      </div>
       <p>
         A campus blackout scrambled your ISP's primary zone file. Patch the records before modem banks begin flapping and keep
         the secondary servers in sync.

--- a/madia.new/public/secret/net/root-zone-relay/root-zone-relay.js
+++ b/madia.new/public/secret/net/root-zone-relay/root-zone-relay.js
@@ -1,3 +1,7 @@
+import { initFullscreenToggle } from "../fullscreen.js";
+
+initFullscreenToggle();
+
 const form = document.getElementById("zone-form");
 const board = document.getElementById("status-board");
 const zoneVisual = document.querySelector(".zone-visual");

--- a/madia.new/public/secret/net/stream-parser-depot/index.html
+++ b/madia.new/public/secret/net/stream-parser-depot/index.html
@@ -9,8 +9,22 @@
   </head>
   <body>
     <header>
-      <p>Layer 03 · Log Sieve</p>
-      <h1>Stream Parser Depot</h1>
+      <div class="header-bar">
+        <div class="header-text">
+          <p>Layer 03 · Log Sieve</p>
+          <h1>Stream Parser Depot</h1>
+        </div>
+        <button
+          type="button"
+          class="fullscreen-toggle"
+          data-role="fullscreen-toggle"
+          data-fullscreen="false"
+          aria-pressed="false"
+        >
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--enter" data-state="enter">Enter full screen</span>
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--exit" data-state="exit">Exit full screen</span>
+        </button>
+      </div>
       <p>
         The overnight shift dumped raw radius logs into a flat file. Pick the awk and sed snippets that clean the
         authentication report for the pager message.

--- a/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.js
+++ b/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.js
@@ -1,3 +1,7 @@
+import { initFullscreenToggle } from "../fullscreen.js";
+
+initFullscreenToggle();
+
 const form = document.getElementById("parser-form");
 const board = document.getElementById("status-board");
 const pipelineVisual = document.querySelector(".pipeline-visual");


### PR DESCRIPTION
## Summary
- add a shared fullscreen helper and styling for the Net arcade header
- inject a fullscreen button into every minigame shell so players can expand the cabinet
- initialize the shared helper from each game module to keep the button state in sync

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e66fdc76c883289685480b67c6e633