### PR TITLE
feat: expand root zone relay puzzle

### DIFF
--- a/madia.new/public/secret/net/root-zone-relay/index.html
+++ b/madia.new/public/secret/net/root-zone-relay/index.html
@@ -38,12 +38,21 @@
           green, push the zone live.
         </p>
         <ul class="task-list">
-          <li><strong>www</strong> should be an <abbr title="Address">A</abbr> record to <code>203.0.113.42</code> with TTL <code>3600</code>.</li>
-          <li><strong>mail</strong> should be an <abbr title="Mail Exchange">MX</abbr> record targeting <code>mail.isp.example.</code> with priority <code>10</code>.</li>
-          <li><strong>@</strong> needs an <abbr title="Name Server">NS</abbr> record pointing at <code>ns1.isp.example.</code>.</li>
+          <li>
+            <strong>www</strong> should be an <abbr title="Address">A</abbr> record routing to the
+            dial-up bank. Logs mention a <code>203</code> netblock.
+          </li>
+          <li>
+            <strong>mail</strong> should be an <abbr title="Mail Exchange">MX</abbr> record. Keep the
+            priority low so nearby relays know the proper hop.
+          </li>
+          <li>
+            <strong>@</strong> needs an <abbr title="Name Server">NS</abbr> record aimed at the
+            primary resolver. Remember the trailing dot.
+          </li>
         </ul>
         <form id="zone-form" class="form-grid">
-          <fieldset>
+          <fieldset data-record="www">
             <legend>www</legend>
             <label>
               Record Type
@@ -56,14 +65,27 @@
             </label>
             <label>
               Value
-              <input type="text" name="www-value" placeholder="203.0.113.42" required />
+              <input
+                type="text"
+                name="www-value"
+                placeholder="203.xxx.xxx.xxx"
+                autocomplete="off"
+                required
+              />
             </label>
             <label>
               TTL
-              <input type="number" name="www-ttl" placeholder="3600" required />
+              <input
+                type="number"
+                name="www-ttl"
+                placeholder="Seconds"
+                inputmode="numeric"
+                autocomplete="off"
+                required
+              />
             </label>
           </fieldset>
-          <fieldset>
+          <fieldset data-record="mail">
             <legend>mail</legend>
             <label>
               Record Type
@@ -76,14 +98,27 @@
             </label>
             <label>
               Target host
-              <input type="text" name="mail-value" placeholder="mail.isp.example." required />
+              <input
+                type="text"
+                name="mail-value"
+                placeholder="host.isp.example."
+                autocomplete="off"
+                required
+              />
             </label>
             <label>
               Priority
-              <input type="number" name="mail-priority" placeholder="10" required />
+              <input
+                type="number"
+                name="mail-priority"
+                placeholder="0-50"
+                inputmode="numeric"
+                autocomplete="off"
+                required
+              />
             </label>
           </fieldset>
-          <fieldset>
+          <fieldset data-record="root">
             <legend>Root (@)</legend>
             <label>
               Record Type
@@ -96,7 +131,13 @@
             </label>
             <label>
               Target host
-              <input type="text" name="root-value" placeholder="ns1.isp.example." required />
+              <input
+                type="text"
+                name="root-value"
+                placeholder="resolver hostname"
+                autocomplete="off"
+                required
+              />
             </label>
           </fieldset>
           <button type="submit" class="execute-button">Push zone live</button>
@@ -106,14 +147,17 @@
           <div class="zone-tile" data-record="www">
             <span class="tile-label">www</span>
             <span class="tile-value">A</span>
+            <span class="tile-progress" data-role="tile-progress">0/3 aligned</span>
           </div>
           <div class="zone-tile" data-record="mail">
             <span class="tile-label">mail</span>
             <span class="tile-value">MX</span>
+            <span class="tile-progress" data-role="tile-progress">0/3 aligned</span>
           </div>
           <div class="zone-tile" data-record="root">
             <span class="tile-label">@</span>
             <span class="tile-value">NS</span>
+            <span class="tile-progress" data-role="tile-progress">0/2 aligned</span>
           </div>
         </div>
         <div class="propagation-meter" aria-hidden="true">
@@ -127,6 +171,21 @@
             <span class="propagation-pip" data-index="2"></span>
           </div>
         </div>
+        <section class="diagnostic-console" aria-labelledby="diagnostic-title" aria-live="polite">
+          <div class="diagnostic-header">
+            <h3 id="diagnostic-title">Diagnostics</h3>
+            <button type="button" class="hint-button" data-role="hint-button">
+              Run trace
+            </button>
+          </div>
+          <p class="diagnostic-subtitle">
+            Each trace surfaces another clue from the NOC. Hints lock on to the record most out of
+            spec.
+          </p>
+          <ul class="hint-feed" data-role="hint-feed">
+            <li class="hint-feed__placeholder">No traces run yet.</li>
+          </ul>
+        </section>
       </section>
     </main>
     <footer>Based on IETF RFCs that kept the '96 backbone humming.</footer>

--- a/madia.new/public/secret/net/root-zone-relay/root-zone-relay.css
+++ b/madia.new/public/secret/net/root-zone-relay/root-zone-relay.css
@@ -68,6 +68,13 @@ body {
   color: rgba(110, 255, 210, 0.8);
 }
 
+.tile-progress {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(198, 234, 232, 0.62);
+}
+
 .zone-tile[data-state="good"] {
   border-color: rgba(110, 255, 210, 0.6);
   box-shadow: 0 0 16px rgba(110, 255, 210, 0.18);
@@ -147,4 +154,171 @@ body {
 .propagation-pip[data-active="on"] {
   background: var(--neon-green);
   box-shadow: 0 0 14px rgba(68, 255, 200, 0.6);
+}
+
+.form-grid fieldset {
+  position: relative;
+  border: 1px solid rgba(110, 255, 210, 0.2);
+  border-radius: 16px;
+  padding: 1rem 1rem 1.1rem;
+  background: linear-gradient(170deg, rgba(0, 20, 26, 0.78), rgba(0, 10, 16, 0.92));
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.6);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.form-grid fieldset legend {
+  padding: 0 0.4rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(198, 234, 232, 0.78);
+}
+
+.form-grid label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.92rem;
+  color: rgba(198, 234, 232, 0.75);
+}
+
+.form-grid select,
+.form-grid input {
+  border-radius: 10px;
+  border: 1px solid rgba(110, 255, 210, 0.2);
+  background: rgba(3, 18, 26, 0.88);
+  color: var(--net-foreground);
+  padding: 0.45rem 0.6rem;
+  font-size: 0.95rem;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.form-grid [data-state="warn"] {
+  border-color: rgba(255, 182, 73, 0.65);
+  box-shadow: 0 0 10px rgba(255, 182, 73, 0.22);
+}
+
+.form-grid [data-state="good"] {
+  border-color: rgba(110, 255, 210, 0.6);
+  box-shadow: 0 0 12px rgba(110, 255, 210, 0.24);
+}
+
+.form-grid [data-state="good"] select,
+.form-grid [data-state="good"] input {
+  border-color: rgba(110, 255, 210, 0.6);
+}
+
+.form-grid [data-state="warn"] select,
+.form-grid [data-state="warn"] input {
+  border-color: rgba(255, 182, 73, 0.7);
+}
+
+.diagnostic-console {
+  margin-top: 1.5rem;
+  border-radius: 18px;
+  border: 1px solid rgba(110, 255, 210, 0.22);
+  background: linear-gradient(150deg, rgba(2, 14, 22, 0.9), rgba(0, 10, 14, 0.96));
+  padding: 1.1rem 1.2rem 1.2rem;
+  box-shadow: inset 0 0 14px rgba(0, 0, 0, 0.55);
+}
+
+.diagnostic-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.diagnostic-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(198, 234, 232, 0.8);
+}
+
+.diagnostic-subtitle {
+  margin: 0.75rem 0 1rem;
+  font-size: 0.85rem;
+  color: rgba(198, 234, 232, 0.65);
+}
+
+.hint-button {
+  border: 1px solid rgba(110, 255, 210, 0.35);
+  border-radius: 999px;
+  padding: 0.4rem 1.1rem;
+  background: linear-gradient(90deg, rgba(8, 40, 48, 0.9), rgba(10, 60, 66, 0.9));
+  color: var(--net-foreground);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.hint-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 0 16px rgba(68, 255, 200, 0.25);
+}
+
+.hint-button:disabled {
+  opacity: 0.65;
+  cursor: progress;
+}
+
+.hint-button[data-state="scanning"] {
+  border-color: rgba(110, 255, 210, 0.6);
+  box-shadow: 0 0 18px rgba(68, 255, 200, 0.35);
+}
+
+.hint-feed {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.hint-feed__placeholder {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(198, 234, 232, 0.55);
+}
+
+.hint-entry {
+  border-radius: 12px;
+  border: 1px solid rgba(110, 255, 210, 0.18);
+  padding: 0.65rem 0.75rem;
+  background: rgba(3, 20, 28, 0.85);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.45);
+  display: grid;
+  gap: 0.25rem;
+}
+
+.hint-entry__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(198, 234, 232, 0.7);
+}
+
+.hint-entry__body {
+  font-size: 0.9rem;
+  color: rgba(207, 255, 246, 0.82);
+}
+
+.hint-entry[data-record="zone"] {
+  border-color: rgba(110, 255, 210, 0.35);
+}
+
+@keyframes net-pulse {
+  from {
+    box-shadow: 0 0 0 rgba(68, 255, 200, 0.45);
+  }
+  to {
+    box-shadow: 0 0 22px rgba(68, 255, 200, 0.45);
+  }
+}
+
+.is-hint {
+  animation: net-pulse 0.45s ease-in-out 0s 2 alternate;
 }


### PR DESCRIPTION
## Summary
- add a diagnostics console with sequential hints and updated zone directives for Root Zone Relay
- enhance tile and form feedback with live progress counters and state-driven styling

## Testing
- python3 -m http.server 8000 (manual)


------
https://chatgpt.com/codex/tasks/task_e_68e9049bcaf08328a48e275287daae60