### PR TITLE
feat: add visual clues to LAN Beacon Scout

### DIFF
--- a/madia.new/public/secret/net/lan-beacon-scout/index.html
+++ b/madia.new/public/secret/net/lan-beacon-scout/index.html
@@ -85,6 +85,10 @@
       </section>
       <section class="map-panel" aria-labelledby="subnet-map">
         <h2 id="subnet-map">Subnet map</h2>
+        <p class="map-instructions">
+          Patch panels glow with the host-bit pattern and handshake lights for each wing. Decode the broadcast target and
+          protocol before firing the sweep.
+        </p>
         <div class="map-grid">
           <article class="map-card" data-zone="newsroom">
             <h3>Newsroom Spine</h3>

--- a/madia.new/public/secret/net/lan-beacon-scout/lan-beacon-scout.css
+++ b/madia.new/public/secret/net/lan-beacon-scout/lan-beacon-scout.css
@@ -86,6 +86,12 @@ main {
   letter-spacing: 0.08em;
 }
 
+.map-panel .map-instructions {
+  margin: 0 0 1.25rem;
+  font-size: 0.85rem;
+  color: rgba(148, 197, 183, 0.78);
+}
+
 .map-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -134,6 +140,111 @@ main {
   margin: 0;
   font-size: 0.85rem;
   color: var(--net-muted);
+}
+
+.clue-panel {
+  margin-top: 0.85rem;
+  padding-top: 0.75rem;
+  border-top: 1px dashed rgba(56, 248, 122, 0.15);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.bit-grid,
+.method-indicators {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.bit-grid__label,
+.method-indicators__label {
+  font-size: 0.65rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 183, 0.72);
+}
+
+.bit-grid__lights {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: 0.3rem;
+}
+
+.bit-light {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0;
+  border-radius: 5px;
+  border: 1px solid rgba(56, 248, 122, 0.15);
+  font-size: 0.68rem;
+  background: rgba(16, 28, 44, 0.55);
+  color: rgba(148, 197, 183, 0.75);
+  box-shadow: inset 0 0 6px rgba(2, 8, 16, 0.6);
+}
+
+.bit-light--network {
+  background: rgba(12, 24, 44, 0.75);
+  color: rgba(148, 197, 183, 0.55);
+}
+
+.bit-light--host {
+  background: rgba(20, 36, 52, 0.65);
+}
+
+.bit-light--hot {
+  background: linear-gradient(180deg, rgba(56, 248, 122, 0.95), rgba(38, 210, 110, 0.85));
+  color: #04160c;
+  font-weight: 600;
+  box-shadow: 0 0 14px rgba(56, 248, 122, 0.4);
+}
+
+.bit-grid__annotation {
+  font-size: 0.7rem;
+  color: rgba(148, 197, 183, 0.7);
+}
+
+.method-indicators__lights {
+  display: flex;
+  gap: 0.45rem;
+}
+
+.method-light {
+  flex: 1;
+  padding: 0.32rem 0.4rem;
+  border-radius: 6px;
+  border: 1px solid rgba(56, 248, 122, 0.16);
+  text-align: center;
+  font-size: 0.75rem;
+  color: rgba(148, 197, 183, 0.75);
+  background: rgba(16, 28, 44, 0.6);
+  box-shadow: inset 0 0 12px rgba(2, 10, 18, 0.55);
+  position: relative;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.method-light::after {
+  content: "";
+  position: absolute;
+  inset: 0.3rem;
+  border-radius: 4px;
+  background: rgba(56, 248, 122, 0.08);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.method-light--active {
+  color: #03170c;
+  border-color: rgba(56, 248, 122, 0.55);
+  background: linear-gradient(180deg, rgba(56, 248, 122, 0.85), rgba(56, 248, 122, 0.65));
+  font-weight: 600;
+  box-shadow: 0 0 18px rgba(56, 248, 122, 0.45);
+}
+
+.method-light--active::after {
+  opacity: 1;
+  background: rgba(6, 34, 20, 0.35);
 }
 
 .log-panel {


### PR DESCRIPTION
## Summary
- add onboarding copy so players know to read the subnet map for hints
- render host-bit scopes and protocol lights on each map card to turn the dropdown choices into a visual puzzle
- style the new clue panels to match the Net aesthetic

## Testing
- Manual smoke test via python -m http.server 5000

------
https://chatgpt.com/codex/tasks/task_e_68e906d7d5748328a7875aebd1948f56