### PR TITLE
Add LAN discovery and NAT negotiation Net arcade games

### DIFF
--- a/madia.new/public/secret/net/lan-beacon-scout/index.html
+++ b/madia.new/public/secret/net/lan-beacon-scout/index.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>LAN Beacon Scout</title>
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="./lan-beacon-scout.css" />
+  </head>
+  <body>
+    <header>
+      <p>Layer 04 · LAN Recon</p>
+      <h1>LAN Beacon Scout</h1>
+      <p>
+        Office floors are dark after a storm and the wiring closet is humming. Sweep each subnet with the right
+        broadcast pattern so the stranded workstations phone home before the helpdesk boards light up.
+      </p>
+    </header>
+    <main>
+      <section class="control-panel" aria-labelledby="broadcast-console">
+        <h2 id="broadcast-console">Broadcast console</h2>
+        <p class="intro-copy">
+          Three wings are waiting for a wake-up packet. Choose the correct broadcast target and discovery tactic for each
+          round. Keep the signal integrity high to earn full credit.
+        </p>
+        <div class="hud" role="status" aria-live="polite">
+          <div class="hud-card">
+            <h3>Score</h3>
+            <output id="score-display" aria-live="off">0</output>
+          </div>
+          <div class="hud-card">
+            <h3>Signal integrity</h3>
+            <div class="integrity-bar" aria-hidden="true">
+              <div id="integrity-fill"></div>
+            </div>
+            <output id="integrity-display" aria-live="off">100%</output>
+          </div>
+          <div class="hud-card">
+            <h3>Round</h3>
+            <output id="round-display" aria-live="off">1 / 3</output>
+          </div>
+        </div>
+        <form id="sweep-form" class="form-grid" aria-describedby="briefing-copy">
+          <fieldset>
+            <legend>Current sweep</legend>
+            <p id="briefing-copy" class="briefing"></p>
+            <label for="broadcast-select">Broadcast target</label>
+            <select id="broadcast-select" name="broadcast">
+              <option value="">Select a broadcast range…</option>
+            </select>
+            <span class="helper-text" id="broadcast-hint"></span>
+            <div class="radio-grid">
+              <span class="radio-label">Discovery method</span>
+              <label>
+                Quick ARP Probe
+                <input type="radio" name="method" value="arp" />
+              </label>
+              <label>
+                UDP Echo Spray
+                <input type="radio" name="method" value="udp" />
+              </label>
+              <label>
+                NetBIOS Name Pulse
+                <input type="radio" name="method" value="netbios" />
+              </label>
+            </div>
+            <button type="submit" class="execute-button">Send beacon</button>
+          </fieldset>
+        </form>
+        <div id="status-board" class="status-board" aria-live="polite">Awaiting first sweep…</div>
+      </section>
+      <section class="map-panel" aria-labelledby="subnet-map">
+        <h2 id="subnet-map">Subnet map</h2>
+        <div class="map-grid">
+          <article class="map-card" data-zone="newsroom">
+            <h3>Newsroom Spine</h3>
+            <p class="cidr">192.168.10.0/24</p>
+            <p class="devices" data-role="device-count">Devices unknown</p>
+          </article>
+          <article class="map-card" data-zone="engineering">
+            <h3>Engineering Lab</h3>
+            <p class="cidr">172.16.8.0/26</p>
+            <p class="devices" data-role="device-count">Devices unknown</p>
+          </article>
+          <article class="map-card" data-zone="archives">
+            <h3>Archive Annex</h3>
+            <p class="cidr">10.0.5.128/27</p>
+            <p class="devices" data-role="device-count">Devices unknown</p>
+          </article>
+        </div>
+      </section>
+      <section class="log-panel" aria-labelledby="discovery-log">
+        <h2 id="discovery-log">Discovery log</h2>
+        <ul id="log-list" class="log-list" aria-live="polite"></ul>
+      </section>
+    </main>
+    <footer>Broadcast responsibly. Beige boxes are listening.</footer>
+    <script type="module" src="./lan-beacon-scout.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/net/lan-beacon-scout/lan-beacon-scout.css
+++ b/madia.new/public/secret/net/lan-beacon-scout/lan-beacon-scout.css
@@ -1,0 +1,177 @@
+main {
+  gap: 2rem;
+}
+
+.intro-copy {
+  margin: 0 0 1rem;
+  color: var(--net-muted);
+}
+
+.hud {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.hud-card {
+  background: rgba(4, 12, 26, 0.85);
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.hud-card h3 {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--net-muted);
+}
+
+.hud-card output {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.integrity-bar {
+  height: 10px;
+  background: rgba(56, 248, 122, 0.15);
+  border-radius: 99px;
+  overflow: hidden;
+}
+
+.integrity-bar div {
+  height: 100%;
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0.6), rgba(56, 248, 122, 0.95));
+  width: 100%;
+  transition: width 0.3s ease;
+}
+
+.briefing {
+  margin: 0 0 0.75rem;
+  color: var(--net-text);
+}
+
+.helper-text {
+  display: block;
+  margin-top: -0.35rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.8rem;
+  color: rgba(148, 197, 183, 0.7);
+}
+
+.radio-grid {
+  margin-bottom: 1rem;
+}
+
+.radio-grid .radio-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 183, 0.8);
+}
+
+.map-panel {
+  background: var(--net-panel);
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 28px rgba(2, 12, 24, 0.4);
+}
+
+.map-panel h2,
+.log-panel h2 {
+  margin-top: 0;
+  letter-spacing: 0.08em;
+}
+
+.map-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.map-card {
+  background: rgba(4, 10, 22, 0.85);
+  border: 1px solid rgba(56, 248, 122, 0.18);
+  border-radius: 10px;
+  padding: 1rem;
+  position: relative;
+  overflow: hidden;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.map-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top, rgba(56, 248, 122, 0.08), transparent 70%);
+  pointer-events: none;
+}
+
+.map-card[data-state="active"] {
+  border-color: var(--net-accent);
+  transform: translateY(-2px);
+  box-shadow: 0 14px 30px rgba(56, 248, 122, 0.18);
+}
+
+.map-card[data-state="complete"] {
+  border-color: rgba(56, 248, 122, 0.65);
+  box-shadow: 0 0 24px rgba(56, 248, 122, 0.3);
+}
+
+.map-card h3 {
+  margin: 0 0 0.35rem;
+}
+
+.map-card .cidr {
+  margin: 0 0 0.4rem;
+  color: rgba(148, 197, 183, 0.8);
+}
+
+.map-card .devices {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--net-muted);
+}
+
+.log-panel {
+  background: rgba(5, 12, 28, 0.85);
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 24px rgba(2, 8, 18, 0.45);
+}
+
+.log-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.log-list li {
+  background: rgba(4, 12, 26, 0.7);
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  border-radius: 8px;
+  padding: 0.65rem 0.75rem;
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.log-list li strong {
+  color: var(--net-accent);
+}
+
+@media (max-width: 720px) {
+  .hud {
+    grid-template-columns: 1fr;
+  }
+
+  .map-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/madia.new/public/secret/net/lan-beacon-scout/lan-beacon-scout.js
+++ b/madia.new/public/secret/net/lan-beacon-scout/lan-beacon-scout.js
@@ -1,0 +1,231 @@
+const rounds = [
+  {
+    id: "newsroom",
+    name: "Newsroom Spine",
+    briefing:
+      "Cube farm NICs took a voltage dip. Hit the all-ones host address and rely on broadcast name chatter to coax them back.",
+    hint: "Desksets live on a /24. Think 255.",
+    broadcast: "192.168.10.255",
+    options: ["192.168.10.254", "192.168.10.255", "192.168.11.255"],
+    method: "netbios",
+    devices: ["ANCHOR-DESK", "EDIT-SUITE-03", "WIRECOPY-NODE"],
+    baseScore: 90,
+    penalty: 15,
+  },
+  {
+    id: "engineering",
+    name: "Engineering Lab",
+    briefing:
+      "Prototype rigs are running a tight /26. They talk fast UDP for their diagnostics channel; flood the right block to wake them.",
+    hint: "Fourth subnet of 172.16.8.0 with /26 mask. Broadcast ends in .63.",
+    broadcast: "172.16.8.63",
+    options: ["172.16.8.63", "172.16.8.127", "172.16.8.95"],
+    method: "udp",
+    devices: ["PCB-LASER", "SILICON-CAGE", "PLOTTER-CTRL"],
+    baseScore: 100,
+    penalty: 20,
+  },
+  {
+    id: "archives",
+    name: "Archive Annex",
+    briefing:
+      "Tape robots idle on an odd /27. They only trust ARP refreshes from the wiring closet after hours.",
+    hint: "/27 broadcast holds the top 5 bits. Expect .159.",
+    broadcast: "10.0.5.159",
+    options: ["10.0.5.159", "10.0.5.191", "10.0.5.143"],
+    method: "arp",
+    devices: ["TAPE-JOCKEY", "INDEXER", "RESTORE-GATE"],
+    baseScore: 110,
+    penalty: 25,
+  },
+];
+
+const TOTAL_ROUNDS = rounds.length;
+const integrityDisplay = document.getElementById("integrity-display");
+const integrityFill = document.getElementById("integrity-fill");
+const scoreDisplay = document.getElementById("score-display");
+const roundDisplay = document.getElementById("round-display");
+const statusBoard = document.getElementById("status-board");
+const form = document.getElementById("sweep-form");
+const briefingCopy = document.getElementById("briefing-copy");
+const broadcastSelect = document.getElementById("broadcast-select");
+const broadcastHint = document.getElementById("broadcast-hint");
+const logList = document.getElementById("log-list");
+const mapCards = new Map(
+  Array.from(document.querySelectorAll(".map-card")).map((card) => [card.dataset.zone, card])
+);
+
+let currentRoundIndex = 0;
+let score = 0;
+let integrity = 100;
+let attemptsThisRound = 0;
+
+const clampIntegrity = () => {
+  integrity = Math.max(0, Math.min(integrity, 100));
+};
+
+const updateHud = () => {
+  integrityDisplay.textContent = `${Math.round(integrity)}%`;
+  integrityFill.style.width = `${integrity}%`;
+  scoreDisplay.textContent = `${score}`;
+  roundDisplay.textContent = `${Math.min(currentRoundIndex + 1, TOTAL_ROUNDS)} / ${TOTAL_ROUNDS}`;
+};
+
+const setStatus = (message, state = "idle") => {
+  statusBoard.textContent = message;
+  statusBoard.dataset.state = state;
+};
+
+const renderDevices = (round) => {
+  const card = mapCards.get(round.id);
+  if (!card) {
+    return;
+  }
+  card.dataset.state = "complete";
+  const counter = card.querySelector('[data-role="device-count"]');
+  if (counter) {
+    counter.textContent = `Found ${round.devices.length} devices`;
+  }
+};
+
+const appendLogEntry = (round, attempts, roundScore) => {
+  const entry = document.createElement("li");
+  const title = document.createElement("strong");
+  title.textContent = `${round.name}`;
+  entry.appendChild(title);
+
+  const summary = document.createElement("span");
+  summary.textContent = `Wake-up successful after ${attempts} ${attempts === 1 ? "sweep" : "sweeps"}.`;
+  entry.appendChild(summary);
+
+  const deviceLine = document.createElement("span");
+  deviceLine.textContent = `Devices online: ${round.devices.join(", ")}.`;
+  entry.appendChild(deviceLine);
+
+  const scoreLine = document.createElement("span");
+  scoreLine.textContent = `Score earned: ${roundScore}`;
+  entry.appendChild(scoreLine);
+
+  logList?.prepend(entry);
+};
+
+const activateRoundCard = (round) => {
+  mapCards.forEach((card, id) => {
+    if (card.dataset.state !== "complete") {
+      delete card.dataset.state;
+    }
+    if (id === round.id) {
+      card.dataset.state = card.dataset.state === "complete" ? "complete" : "active";
+    }
+  });
+};
+
+const populateRound = () => {
+  const round = rounds[currentRoundIndex];
+  if (!round) {
+    return;
+  }
+  attemptsThisRound = 0;
+  briefingCopy.textContent = round.briefing;
+  broadcastHint.textContent = round.hint;
+  while (broadcastSelect.options.length > 1) {
+    broadcastSelect.remove(1);
+  }
+  round.options.forEach((value) => {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = value;
+    broadcastSelect.appendChild(option);
+  });
+  broadcastSelect.value = "";
+  Array.from(form.querySelectorAll('input[name="method"]')).forEach((input) => {
+    input.checked = false;
+  });
+  activateRoundCard(round);
+  setStatus("Link idle. Configure sweep parameters.");
+  updateHud();
+};
+
+const advanceRound = () => {
+  currentRoundIndex += 1;
+  if (currentRoundIndex >= TOTAL_ROUNDS) {
+    roundDisplay.textContent = `${TOTAL_ROUNDS} / ${TOTAL_ROUNDS}`;
+    const finalScore = score + Math.round(integrity);
+    setStatus("All segments reporting. Signal locked in.", "success");
+    window.parent?.postMessage(
+      {
+        type: "net:level-complete",
+        game: "lan-beacon-scout",
+        payload: {
+          status: "Broadcast ring restored",
+          score: finalScore,
+        },
+      },
+      "*"
+    );
+    return;
+  }
+  populateRound();
+};
+
+form?.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const round = rounds[currentRoundIndex];
+  if (!round) {
+    return;
+  }
+  const selectedBroadcast = broadcastSelect.value;
+  const methodInput = form.querySelector('input[name="method"]:checked');
+  const selectedMethod = methodInput?.value || "";
+  if (!selectedBroadcast || !selectedMethod) {
+    setStatus("Need both broadcast target and method before sending.", "error");
+    return;
+  }
+  attemptsThisRound += 1;
+  if (selectedBroadcast !== round.broadcast || selectedMethod !== round.method) {
+    integrity -= 12;
+    clampIntegrity();
+    updateHud();
+    setStatus("Echo lost. Adjust the sweep parameters and retry.", "error");
+    const card = mapCards.get(round.id);
+    if (card) {
+      card.dataset.state = "active";
+    }
+    return;
+  }
+
+  const penalty = Math.max(0, (attemptsThisRound - 1) * round.penalty);
+  const roundScore = Math.max(round.baseScore - penalty, Math.floor(round.penalty / 2));
+  score += roundScore;
+  updateHud();
+  renderDevices(round);
+  appendLogEntry(round, attemptsThisRound, roundScore);
+  setStatus("Broadcast acknowledged. Devices checking in.", "success");
+  setTimeout(() => {
+    advanceRound();
+  }, 500);
+});
+
+form?.addEventListener("input", () => {
+  if (statusBoard.dataset.state === "success") {
+    return;
+  }
+  const round = rounds[currentRoundIndex];
+  if (!round) {
+    return;
+  }
+  const selectedBroadcast = broadcastSelect.value;
+  const methodInput = form.querySelector('input[name="method"]:checked');
+  const selectedMethod = methodInput?.value || "";
+  if (selectedBroadcast === round.broadcast && selectedMethod === round.method) {
+    setStatus("Sweep configured. Fire when ready.");
+    const card = mapCards.get(round.id);
+    if (card && card.dataset.state !== "complete") {
+      card.dataset.state = "active";
+    }
+  } else {
+    setStatus("Fine-tune the beacon parameters.");
+  }
+});
+
+populateRound();

--- a/madia.new/public/secret/net/nat-handshake-lab/index.html
+++ b/madia.new/public/secret/net/nat-handshake-lab/index.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>NAT Handshake Lab</title>
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="./nat-handshake-lab.css" />
+  </head>
+  <body>
+    <header>
+      <p>Layer 05 · Edge Negotiator</p>
+      <h1>NAT Handshake Lab</h1>
+      <p>
+        A stack of remote crews are calling in from hotel Wi-Fi. Shape your translation table and keepalive plan so every
+        handshake survives the journey through the beige NAT gateway.
+      </p>
+    </header>
+    <main>
+      <section class="control-panel" aria-labelledby="nat-console">
+        <h2 id="nat-console">Translation console</h2>
+        <p class="intro-copy">
+          Pair each request with the right mapping style and keepalive cadence. The gateway exposes limited ports — drop the
+          wrong policy and the session collapses.
+        </p>
+        <div class="hud" role="status" aria-live="polite">
+          <div class="hud-card">
+            <h3>Score</h3>
+            <output id="nat-score" aria-live="off">0</output>
+          </div>
+          <div class="hud-card">
+            <h3>Gateway stability</h3>
+            <div class="stability-bar" aria-hidden="true">
+              <div id="stability-fill"></div>
+            </div>
+            <output id="stability-display" aria-live="off">100%</output>
+          </div>
+          <div class="hud-card">
+            <h3>Translations locked</h3>
+            <output id="session-progress" aria-live="off">0 / 3</output>
+          </div>
+        </div>
+        <form id="nat-form" class="form-grid">
+          <fieldset>
+            <legend>Connection queue</legend>
+            <div class="session-grid">
+              <article class="session-card" data-session="stun">
+                <h3>Satellite Uplink Crew</h3>
+                <p class="summary">
+                  Needs low-latency voice via UDP 3478. Remote base polls with STUN every 20 seconds.
+                </p>
+                <label for="mapping-stun">Mapping style</label>
+                <select id="mapping-stun" name="mapping-stun">
+                  <option value="">Choose a mapping…</option>
+                  <option value="static">Static pinhole</option>
+                  <option value="restricted">Restricted cone</option>
+                  <option value="preserving">Port-preserving</option>
+                  <option value="symmetric">Symmetric</option>
+                </select>
+                <label for="keepalive-stun">Keepalive tactic</label>
+                <select id="keepalive-stun" name="keepalive-stun">
+                  <option value="">Choose a keepalive…</option>
+                  <option value="stun">STUN binding refresh</option>
+                  <option value="udp">Manual UDP ping</option>
+                  <option value="alg">Application-layer gateway assist</option>
+                </select>
+              </article>
+              <article class="session-card" data-session="ftp">
+                <h3>Graphics Vendor FTP</h3>
+                <p class="summary">
+                  Passive-mode file drop. Control on TCP 21, ephemeral data ports follow client suggestion.
+                </p>
+                <label for="mapping-ftp">Mapping style</label>
+                <select id="mapping-ftp" name="mapping-ftp">
+                  <option value="">Choose a mapping…</option>
+                  <option value="static">Static pinhole</option>
+                  <option value="restricted">Restricted cone</option>
+                  <option value="preserving">Port-preserving</option>
+                  <option value="symmetric">Symmetric</option>
+                </select>
+                <label for="keepalive-ftp">Keepalive tactic</label>
+                <select id="keepalive-ftp" name="keepalive-ftp">
+                  <option value="">Choose a keepalive…</option>
+                  <option value="stun">STUN binding refresh</option>
+                  <option value="udp">Manual UDP ping</option>
+                  <option value="alg">Application-layer gateway assist</option>
+                </select>
+              </article>
+              <article class="session-card" data-session="tunnel">
+                <h3>Investigations VPN Tunnel</h3>
+                <p class="summary">ESP-over-UDP fallback, expects periodic DPD keepalives and consistent outer ports.</p>
+                <label for="mapping-tunnel">Mapping style</label>
+                <select id="mapping-tunnel" name="mapping-tunnel">
+                  <option value="">Choose a mapping…</option>
+                  <option value="static">Static pinhole</option>
+                  <option value="restricted">Restricted cone</option>
+                  <option value="preserving">Port-preserving</option>
+                  <option value="symmetric">Symmetric</option>
+                </select>
+                <label for="keepalive-tunnel">Keepalive tactic</label>
+                <select id="keepalive-tunnel" name="keepalive-tunnel">
+                  <option value="">Choose a keepalive…</option>
+                  <option value="stun">STUN binding refresh</option>
+                  <option value="udp">Manual UDP ping</option>
+                  <option value="alg">Application-layer gateway assist</option>
+                </select>
+              </article>
+            </div>
+            <button type="submit" class="execute-button">Negotiate mappings</button>
+          </fieldset>
+        </form>
+        <div id="nat-status" class="status-board" aria-live="polite">Gateway idle. Awaiting policy.</div>
+      </section>
+      <section class="log-panel" aria-labelledby="negotiation-log">
+        <h2 id="negotiation-log">Negotiation log</h2>
+        <ul id="timeline" class="log-list" aria-live="polite"></ul>
+      </section>
+    </main>
+    <footer>Keep the translators lean and the crew online.</footer>
+    <script type="module" src="./nat-handshake-lab.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/net/nat-handshake-lab/nat-handshake-lab.css
+++ b/madia.new/public/secret/net/nat-handshake-lab/nat-handshake-lab.css
@@ -1,0 +1,130 @@
+main {
+  gap: 2rem;
+}
+
+.intro-copy {
+  margin: 0 0 1rem;
+  color: var(--net-muted);
+}
+
+.hud {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.hud-card {
+  background: rgba(6, 14, 30, 0.85);
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.hud-card h3 {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--net-muted);
+}
+
+.hud-card output {
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.stability-bar {
+  height: 10px;
+  background: rgba(56, 248, 122, 0.15);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.stability-bar div {
+  height: 100%;
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0.55), rgba(56, 248, 122, 0.95));
+  transition: width 0.3s ease;
+  width: 100%;
+}
+
+.session-grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.session-card {
+  background: rgba(4, 10, 22, 0.82);
+  border: 1px solid rgba(56, 248, 122, 0.18);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.65rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.session-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(56, 248, 122, 0.08), transparent 60%);
+  pointer-events: none;
+}
+
+.session-card[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.5);
+  box-shadow: 0 0 24px rgba(255, 95, 109, 0.25);
+}
+
+.session-card[data-state="locked"] {
+  border-color: rgba(56, 248, 122, 0.6);
+  box-shadow: 0 0 24px rgba(56, 248, 122, 0.3);
+}
+
+.session-card h3 {
+  margin: 0;
+  letter-spacing: 0.04em;
+}
+
+.session-card .summary {
+  margin: 0;
+  color: rgba(148, 197, 183, 0.8);
+  font-size: 0.85rem;
+}
+
+.log-panel {
+  background: rgba(4, 12, 26, 0.8);
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 28px rgba(2, 10, 22, 0.45);
+}
+
+.log-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.log-list li {
+  background: rgba(5, 14, 28, 0.85);
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  border-radius: 8px;
+  padding: 0.65rem 0.75rem;
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.log-list li strong {
+  color: var(--net-accent);
+}
+
+@media (max-width: 720px) {
+  .hud {
+    grid-template-columns: 1fr;
+  }
+}

--- a/madia.new/public/secret/net/nat-handshake-lab/nat-handshake-lab.js
+++ b/madia.new/public/secret/net/nat-handshake-lab/nat-handshake-lab.js
@@ -1,0 +1,209 @@
+const sessions = [
+  {
+    id: "stun",
+    name: "Satellite Uplink Crew",
+    mapping: "preserving",
+    keepalive: "stun",
+    baseScore: 120,
+    penalty: 25,
+    log: "Port 3478 pinned. STUN reflectors report clean round trips.",
+  },
+  {
+    id: "ftp",
+    name: "Graphics Vendor FTP",
+    mapping: "restricted",
+    keepalive: "alg",
+    baseScore: 110,
+    penalty: 20,
+    log: "ALG opened passive data slots. Vendor upload underway.",
+  },
+  {
+    id: "tunnel",
+    name: "Investigations VPN Tunnel",
+    mapping: "static",
+    keepalive: "udp",
+    baseScore: 140,
+    penalty: 30,
+    log: "DPD timers satisfied. Tunnel renegotiation succeeded.",
+  },
+];
+
+const form = document.getElementById("nat-form");
+const statusBoard = document.getElementById("nat-status");
+const timeline = document.getElementById("timeline");
+const scoreOutput = document.getElementById("nat-score");
+const stabilityDisplay = document.getElementById("stability-display");
+const stabilityFill = document.getElementById("stability-fill");
+const progressOutput = document.getElementById("session-progress");
+const sessionCards = new Map(
+  Array.from(document.querySelectorAll(".session-card")).map((card) => [card.dataset.session, card])
+);
+
+let stability = 100;
+let score = 0;
+const locked = new Set();
+const attempts = new Map(sessions.map((session) => [session.id, 0]));
+
+const clampStability = () => {
+  stability = Math.max(0, Math.min(stability, 100));
+};
+
+const updateHud = () => {
+  scoreOutput.textContent = `${score}`;
+  stabilityDisplay.textContent = `${Math.round(stability)}%`;
+  stabilityFill.style.width = `${stability}%`;
+  progressOutput.textContent = `${locked.size} / ${sessions.length}`;
+};
+
+const setStatus = (message, state = "idle") => {
+  statusBoard.textContent = message;
+  statusBoard.dataset.state = state;
+};
+
+const appendLog = (session, sessionScore, attemptsUsed) => {
+  const entry = document.createElement("li");
+  const title = document.createElement("strong");
+  title.textContent = session.name;
+  entry.appendChild(title);
+
+  const detail = document.createElement("span");
+  detail.textContent = session.log;
+  entry.appendChild(detail);
+
+  const attemptLine = document.createElement("span");
+  attemptLine.textContent = `Locked after ${attemptsUsed} ${attemptsUsed === 1 ? "pass" : "passes"}.`;
+  entry.appendChild(attemptLine);
+
+  const scoreLine = document.createElement("span");
+  scoreLine.textContent = `Score earned: ${sessionScore}`;
+  entry.appendChild(scoreLine);
+
+  timeline?.prepend(entry);
+};
+
+const lockSession = (session, sessionScore, attemptsUsed) => {
+  locked.add(session.id);
+  const card = sessionCards.get(session.id);
+  if (card) {
+    card.dataset.state = "locked";
+  }
+  appendLog(session, sessionScore, attemptsUsed);
+  updateHud();
+  if (locked.size === sessions.length) {
+    const finalScore = score + Math.round(stability);
+    setStatus("All traversals pinned. Gateway humming.", "success");
+    window.parent?.postMessage(
+      {
+        type: "net:level-complete",
+        game: "nat-handshake-lab",
+        payload: {
+          status: "Negotiation complete",
+          score: finalScore,
+        },
+      },
+      "*"
+    );
+  }
+};
+
+const markError = (session) => {
+  const card = sessionCards.get(session.id);
+  if (card && card.dataset.state !== "locked") {
+    card.dataset.state = "error";
+  }
+};
+
+const clearTransientStates = () => {
+  sessionCards.forEach((card, id) => {
+    if (!locked.has(id) && card.dataset.state === "error") {
+      delete card.dataset.state;
+    }
+  });
+};
+
+form?.addEventListener("submit", (event) => {
+  event.preventDefault();
+  if (!form) {
+    return;
+  }
+  const formData = new FormData(form);
+  const missing = sessions.filter((session) => {
+    if (locked.has(session.id)) {
+      return false;
+    }
+    const mappingValue = formData.get(`mapping-${session.id}`) || "";
+    const keepaliveValue = formData.get(`keepalive-${session.id}`) || "";
+    return !mappingValue || !keepaliveValue;
+  });
+  if (missing.length) {
+    missing.forEach((session) => markError(session));
+    setStatus("Policies incomplete. Fill every mapping and keepalive.", "error");
+    return;
+  }
+
+  let anyError = false;
+  sessions.forEach((session) => {
+    const mappingValue = formData.get(`mapping-${session.id}`) || "";
+    const keepaliveValue = formData.get(`keepalive-${session.id}`) || "";
+    if (locked.has(session.id)) {
+      return;
+    }
+    const attemptCount = (attempts.get(session.id) || 0) + 1;
+    attempts.set(session.id, attemptCount);
+    if (mappingValue !== session.mapping || keepaliveValue !== session.keepalive) {
+      anyError = true;
+      markError(session);
+    } else {
+      const penalty = Math.max(0, (attemptCount - 1) * session.penalty);
+      const sessionScore = Math.max(session.baseScore - penalty, Math.floor(session.penalty / 2));
+      score += sessionScore;
+      const card = sessionCards.get(session.id);
+      if (card) {
+        card.dataset.state = "locked";
+      }
+      lockSession(session, sessionScore, attemptCount);
+    }
+  });
+
+  if (anyError) {
+    stability -= 14;
+    clampStability();
+    updateHud();
+    const problematic = sessions
+      .filter((session) => !locked.has(session.id))
+      .map((session) => session.name);
+    if (problematic.length) {
+      setStatus(`Mappings rejected: ${problematic.join(", ")}.`, "error");
+    } else {
+      setStatus("At least one policy bounced. Re-evaluate choices.", "error");
+    }
+  } else if (locked.size < sessions.length) {
+    setStatus("Partial success. Remaining sessions still negotiating.", "idle");
+  }
+
+  updateHud();
+});
+
+form?.addEventListener("input", () => {
+  if (!form) {
+    return;
+  }
+  clearTransientStates();
+  if (statusBoard.dataset.state === "success") {
+    return;
+  }
+  const formData = new FormData(form);
+  const outstanding = sessions.filter((session) => !locked.has(session.id));
+  const ready = outstanding.every((session) => {
+    const mappingValue = formData.get(`mapping-${session.id}`) || "";
+    const keepaliveValue = formData.get(`keepalive-${session.id}`) || "";
+    return Boolean(mappingValue && keepaliveValue);
+  });
+  if (ready) {
+    setStatus("Policies staged. Commit to push them live.");
+  } else {
+    setStatus("Drafting translation rules…");
+  }
+});
+
+updateHud();

--- a/madia.new/public/secret/net/net.js
+++ b/madia.new/public/secret/net/net.js
@@ -39,6 +39,15 @@ const nodes = [
     thumbnail: "make bzImage",
   },
   {
+    id: "nat-handshake-lab",
+    layer: "Layer 05 · Edge Negotiator",
+    name: "NAT Handshake Lab",
+    description:
+      "Shape translation rules so remote crews punch through hotel NAT and keep their tunnels alive.",
+    url: "./nat-handshake-lab/index.html",
+    thumbnail: "NAT Ops",
+  },
+  {
     id: "modem-skunkworks",
     layer: "Layer 04 · Dial-Up Ops",
     name: "Modem Skunkworks",
@@ -46,6 +55,15 @@ const nodes = [
       "Sequence the perfect PPP handshake so the remote newsroom can sync before sunrise.",
     url: "./modem-skunkworks/index.html",
     thumbnail: "PPP Sync",
+  },
+  {
+    id: "lan-beacon-scout",
+    layer: "Layer 04 · LAN Recon",
+    name: "LAN Beacon Scout",
+    description:
+      "Wake snoozing workstations with precision broadcasts before the newsroom floods the helpdesk.",
+    url: "./lan-beacon-scout/index.html",
+    thumbnail: "LAN Scan",
   },
   {
     id: "borderline-broadcast",


### PR DESCRIPTION
## Summary
- add the LAN Beacon Scout broadcast sweep cabinet with HUD, subnet map, and discovery log
- introduce the NAT Handshake Lab puzzle for mapping/keepalive negotiation with scoring and status feedback
- register both cabinets inside the Net arcade launcher

## Testing
- manual verification via `python -m http.server 5000`


------
https://chatgpt.com/codex/tasks/task_e_68e670b1fe7c832891f584a2a7d4c3c5