### PR TITLE
Add Registrar Launch Desk to Net arcade

### DIFF
--- a/madia.new/public/secret/net/net.js
+++ b/madia.new/public/secret/net/net.js
@@ -21,6 +21,15 @@ const nodes = [
     thumbnail: "NS Lookup",
   },
   {
+    id: "registrar-launch-desk",
+    layer: "Layer 07 · Registrar Ops",
+    name: "Registrar Launch Desk",
+    description:
+      "Stage domain records across three registrars and only push the combos that keep every service resolving.",
+    url: "./registrar-launch-desk/index.html",
+    thumbnail: "DNS Desk",
+  },
+  {
     id: "daemon-handshake",
     layer: "Layer 06 · Web Stack",
     name: "Daemon Handshake",

--- a/madia.new/public/secret/net/registrar-launch-desk/index.html
+++ b/madia.new/public/secret/net/registrar-launch-desk/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Registrar Launch Desk</title>
+    <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="./registrar-launch-desk.css" />
+  </head>
+  <body>
+    <header>
+      <div class="header-bar">
+        <div class="header-text">
+          <p>Layer 07 · Registrar Ops</p>
+          <h1>Registrar Launch Desk</h1>
+        </div>
+        <button
+          type="button"
+          class="fullscreen-toggle"
+          data-role="fullscreen-toggle"
+          data-fullscreen="false"
+          aria-pressed="false"
+        >
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--enter" data-state="enter">Enter full screen</span>
+          <span class="fullscreen-toggle__label fullscreen-toggle__label--exit" data-state="exit">Exit full screen</span>
+        </button>
+      </div>
+      <p>
+        Three registrar queues just landed in your lap. Stage the right DNS records, vet the zone, and push the launch window
+        before the modem bank starts lighting up.
+      </p>
+    </header>
+    <main>
+      <section class="control-panel" aria-labelledby="desk-directive">
+        <h2 id="desk-directive">Deployment console</h2>
+        <p>
+          Each briefing includes a domain, the on-call notes, and a crate of potential records. Flip the toggles to stage
+          records in your zone, validate the mix, and advance the queue once everything resolves cleanly.
+        </p>
+        <div class="status-ribbon" id="desk-status" aria-live="polite"></div>
+        <div class="panel-grid">
+          <article class="card card--scenario" id="scenario-card" aria-live="polite"></article>
+          <article class="card card--candidates" aria-labelledby="candidate-heading">
+            <div class="card__header">
+              <h3 id="candidate-heading">Record crates</h3>
+              <p>Flip the toggles to load records into the staging zone. Descriptions mirror the registrar binder.</p>
+            </div>
+            <div id="candidate-list" class="candidate-list"></div>
+          </article>
+          <article class="card card--zone" aria-labelledby="zone-heading">
+            <div class="card__header">
+              <h3 id="zone-heading">Staged zone</h3>
+              <p>Records queued for publish. Remove anything suspect before validation.</p>
+            </div>
+            <div id="zone-body" class="zone-body"></div>
+            <div class="action-bar">
+              <button type="button" class="action-button" id="reset-button">Clear zone</button>
+              <button type="button" class="action-button action-button--primary" id="check-button">Run validation</button>
+              <button type="button" class="action-button action-button--accent" id="next-button" hidden>Next briefing</button>
+            </div>
+            <div id="feedback" class="feedback" role="status" aria-live="polite"></div>
+          </article>
+        </div>
+        <div class="status-map">
+          <div class="status-board" id="status-board" data-state="idle" aria-live="polite">
+            Patch queue open. Queue records to stage the zone.
+          </div>
+          <div class="signal-map" id="signal-map" data-state="idle" aria-hidden="true">
+            <span class="signal-node signal-node--registrar"></span>
+            <span class="signal-node signal-node--apex"></span>
+            <span class="signal-node signal-node--service"></span>
+            <span class="signal-beam signal-beam--one"></span>
+            <span class="signal-beam signal-beam--two"></span>
+            <span class="signal-beam signal-beam--three"></span>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer>Based on the onboarding binders that kept dial-up launches on schedule.</footer>
+    <script type="module" src="./registrar-launch-desk.js"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/net/registrar-launch-desk/registrar-launch-desk.css
+++ b/madia.new/public/secret/net/registrar-launch-desk/registrar-launch-desk.css
@@ -1,0 +1,468 @@
+body {
+  background: radial-gradient(circle at top right, rgba(56, 248, 122, 0.1), transparent 55%),
+    radial-gradient(circle at bottom left, rgba(11, 83, 148, 0.2), transparent 60%), var(--net-bg);
+}
+
+.status-ribbon {
+  margin: 1rem 0;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  background: linear-gradient(120deg, rgba(8, 24, 40, 0.92), rgba(10, 32, 52, 0.95));
+  box-shadow: 0 10px 22px rgba(3, 12, 28, 0.45);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.status-ribbon__chunk {
+  color: var(--net-muted);
+}
+
+.status-ribbon__domain {
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(56, 248, 122, 0.12);
+  border: 1px solid rgba(56, 248, 122, 0.35);
+  color: var(--net-accent);
+}
+
+.panel-grid {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(270px, 1fr));
+}
+
+.card {
+  background: linear-gradient(170deg, rgba(6, 16, 32, 0.92), rgba(8, 28, 46, 0.96));
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  border-radius: 14px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 12px 26px rgba(2, 12, 26, 0.5);
+}
+
+.card__header h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.card__header p {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  color: var(--net-muted);
+}
+
+.card--scenario h3,
+.card--scenario h2 {
+  margin: 0;
+}
+
+.scenario-domain {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--net-muted);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.scenario-domain span {
+  margin-left: 0.4rem;
+  color: var(--net-accent);
+}
+
+.scenario-title {
+  margin: 0.35rem 0 0.5rem;
+  font-size: 1.3rem;
+  letter-spacing: 0.04em;
+}
+
+.scenario-narrative {
+  margin: 0.5rem 0;
+  font-size: 0.95rem;
+  color: var(--net-text);
+  line-height: 1.55;
+}
+
+.scenario-objectives {
+  margin: 0.75rem 0 0;
+}
+
+.scenario-objectives h3 {
+  margin: 0 0 0.5rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--net-muted);
+}
+
+.goal-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.candidate-list {
+  overflow: auto;
+  border-radius: 10px;
+  border: 1px solid rgba(56, 248, 122, 0.15);
+  background: rgba(6, 16, 32, 0.6);
+}
+
+.candidate-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.candidate-table caption {
+  caption-side: top;
+  padding: 0.75rem 1rem;
+  text-align: left;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--net-muted);
+}
+
+.candidate-table th,
+.candidate-table td {
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid rgba(56, 248, 122, 0.08);
+  text-align: left;
+}
+
+.candidate-table th {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 183, 0.78);
+}
+
+.candidate-table td {
+  vertical-align: top;
+}
+
+.candidate-table tr[data-selected="true"] {
+  background: rgba(56, 248, 122, 0.08);
+}
+
+.candidate-table tr:hover {
+  background: rgba(56, 248, 122, 0.12);
+}
+
+.candidate-table__toggle {
+  width: 3rem;
+  text-align: center;
+}
+
+.candidate-table__notes {
+  color: rgba(148, 197, 183, 0.9);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.zone-body {
+  min-height: 9rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.zone-empty {
+  margin: 0;
+  padding: 1rem;
+  border-radius: 10px;
+  border: 1px dashed rgba(56, 248, 122, 0.25);
+  background: rgba(8, 20, 38, 0.8);
+  color: var(--net-muted);
+  text-align: center;
+  font-style: italic;
+}
+
+.zone-record {
+  position: relative;
+  padding: 1rem 1.1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  background: linear-gradient(145deg, rgba(5, 14, 28, 0.95), rgba(10, 32, 52, 0.9));
+  display: grid;
+  gap: 0.5rem;
+}
+
+.zone-record__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: baseline;
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.zone-record__host {
+  color: var(--net-accent);
+}
+
+.zone-record__type {
+  padding: 0.1rem 0.5rem;
+  border-radius: 6px;
+  background: rgba(56, 248, 122, 0.1);
+  border: 1px solid rgba(56, 248, 122, 0.35);
+  font-size: 0.75rem;
+}
+
+.zone-record__value {
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
+}
+
+.zone-record__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--net-muted);
+}
+
+.zone-record__note {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(148, 197, 183, 0.86);
+}
+
+.zone-record__remove {
+  align-self: flex-start;
+  margin-top: 0.25rem;
+  font-size: 0.7rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(56, 248, 122, 0.45);
+  background: rgba(6, 20, 36, 0.85);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.action-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.action-button {
+  font-size: 0.75rem;
+  padding: 0.6rem 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.action-button--primary {
+  border-color: rgba(56, 248, 122, 0.55);
+  background: linear-gradient(135deg, rgba(56, 248, 122, 0.18), rgba(56, 248, 122, 0.3));
+}
+
+.action-button--accent {
+  border-color: rgba(244, 180, 0, 0.65);
+  background: linear-gradient(135deg, rgba(244, 180, 0, 0.18), rgba(244, 180, 0, 0.28));
+  color: #fff6ce;
+}
+
+.feedback {
+  min-height: 3rem;
+  display: flex;
+  align-items: stretch;
+}
+
+.feedback__message {
+  width: 100%;
+  padding: 0.9rem 1rem;
+  border-radius: 10px;
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  background: rgba(6, 16, 32, 0.85);
+  font-size: 0.85rem;
+  line-height: 1.5;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.feedback[data-tone="success"] .feedback__message {
+  border-color: rgba(56, 248, 122, 0.5);
+  color: var(--status-success);
+}
+
+.feedback[data-tone="warning"] .feedback__message {
+  border-color: rgba(244, 180, 0, 0.45);
+  color: #ffe9ae;
+}
+
+.feedback[data-tone="error"] .feedback__message {
+  border-color: rgba(255, 95, 109, 0.45);
+  color: #ffd9e1;
+}
+
+.status-map {
+  margin-top: 2rem;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: stretch;
+}
+
+.signal-map {
+  position: relative;
+  min-height: 220px;
+  border-radius: 16px;
+  border: 1px solid rgba(56, 248, 122, 0.2);
+  background: radial-gradient(circle at 20% 20%, rgba(56, 248, 122, 0.15), transparent 55%),
+    linear-gradient(160deg, rgba(5, 18, 36, 0.95), rgba(9, 28, 44, 0.92));
+  overflow: hidden;
+}
+
+.signal-node {
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(56, 248, 122, 0.45);
+  box-shadow: 0 0 18px rgba(56, 248, 122, 0.35);
+  transform: translate(-50%, -50%);
+}
+
+.signal-node--registrar {
+  top: 20%;
+  left: 22%;
+}
+
+.signal-node--apex {
+  top: 52%;
+  left: 50%;
+}
+
+.signal-node--service {
+  bottom: 16%;
+  right: 18%;
+}
+
+.signal-beam {
+  position: absolute;
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0), rgba(56, 248, 122, 0.8), rgba(56, 248, 122, 0));
+  opacity: 0.2;
+}
+
+.signal-beam--one {
+  width: 50%;
+  top: 28%;
+  left: 20%;
+  transform: rotate(12deg);
+}
+
+.signal-beam--two {
+  width: 46%;
+  top: 56%;
+  left: 28%;
+  transform: rotate(-6deg);
+}
+
+.signal-beam--three {
+  width: 38%;
+  bottom: 22%;
+  left: 36%;
+  transform: rotate(24deg);
+}
+
+.signal-map[data-state="processing"] .signal-beam {
+  opacity: 0.6;
+  animation: beam-sweep 1.6s linear infinite;
+}
+
+.signal-map[data-state="processing"] .signal-node,
+.signal-map[data-state="staging"] .signal-node {
+  animation: node-pulse 1.6s ease-in-out infinite;
+}
+
+.signal-map[data-state="success"] {
+  border-color: rgba(56, 248, 122, 0.6);
+  box-shadow: 0 0 26px rgba(56, 248, 122, 0.35);
+}
+
+.signal-map[data-state="success"] .signal-node {
+  background: rgba(56, 248, 122, 0.75);
+  box-shadow: 0 0 24px rgba(56, 248, 122, 0.5);
+}
+
+.signal-map[data-state="success"] .signal-beam {
+  opacity: 0.7;
+  animation: beam-sweep 1.8s linear infinite;
+}
+
+.signal-map[data-state="error"] {
+  border-color: rgba(255, 95, 109, 0.6);
+  box-shadow: 0 0 22px rgba(255, 95, 109, 0.3);
+  animation: map-shake 0.6s ease;
+}
+
+.signal-map[data-state="error"] .signal-node {
+  background: rgba(255, 95, 109, 0.7);
+  box-shadow: 0 0 20px rgba(255, 95, 109, 0.4);
+}
+
+.signal-map[data-state="error"] .signal-beam {
+  background: linear-gradient(90deg, rgba(255, 95, 109, 0), rgba(255, 95, 109, 0.8), rgba(255, 95, 109, 0));
+  opacity: 0.5;
+}
+
+@keyframes beam-sweep {
+  0% {
+    background-position: 0% 50%;
+  }
+  100% {
+    background-position: 200% 50%;
+  }
+}
+
+@keyframes node-pulse {
+  0%,
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+  }
+  50% {
+    transform: translate(-50%, -50%) scale(1.2);
+  }
+}
+
+@keyframes map-shake {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+  25% {
+    transform: translate3d(-4px, 3px, 0);
+  }
+  50% {
+    transform: translate3d(3px, -2px, 0);
+  }
+  75% {
+    transform: translate3d(-2px, 2px, 0);
+  }
+}
+
+@media (max-width: 720px) {
+  .status-map {
+    grid-template-columns: 1fr;
+  }
+
+  .status-ribbon {
+    justify-content: center;
+  }
+}

--- a/madia.new/public/secret/net/registrar-launch-desk/registrar-launch-desk.js
+++ b/madia.new/public/secret/net/registrar-launch-desk/registrar-launch-desk.js
@@ -1,0 +1,683 @@
+import { initFullscreenToggle } from "../fullscreen.js";
+
+initFullscreenToggle();
+
+const scenarios = [
+  {
+    id: "launch-day",
+    title: "Round 1 · Launch day logistics",
+    domain: "orbit.cafe",
+    narrative:
+      "Orbit Café's marketing site is ready to launch. The web host handed you a single IPv4 address and a managed mail server.",
+    goals: [
+      "Point the apex (@) to the web host at 203.0.113.42 with an A record.",
+      "Send www traffic to the apex using a CNAME alias.",
+      "Route mail to mail.orbit-mail.net with priority 10.",
+    ],
+    candidates: [
+      {
+        id: "a-root-web",
+        host: "@",
+        type: "A",
+        value: "203.0.113.42",
+        ttl: "3600",
+        description: "Primary web server provided by Launchpad Static Hosting.",
+      },
+      {
+        id: "a-root-alt",
+        host: "@",
+        type: "A",
+        value: "198.51.100.24",
+        ttl: "3600",
+        description: "An old sandbox address that is no longer in use.",
+      },
+      {
+        id: "cname-www-root",
+        host: "www",
+        type: "CNAME",
+        value: "@",
+        ttl: "3600",
+        description: "Lets www orbit the same destination as the apex.",
+      },
+      {
+        id: "cname-www-app",
+        host: "www",
+        type: "CNAME",
+        value: "app.orbit-pages.net",
+        ttl: "3600",
+        description: "Points www at a staging app that is not meant for production.",
+      },
+      {
+        id: "mx-mail",
+        host: "@",
+        type: "MX",
+        value: "mail.orbit-mail.net",
+        priority: 10,
+        ttl: "3600",
+        description: "Primary mailbox cluster from Orbit Mail.",
+      },
+      {
+        id: "mx-mail-backup",
+        host: "@",
+        type: "MX",
+        value: "backup.orbit-mail.net",
+        priority: 30,
+        ttl: "3600",
+        description: "Legacy backup MX that Orbit Mail retired last quarter.",
+      },
+      {
+        id: "txt-verification",
+        host: "@",
+        type: "TXT",
+        value: "google-site-verification=t7dLQ2Fx9oLJrKJwA1",
+        ttl: "3600",
+        description: "Verification token for an analytics service you may add later.",
+      },
+    ],
+    solution: ["a-root-web", "cname-www-root", "mx-mail"],
+  },
+  {
+    id: "mail-hardening",
+    title: "Round 2 · Harden your inbox",
+    domain: "papertrail.studio",
+    narrative:
+      "Papertrail Studio already serves a site from their craft CMS, but they are migrating mail to Papertrail Mail and need SPF configured.",
+    goals: [
+      "Keep the website online with the CMS server at 198.51.100.24.",
+      "Publish the SPF policy v=spf1 include:_spf.papertrailmail.com -all.",
+      "Add both priority 10 and 30 MX records pointing to Papertrail Mail.",
+    ],
+    candidates: [
+      {
+        id: "a-root-cms",
+        host: "@",
+        type: "A",
+        value: "198.51.100.24",
+        ttl: "1800",
+        description: "Current CMS server that should keep receiving traffic.",
+      },
+      {
+        id: "a-root-staging",
+        host: "@",
+        type: "A",
+        value: "203.0.113.19",
+        ttl: "1800",
+        description: "Staging server used only for QA builds.",
+      },
+      {
+        id: "txt-spf",
+        host: "@",
+        type: "TXT",
+        value: '"v=spf1 include:_spf.papertrailmail.com -all"',
+        ttl: "3600",
+        description: "SPF record recommended by Papertrail Mail's onboarding wizard.",
+      },
+      {
+        id: "txt-sandbox",
+        host: "@",
+        type: "TXT",
+        value: '"v=spf1 mx -all"',
+        ttl: "3600",
+        description: "Old SPF placeholder that blocks Papertrail Mail from sending.",
+      },
+      {
+        id: "mx-primary",
+        host: "@",
+        type: "MX",
+        value: "mx1.papertrailmail.com",
+        priority: 10,
+        ttl: "3600",
+        description: "Primary inbound mail exchanger for Papertrail Mail.",
+      },
+      {
+        id: "mx-secondary",
+        host: "@",
+        type: "MX",
+        value: "mx2.papertrailmail.com",
+        priority: 30,
+        ttl: "3600",
+        description: "Backup mail exchanger required for failover.",
+      },
+      {
+        id: "cname-calendar",
+        host: "calendar",
+        type: "CNAME",
+        value: "ghs.googlehosted.com",
+        ttl: "3600",
+        description: "Points calendar.papertrail.studio to Google Calendar (optional).",
+      },
+    ],
+    solution: ["a-root-cms", "txt-spf", "mx-primary", "mx-secondary"],
+  },
+  {
+    id: "multi-stack",
+    title: "Round 3 · Multi-stack launch",
+    domain: "pixel.quest",
+    narrative:
+      "Pixel Quest is rolling out a hybrid stack with both IPv4 and IPv6 endpoints plus third-party verification tokens.",
+    goals: [
+      "Send the apex to the load balancer at 203.0.113.80.",
+      "Expose an IPv6 API at api.pixel.quest using 2001:db8:200::5.",
+      "Direct www to the apex with a CNAME so marketing stays in sync.",
+      "Publish the TXT token stripe-verification=PX-44321 for billing onboarding.",
+    ],
+    candidates: [
+      {
+        id: "a-root-lb",
+        host: "@",
+        type: "A",
+        value: "203.0.113.80",
+        ttl: "1200",
+        description: "Main IPv4 load balancer for the marketing site.",
+      },
+      {
+        id: "a-root-misconfigured",
+        host: "@",
+        type: "A",
+        value: "192.0.2.17",
+        ttl: "1200",
+        description: "Legacy IP from an old provider that should be removed.",
+      },
+      {
+        id: "cname-www",
+        host: "www",
+        type: "CNAME",
+        value: "@",
+        ttl: "1200",
+        description: "Keeps the www host synced with the apex content.",
+      },
+      {
+        id: "aaaa-api",
+        host: "api",
+        type: "AAAA",
+        value: "2001:db8:200::5",
+        ttl: "900",
+        description: "IPv6 address exposed by the API gateway.",
+      },
+      {
+        id: "a-api-ipv4",
+        host: "api",
+        type: "A",
+        value: "203.0.113.90",
+        ttl: "900",
+        description: "Fallback IPv4 address not yet ready for production.",
+      },
+      {
+        id: "txt-stripe",
+        host: "@",
+        type: "TXT",
+        value: '"stripe-verification=PX-44321"',
+        ttl: "3600",
+        description: "Required token for Stripe's domain claim flow.",
+      },
+      {
+        id: "txt-beta",
+        host: "beta",
+        type: "TXT",
+        value: '"beta-launch=soon"',
+        ttl: "3600",
+        description: "Fun easter egg record that marketing wants after launch.",
+      },
+    ],
+    solution: ["a-root-lb", "cname-www", "aaaa-api", "txt-stripe"],
+  },
+];
+
+const els = {
+  status: document.getElementById("desk-status"),
+  scenario: document.getElementById("scenario-card"),
+  candidateList: document.getElementById("candidate-list"),
+  zoneBody: document.getElementById("zone-body"),
+  resetButton: document.getElementById("reset-button"),
+  checkButton: document.getElementById("check-button"),
+  nextButton: document.getElementById("next-button"),
+  feedback: document.getElementById("feedback"),
+  statusBoard: document.getElementById("status-board"),
+  signalMap: document.getElementById("signal-map"),
+};
+
+const state = {
+  index: 0,
+  selected: new Set(),
+  complete: Array(scenarios.length).fill(false),
+};
+
+attachListeners();
+renderScenario();
+updateStatus();
+
+function attachListeners() {
+  els.resetButton?.addEventListener("click", () => {
+    state.selected.clear();
+    state.complete[state.index] = false;
+    renderCandidates();
+    renderZone();
+    setFeedback(null);
+    setStatusBoard("Patch queue open. Queue records to stage the zone.", "idle");
+    setDiagramState("idle");
+    els.checkButton.disabled = false;
+    updateNextButton();
+    updateStatus();
+  });
+
+  els.checkButton?.addEventListener("click", () => {
+    runValidation();
+  });
+
+  els.nextButton?.addEventListener("click", () => {
+    if (state.index === scenarios.length - 1) {
+      restartGame();
+      return;
+    }
+    state.index = Math.min(state.index + 1, scenarios.length - 1);
+    state.selected.clear();
+    renderScenario();
+    updateStatus();
+  });
+}
+
+function renderScenario() {
+  const scenario = scenarios[state.index];
+  if (!scenario || !els.scenario) {
+    return;
+  }
+
+  els.scenario.innerHTML = "";
+
+  const domainLabel = document.createElement("p");
+  domainLabel.className = "scenario-domain";
+  domainLabel.append("Domain: ");
+  const domainValue = document.createElement("span");
+  domainValue.textContent = scenario.domain;
+  domainLabel.appendChild(domainValue);
+
+  const title = document.createElement("h2");
+  title.className = "scenario-title";
+  title.textContent = scenario.title;
+
+  const narrative = document.createElement("p");
+  narrative.className = "scenario-narrative";
+  narrative.textContent = scenario.narrative;
+
+  const objectives = document.createElement("div");
+  objectives.className = "scenario-objectives";
+  const objectivesHeading = document.createElement("h3");
+  objectivesHeading.textContent = "Objectives";
+  objectives.appendChild(objectivesHeading);
+
+  const goalList = document.createElement("ul");
+  goalList.className = "goal-list";
+  scenario.goals.forEach((goal) => {
+    const item = document.createElement("li");
+    item.textContent = goal;
+    goalList.appendChild(item);
+  });
+  objectives.appendChild(goalList);
+
+  els.scenario.append(domainLabel, title, narrative, objectives);
+
+  state.selected.clear();
+  updateNextButton();
+  setFeedback(null);
+  els.checkButton.disabled = false;
+  setStatusBoard("Patch queue open. Queue records to stage the zone.", "idle");
+  setDiagramState("idle");
+  renderCandidates();
+  renderZone();
+}
+
+function renderCandidates() {
+  const scenario = scenarios[state.index];
+  if (!scenario || !els.candidateList) {
+    return;
+  }
+
+  els.candidateList.innerHTML = "";
+
+  const table = document.createElement("table");
+  table.className = "candidate-table";
+  const caption = document.createElement("caption");
+  caption.textContent = "Candidate records";
+  table.appendChild(caption);
+
+  const thead = document.createElement("thead");
+  const headRow = document.createElement("tr");
+  ["Load", "Host", "Type", "Target / Value", "TTL", "Priority", "Notes"].forEach((heading) => {
+    const th = document.createElement("th");
+    th.textContent = heading;
+    if (heading === "Load" || heading === "TTL" || heading === "Priority") {
+      th.style.textAlign = "center";
+    }
+    headRow.appendChild(th);
+  });
+  thead.appendChild(headRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement("tbody");
+  scenario.candidates.forEach((candidate) => {
+    const row = document.createElement("tr");
+    const isSelected = state.selected.has(candidate.id);
+    if (isSelected) {
+      row.dataset.selected = "true";
+    }
+
+    const toggleCell = document.createElement("td");
+    toggleCell.className = "candidate-table__toggle";
+    toggleCell.style.textAlign = "center";
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.checked = isSelected;
+    checkbox.id = `candidate-${candidate.id}`;
+    checkbox.setAttribute(
+      "aria-label",
+      `Load ${candidate.host} ${candidate.type} record`
+    );
+    checkbox.addEventListener("change", (event) => {
+      toggleCandidate(candidate.id, event.target.checked);
+    });
+    toggleCell.appendChild(checkbox);
+    row.appendChild(toggleCell);
+
+    const hostCell = document.createElement("td");
+    hostCell.textContent = candidate.host;
+    row.appendChild(hostCell);
+
+    const typeCell = document.createElement("td");
+    typeCell.textContent = candidate.type;
+    row.appendChild(typeCell);
+
+    const valueCell = document.createElement("td");
+    valueCell.textContent = candidate.value;
+    row.appendChild(valueCell);
+
+    const ttlCell = document.createElement("td");
+    ttlCell.style.textAlign = "center";
+    ttlCell.textContent = candidate.ttl ?? "—";
+    row.appendChild(ttlCell);
+
+    const priorityCell = document.createElement("td");
+    priorityCell.style.textAlign = "center";
+    if (candidate.type === "MX" && candidate.priority !== undefined) {
+      priorityCell.textContent = String(candidate.priority);
+    } else {
+      priorityCell.textContent = "—";
+    }
+    row.appendChild(priorityCell);
+
+    const notesCell = document.createElement("td");
+    notesCell.className = "candidate-table__notes";
+    notesCell.textContent = candidate.description;
+    row.appendChild(notesCell);
+
+    tbody.appendChild(row);
+  });
+
+  table.appendChild(tbody);
+  els.candidateList.appendChild(table);
+}
+
+function renderZone() {
+  const scenario = scenarios[state.index];
+  if (!scenario || !els.zoneBody) {
+    return;
+  }
+
+  els.zoneBody.innerHTML = "";
+  const records = scenario.candidates.filter((candidate) =>
+    state.selected.has(candidate.id)
+  );
+
+  if (!records.length) {
+    const empty = document.createElement("p");
+    empty.className = "zone-empty";
+    empty.textContent = "No records staged. Flip the toggles to queue them.";
+    els.zoneBody.appendChild(empty);
+    return;
+  }
+
+  records.forEach((record) => {
+    const card = document.createElement("div");
+    card.className = "zone-record";
+
+    const header = document.createElement("div");
+    header.className = "zone-record__header";
+    const host = document.createElement("span");
+    host.className = "zone-record__host";
+    host.textContent = record.host;
+    const type = document.createElement("span");
+    type.className = "zone-record__type";
+    type.textContent = record.type;
+    header.append(host, type);
+
+    const value = document.createElement("div");
+    value.className = "zone-record__value";
+    value.textContent = record.value;
+
+    const meta = document.createElement("div");
+    meta.className = "zone-record__meta";
+    if (record.ttl) {
+      const ttl = document.createElement("span");
+      ttl.textContent = `TTL ${record.ttl}`;
+      meta.appendChild(ttl);
+    }
+    if (record.type === "MX" && record.priority !== undefined) {
+      const priority = document.createElement("span");
+      priority.textContent = `Priority ${record.priority}`;
+      meta.appendChild(priority);
+    }
+
+    const note = document.createElement("p");
+    note.className = "zone-record__note";
+    note.textContent = record.description;
+
+    const remove = document.createElement("button");
+    remove.type = "button";
+    remove.className = "zone-record__remove";
+    remove.textContent = "Remove";
+    remove.addEventListener("click", () => {
+      toggleCandidate(record.id, false);
+    });
+
+    card.append(header, value, meta, note, remove);
+    els.zoneBody.appendChild(card);
+  });
+}
+
+function toggleCandidate(id, shouldSelect) {
+  if (shouldSelect) {
+    state.selected.add(id);
+  } else {
+    state.selected.delete(id);
+  }
+
+  if (state.complete[state.index]) {
+    state.complete[state.index] = false;
+    els.checkButton.disabled = false;
+  }
+
+  renderCandidates();
+  renderZone();
+  setFeedback(null);
+  updateNextButton();
+  setStatusBoard(
+    state.selected.size
+      ? "Zone staging rack warmed up. Validate before pushing."
+      : "Patch queue open. Queue records to stage the zone.",
+    state.selected.size ? "staging" : "idle"
+  );
+  setDiagramState(state.selected.size ? "staging" : "idle");
+  updateStatus();
+}
+
+function runValidation() {
+  const scenario = scenarios[state.index];
+  if (!scenario) {
+    return;
+  }
+
+  setStatusBoard("Running validation across registrars…", "processing");
+  setDiagramState("processing");
+
+  const missing = scenario.solution.filter((id) => !state.selected.has(id));
+  const extras = Array.from(state.selected).filter(
+    (id) => !scenario.solution.includes(id)
+  );
+
+  if (!missing.length && !extras.length) {
+    handleSuccess(scenario);
+    return;
+  }
+
+  const detailBlocks = [];
+  if (missing.length) {
+    detailBlocks.push(createListBlock("Missing", missing, scenario));
+  }
+  if (extras.length) {
+    detailBlocks.push(createListBlock("Not needed right now", extras, scenario));
+  }
+
+  const summary = document.createElement("p");
+  summary.textContent = "Not quite. Cross-check the onboarding binder and try again.";
+  detailBlocks.unshift(summary);
+
+  setFeedback(detailBlocks, "warning");
+  setStatusBoard("Validation failed. Compare notes and retry.", "error");
+  setDiagramState("error");
+}
+
+function handleSuccess(scenario) {
+  state.complete[state.index] = true;
+  els.checkButton.disabled = true;
+  setFeedback("Registrar signs off. Propagation timers already ticking.", "success");
+  setStatusBoard(
+    `${scenario.domain} cleared. Services resolving within minutes.`,
+    "success"
+  );
+  setDiagramState("success");
+  updateNextButton();
+  updateStatus();
+
+  const score = 3600 + state.index * 240;
+  window.parent?.postMessage(
+    {
+      type: "net:level-complete",
+      game: "registrar-launch-desk",
+      payload: {
+        status: `${scenario.domain} verified`,
+        score,
+      },
+    },
+    "*"
+  );
+}
+
+function restartGame() {
+  state.index = 0;
+  state.selected.clear();
+  state.complete = Array(scenarios.length).fill(false);
+  renderScenario();
+  updateStatus();
+}
+
+function updateStatus() {
+  if (!els.status) {
+    return;
+  }
+  const scenario = scenarios[state.index];
+  const completed = state.complete.filter(Boolean).length;
+  els.status.innerHTML = "";
+
+  const roundChunk = document.createElement("span");
+  roundChunk.className = "status-ribbon__chunk";
+  roundChunk.textContent = `Round ${state.index + 1} of ${scenarios.length}`;
+  els.status.appendChild(roundChunk);
+
+  const clearedChunk = document.createElement("span");
+  clearedChunk.className = "status-ribbon__chunk";
+  clearedChunk.textContent = `Clearances ${completed}/${scenarios.length}`;
+  els.status.appendChild(clearedChunk);
+
+  if (scenario) {
+    const domainChunk = document.createElement("span");
+    domainChunk.className = "status-ribbon__domain";
+    domainChunk.textContent = scenario.domain;
+    els.status.appendChild(domainChunk);
+  }
+}
+
+function updateNextButton() {
+  if (!els.nextButton) {
+    return;
+  }
+  const isComplete = state.complete[state.index];
+  els.nextButton.hidden = !isComplete;
+  els.nextButton.textContent =
+    state.index === scenarios.length - 1 ? "Replay rotation" : "Next briefing";
+}
+
+function setFeedback(content, tone = "info") {
+  if (!els.feedback) {
+    return;
+  }
+  els.feedback.innerHTML = "";
+  if (!content || (Array.isArray(content) && content.length === 0)) {
+    els.feedback.removeAttribute("data-tone");
+    return;
+  }
+
+  const wrapper = document.createElement("div");
+  wrapper.className = "feedback__message";
+  const blocks = Array.isArray(content) ? content : [content];
+  blocks.forEach((block) => {
+    if (typeof block === "string") {
+      const paragraph = document.createElement("p");
+      paragraph.textContent = block;
+      wrapper.appendChild(paragraph);
+      return;
+    }
+    wrapper.appendChild(block);
+  });
+  els.feedback.dataset.tone = tone;
+  els.feedback.appendChild(wrapper);
+}
+
+function setStatusBoard(message, stateName = "idle") {
+  if (!els.statusBoard) {
+    return;
+  }
+  els.statusBoard.textContent = message;
+  els.statusBoard.dataset.state = stateName;
+}
+
+function setDiagramState(stateName) {
+  if (els.signalMap) {
+    els.signalMap.dataset.state = stateName;
+  }
+}
+
+function createListBlock(label, ids, scenario) {
+  const container = document.createElement("div");
+  const heading = document.createElement("p");
+  heading.textContent = `${label}:`;
+  container.appendChild(heading);
+  const list = document.createElement("ul");
+  ids.forEach((id) => {
+    const item = document.createElement("li");
+    item.textContent = describeCandidate(scenario, id);
+    list.appendChild(item);
+  });
+  container.appendChild(list);
+  return container;
+}
+
+function describeCandidate(scenario, candidateId) {
+  const candidate = scenario.candidates.find((entry) => entry.id === candidateId);
+  if (!candidate) {
+    return "Unknown record";
+  }
+  const priority =
+    candidate.type === "MX" && candidate.priority !== undefined
+      ? ` (priority ${candidate.priority})`
+      : "";
+  return `${candidate.host} ${candidate.type} → ${candidate.value}${priority}`;
+}


### PR DESCRIPTION
## Summary
- port the DNS Setup Minigame into the Net arcade as the Registrar Launch Desk cabinet
- build the cabinet UI with record toggles, staged zone feedback, and registrar status visuals across three scenarios
- register the new cabinet in the Net launcher grid

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e6bd7847c48328825a5052ba51155d