### PR TITLE
Add fullscreen support to LAN Beacon Scout and NAT Handshake Lab

### DIFF
--- a/madia.new/public/secret/net/lan-beacon-scout/index.html
+++ b/madia.new/public/secret/net/lan-beacon-scout/index.html
@@ -9,8 +9,22 @@
   </head>
   <body>
     <header>
-      <p>Layer 04 · LAN Recon</p>
-      <h1>LAN Beacon Scout</h1>
+      <div class="header-bar">
+        <div class="header-text">
+          <p>Layer 04 · LAN Recon</p>
+          <h1>LAN Beacon Scout</h1>
+        </div>
+        <button
+          type="button"
+          class="fullscreen-toggle"
+          data-role="fullscreen-toggle"
+          data-fullscreen="false"
+          aria-pressed="false"
+        >
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--enter" data-state="enter">Enter full screen</span>
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--exit" data-state="exit">Exit full screen</span>
+        </button>
+      </div>
       <p>
         Office floors are dark after a storm and the wiring closet is humming. Sweep each subnet with the right
         broadcast pattern so the stranded workstations phone home before the helpdesk boards light up.

--- a/madia.new/public/secret/net/lan-beacon-scout/lan-beacon-scout.js
+++ b/madia.new/public/secret/net/lan-beacon-scout/lan-beacon-scout.js
@@ -1,3 +1,7 @@
+import { initFullscreenToggle } from "../fullscreen.js";
+
+initFullscreenToggle();
+
 const rounds = [
   {
     id: "newsroom",

--- a/madia.new/public/secret/net/nat-handshake-lab/index.html
+++ b/madia.new/public/secret/net/nat-handshake-lab/index.html
@@ -9,8 +9,22 @@
   </head>
   <body>
     <header>
-      <p>Layer 05 · Edge Negotiator</p>
-      <h1>NAT Handshake Lab</h1>
+      <div class="header-bar">
+        <div class="header-text">
+          <p>Layer 05 · Edge Negotiator</p>
+          <h1>NAT Handshake Lab</h1>
+        </div>
+        <button
+          type="button"
+          class="fullscreen-toggle"
+          data-role="fullscreen-toggle"
+          data-fullscreen="false"
+          aria-pressed="false"
+        >
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--enter" data-state="enter">Enter full screen</span>
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--exit" data-state="exit">Exit full screen</span>
+        </button>
+      </div>
       <p>
         A stack of remote crews are calling in from hotel Wi-Fi. Shape your translation table and keepalive plan so every
         handshake survives the journey through the beige NAT gateway.

--- a/madia.new/public/secret/net/nat-handshake-lab/nat-handshake-lab.js
+++ b/madia.new/public/secret/net/nat-handshake-lab/nat-handshake-lab.js
@@ -1,3 +1,7 @@
+import { initFullscreenToggle } from "../fullscreen.js";
+
+initFullscreenToggle();
+
 const sessions = [
   {
     id: "stun",


### PR DESCRIPTION
## Summary
- add the shared fullscreen toggle UI to the LAN Beacon Scout and NAT Handshake Lab launch screens
- initialize both minigames with the common fullscreen helper so the new control functions

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e673401e78832882994eb308ad3369