### PR TITLE
Add drag-and-drop handshake puzzle to Modem Skunkworks

### DIFF
--- a/madia.new/public/secret/net/modem-skunkworks/index.html
+++ b/madia.new/public/secret/net/modem-skunkworks/index.html
@@ -33,51 +33,121 @@
     <main>
       <section class="control-panel" aria-labelledby="ppp-brief">
         <h2 id="ppp-brief">Handshake console</h2>
-        <p>Assign the correct order to each PPP phase. No duplicates allowed.</p>
+        <p>Drag each module into position or select it and activate a slot.</p>
         <form id="ppp-form" class="form-grid">
           <fieldset>
             <legend>Phase ordering</legend>
-            <div class="phase-grid">
-              <label>
-                Carrier detect
-                <select name="carrier">
-                  <option value="">--</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                </select>
-              </label>
-              <label>
-                Link control negotiation (LCP)
-                <select name="lcp">
-                  <option value="">--</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                </select>
-              </label>
-              <label>
-                Authentication (PAP/CHAP)
-                <select name="auth">
-                  <option value="">--</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                </select>
-              </label>
-              <label>
-                Network control (IPCP)
-                <select name="ipcp">
-                  <option value="">--</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                </select>
-              </label>
+            <div class="assignment-grid">
+              <section class="phase-pool" aria-labelledby="phase-pool-heading">
+                <h3 id="phase-pool-heading">Phase modules</h3>
+                <div class="chip-deck" data-role="phase-pool">
+                  <button
+                    type="button"
+                    class="phase-chip"
+                    data-phase="carrier"
+                    data-phase-label="Carrier detect"
+                    draggable="true"
+                  >
+                    <span class="chip-title">Carrier detect</span>
+                    <span class="chip-detail">Listen for the tone</span>
+                  </button>
+                  <button
+                    type="button"
+                    class="phase-chip"
+                    data-phase="lcp"
+                    data-phase-label="Link control negotiation"
+                    draggable="true"
+                  >
+                    <span class="chip-title">Link control (LCP)</span>
+                    <span class="chip-detail">Agree on framing</span>
+                  </button>
+                  <button
+                    type="button"
+                    class="phase-chip"
+                    data-phase="auth"
+                    data-phase-label="Authentication"
+                    draggable="true"
+                  >
+                    <span class="chip-title">Authentication</span>
+                    <span class="chip-detail">PAP / CHAP exchange</span>
+                  </button>
+                  <button
+                    type="button"
+                    class="phase-chip"
+                    data-phase="ipcp"
+                    data-phase-label="Network control"
+                    draggable="true"
+                  >
+                    <span class="chip-title">Network control (IPCP)</span>
+                    <span class="chip-detail">Lease an IP</span>
+                  </button>
+                </div>
+              </section>
+              <section class="phase-slots" aria-labelledby="phase-slots-heading">
+                <h3 id="phase-slots-heading">Handshake order</h3>
+                <div class="slot-grid">
+                  <div class="phase-slot" data-role="phase-slot" data-slot="1" data-phase="">
+                    <div
+                      class="slot-drop"
+                      data-role="slot-drop"
+                      role="button"
+                      tabindex="0"
+                      aria-label="Slot 1 awaiting assignment"
+                    >
+                      <span class="slot-index" aria-hidden="true">1</span>
+                      <div class="slot-content" data-role="slot-content">
+                        <span class="slot-placeholder" data-role="slot-placeholder">Awaiting phase</span>
+                      </div>
+                    </div>
+                    <input type="hidden" name="slot-1" data-role="slot-input" value="" />
+                  </div>
+                  <div class="phase-slot" data-role="phase-slot" data-slot="2" data-phase="">
+                    <div
+                      class="slot-drop"
+                      data-role="slot-drop"
+                      role="button"
+                      tabindex="0"
+                      aria-label="Slot 2 awaiting assignment"
+                    >
+                      <span class="slot-index" aria-hidden="true">2</span>
+                      <div class="slot-content" data-role="slot-content">
+                        <span class="slot-placeholder" data-role="slot-placeholder">Awaiting phase</span>
+                      </div>
+                    </div>
+                    <input type="hidden" name="slot-2" data-role="slot-input" value="" />
+                  </div>
+                  <div class="phase-slot" data-role="phase-slot" data-slot="3" data-phase="">
+                    <div
+                      class="slot-drop"
+                      data-role="slot-drop"
+                      role="button"
+                      tabindex="0"
+                      aria-label="Slot 3 awaiting assignment"
+                    >
+                      <span class="slot-index" aria-hidden="true">3</span>
+                      <div class="slot-content" data-role="slot-content">
+                        <span class="slot-placeholder" data-role="slot-placeholder">Awaiting phase</span>
+                      </div>
+                    </div>
+                    <input type="hidden" name="slot-3" data-role="slot-input" value="" />
+                  </div>
+                  <div class="phase-slot" data-role="phase-slot" data-slot="4" data-phase="">
+                    <div
+                      class="slot-drop"
+                      data-role="slot-drop"
+                      role="button"
+                      tabindex="0"
+                      aria-label="Slot 4 awaiting assignment"
+                    >
+                      <span class="slot-index" aria-hidden="true">4</span>
+                      <div class="slot-content" data-role="slot-content">
+                        <span class="slot-placeholder" data-role="slot-placeholder">Awaiting phase</span>
+                      </div>
+                    </div>
+                    <input type="hidden" name="slot-4" data-role="slot-input" value="" />
+                  </div>
+                </div>
+              </section>
             </div>
           </fieldset>
           <button type="submit" class="execute-button">Dial now</button>

--- a/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.css
+++ b/madia.new/public/secret/net/modem-skunkworks/modem-skunkworks.css
@@ -2,10 +2,168 @@ body {
   background: radial-gradient(circle at center, rgba(56, 248, 122, 0.1), transparent 60%), var(--net-bg);
 }
 
-.phase-grid {
+.assignment-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 0.75rem;
+  gap: 1.25rem;
+}
+
+@media (min-width: 720px) {
+  .assignment-grid {
+    grid-template-columns: minmax(260px, 1fr) minmax(320px, 1fr);
+    align-items: start;
+  }
+}
+
+.phase-pool,
+.phase-slots {
+  background: rgba(0, 12, 18, 0.85);
+  border: 1px solid rgba(110, 255, 210, 0.2);
+  border-radius: 16px;
+  padding: 1rem 1.1rem 1.25rem;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.45);
+}
+
+.phase-pool h3,
+.phase-slots h3 {
+  margin-bottom: 0.8rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(198, 234, 232, 0.78);
+}
+
+.chip-deck {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.phase-chip {
+  position: relative;
+  width: 100%;
+  text-align: left;
+  padding: 0.75rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid rgba(110, 255, 210, 0.28);
+  background: linear-gradient(130deg, rgba(4, 24, 32, 0.95), rgba(0, 12, 20, 0.92));
+  color: rgba(198, 234, 232, 0.85);
+  cursor: grab;
+  display: grid;
+  gap: 0.25rem;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+}
+
+.phase-chip:focus-visible {
+  outline: 2px solid var(--neon-green);
+  outline-offset: 2px;
+}
+
+.phase-chip:active {
+  cursor: grabbing;
+  transform: scale(0.98);
+}
+
+.phase-chip[data-selected="true"] {
+  border-color: rgba(110, 255, 210, 0.6);
+  box-shadow: 0 0 16px rgba(68, 255, 200, 0.32);
+}
+
+.phase-chip[data-location="slot"] {
+  cursor: pointer;
+}
+
+.phase-chip[aria-disabled="true"] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.chip-title {
+  font-size: 0.92rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.chip-detail {
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+  color: rgba(168, 214, 210, 0.7);
+}
+
+.slot-grid {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.phase-slot {
+  position: relative;
+  border-radius: 14px;
+  border: 1px solid rgba(110, 255, 210, 0.2);
+  background: linear-gradient(130deg, rgba(2, 18, 26, 0.9), rgba(0, 12, 20, 0.86));
+  padding: 0.6rem 0.7rem;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.5);
+}
+
+.slot-drop {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.65rem;
+  align-items: center;
+  padding: 0.4rem 0.5rem;
+  border-radius: 10px;
+  border: 1px dashed rgba(110, 255, 210, 0.25);
+  background: rgba(0, 14, 22, 0.8);
+  cursor: pointer;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+
+.slot-drop:focus-visible {
+  outline: 2px solid var(--neon-green);
+  outline-offset: 2px;
+}
+
+.slot-drop[data-state="filled"] {
+  border-style: solid;
+  border-color: rgba(110, 255, 210, 0.5);
+  background: rgba(4, 32, 40, 0.85);
+  box-shadow: 0 0 16px rgba(68, 255, 200, 0.25);
+}
+
+.slot-drop[data-drop="active"] {
+  border-color: rgba(110, 255, 210, 0.65);
+  box-shadow: 0 0 18px rgba(68, 255, 200, 0.35);
+}
+
+.slot-index {
+  width: 2rem;
+  height: 2rem;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(110, 255, 210, 0.35);
+  color: rgba(198, 234, 232, 0.85);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.slot-content {
+  min-height: 2.5rem;
+}
+
+.slot-placeholder {
+  display: inline-block;
+  font-size: 0.82rem;
+  color: rgba(168, 214, 210, 0.65);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.phase-slot .phase-chip {
+  margin: 0;
+}
+
+.phase-slot .phase-chip:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.8);
+  outline-offset: 2px;
 }
 
 .execute-button {


### PR DESCRIPTION
## Summary
- replace the PPP ordering dropdowns with draggable phase modules and slot targets for a more tactile puzzle
- refresh the Modem Skunkworks styling to support the new chip pool and slot grid
- add drag-and-drop and keyboard controls to evaluate the handshake order and update the modem status board

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68e905ee14c08328880edfea33c89cff