### PR TITLE
Expand Net Ops widget gallery with interactive retro controls

### DIFF
--- a/madia.new/public/secret/net/testbed.html
+++ b/madia.new/public/secret/net/testbed.html
@@ -1,0 +1,480 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Net Ops Widget Switchboard</title>
+    <link rel="stylesheet" href="./widgets.css" />
+  </head>
+  <body class="widget-lab scanlines">
+    <header class="widget-lab__header">
+      <p class="widget-lab__eyebrow">Net Ops // Hidden Lab</p>
+      <h1 class="widget-lab__title">Widget Switchboard</h1>
+      <p class="widget-lab__tagline">
+        A private gallery of bespoke retro controls built for quick swaps into any Net operation.
+      </p>
+    </header>
+    <p class="widget-lab__intro">
+      Each control below ships as a standalone widget with keyboard support, screen reader roles, and shared styling so the games
+      can trade their default dropdowns, radio clusters, and meters for something <strong>intrusion ready</strong>.
+    </p>
+    <main class="widget-testbed">
+      <section class="widget-section" aria-labelledby="directory-switchboard">
+        <div class="widget-section__meta">
+          <h2 class="widget-section__title" id="directory-switchboard">Directory Switchboard</h2>
+          <span class="widget-section__tag">Dropdown replacement</span>
+        </div>
+        <div class="widget-grid">
+          <div
+            class="neon-select"
+            data-widget="neon-select"
+            data-value="uplink-metro"
+            aria-labelledby="switchboard-label"
+          >
+            <input type="hidden" name="uplink-profile" value="uplink-metro" />
+            <p class="neon-select__label" id="switchboard-label">Routing profile</p>
+            <div class="neon-select__rail">
+              <button class="neon-select__option" data-value="uplink-metro" data-hint="Metro backbone" type="button">
+                <span class="neon-select__option-title">Metro Backbone 9x</span>
+              </button>
+              <button class="neon-select__option" data-value="colocation" data-hint="Colo site" type="button">
+                <span class="neon-select__option-title">Colocation Mirror Stack</span>
+              </button>
+              <button class="neon-select__option" data-value="disaster" data-hint="Failover" type="button">
+                <span class="neon-select__option-title">Disaster Recovery Net</span>
+              </button>
+              <button class="neon-select__option" data-value="dialstorm" data-hint="56k burst" type="button">
+                <span class="neon-select__option-title">Dialstorm Ridge Uplink</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section class="widget-section" aria-labelledby="beacon-array">
+        <div class="widget-section__meta">
+          <h2 class="widget-section__title" id="beacon-array">Beacon Mode Array</h2>
+          <span class="widget-section__tag">Radio set replacement</span>
+        </div>
+        <div class="widget-grid" data-columns="2">
+          <div
+            class="segment-toggle"
+            data-widget="segment-toggle"
+            data-value="standby"
+            aria-labelledby="beacon-array"
+          >
+            <input type="hidden" name="beacon-mode" value="standby" />
+            <div class="segment-toggle__rail">
+              <button class="segment-toggle__option" data-value="standby" type="button">
+                <span class="segment-toggle__label">Mode</span>
+                <span class="segment-toggle__value">Standby Sweep</span>
+              </button>
+              <button class="segment-toggle__option" data-value="burst" type="button">
+                <span class="segment-toggle__label">Mode</span>
+                <span class="segment-toggle__value">Beacon Burst</span>
+              </button>
+              <button class="segment-toggle__option" data-value="lock" type="button">
+                <span class="segment-toggle__label">Mode</span>
+                <span class="segment-toggle__value">Lockdown Pulse</span>
+              </button>
+            </div>
+          </div>
+          <button class="net-command" type="button">Initiate Beacon Pattern</button>
+        </div>
+      </section>
+      <section class="widget-section" aria-labelledby="telemetry-overwatch">
+        <div class="widget-section__meta">
+          <h2 class="widget-section__title" id="telemetry-overwatch">Telemetry Overwatch</h2>
+          <span class="widget-section__tag">Progress display alternatives</span>
+        </div>
+        <div class="widget-grid" data-columns="2">
+          <div class="status-rail" data-widget="status-rail">
+            <div class="status-rail__row">
+              <span class="status-rail__label">Cache Saturation</span>
+              <div class="status-rail__bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" data-progress="62">
+                <div class="status-rail__bar-fill"></div>
+              </div>
+              <span class="status-rail__value">62%</span>
+            </div>
+            <div class="status-rail__row">
+              <span class="status-rail__label">Traceroute Confidence</span>
+              <div
+                class="status-rail__bar"
+                role="progressbar"
+                aria-valuemin="0"
+                aria-valuemax="100"
+                data-progress="45"
+                data-state="warning"
+              >
+                <div class="status-rail__bar-fill"></div>
+              </div>
+              <span class="status-rail__value">45%</span>
+            </div>
+            <div class="status-rail__row">
+              <span class="status-rail__label">Uplink Stability</span>
+              <div
+                class="status-rail__bar"
+                role="progressbar"
+                aria-valuemin="0"
+                aria-valuemax="100"
+                data-progress="30"
+                data-state="danger"
+              >
+                <div class="status-rail__bar-fill"></div>
+              </div>
+              <span class="status-rail__value">30%</span>
+            </div>
+          </div>
+          <div class="packet-scrubber" data-widget="packet-scrubber" data-value="68">
+            <div class="packet-scrubber__face">
+              <div class="packet-scrubber__dial" data-value="68">
+                <div class="packet-scrubber__pointer"></div>
+                <div class="packet-scrubber__spectrum"></div>
+              </div>
+            </div>
+            <div class="packet-scrubber__legend">
+              <span>Idle</span>
+              <strong>Throughput</strong>
+              <span>Max</span>
+            </div>
+            <input
+              type="range"
+              min="0"
+              max="100"
+              value="68"
+              step="1"
+              aria-label="Throughput target"
+              data-role="scrubber-input"
+            />
+          </div>
+        </div>
+      </section>
+      <section class="widget-section" aria-labelledby="orbital-vector">
+        <div class="widget-section__meta">
+          <h2 class="widget-section__title" id="orbital-vector">Orbital Vector Dial</h2>
+          <span class="widget-section__tag">Analog dial control</span>
+        </div>
+        <div class="widget-grid">
+          <div class="orbital-dial" data-widget="orbital-dial" data-value="210">
+            <input type="hidden" name="orbital-vector" value="210" />
+            <div class="orbital-dial__ring">
+              <span class="orbital-dial__needle"></span>
+              <div class="orbital-dial__control">
+                <button
+                  class="orbital-dial__knob"
+                  type="button"
+                  aria-label="Set orbital vector"
+                  aria-valuemin="0"
+                  aria-valuemax="359"
+                ></button>
+              </div>
+            </div>
+            <p class="orbital-dial__readout">Vector <strong>210°</strong></p>
+            <p class="widget-note">Drag to spin or use arrow keys for fine adjustment.</p>
+          </div>
+        </div>
+      </section>
+      <section class="widget-section" aria-labelledby="plasma-columns">
+        <div class="widget-section__meta">
+          <h2 class="widget-section__title" id="plasma-columns">Plasma Column Fader</h2>
+          <span class="widget-section__tag">Vertical slider array</span>
+        </div>
+        <div class="plasma-fader" data-widget="plasma-fader">
+          <div class="plasma-fader__column" data-channel="alpha" data-value="64">
+            <input type="hidden" name="plasma-alpha" value="64" />
+            <div class="plasma-fader__track">
+              <div class="plasma-fader__slot"></div>
+              <button
+                class="plasma-fader__thumb"
+                type="button"
+                aria-label="Alpha output"
+                aria-valuemin="0"
+                aria-valuemax="100"
+              ></button>
+            </div>
+            <p class="plasma-fader__value">ALPHA Output: 64%</p>
+          </div>
+          <div class="plasma-fader__column" data-channel="beta" data-value="28">
+            <input type="hidden" name="plasma-beta" value="28" />
+            <div class="plasma-fader__track">
+              <div class="plasma-fader__slot"></div>
+              <button
+                class="plasma-fader__thumb"
+                type="button"
+                aria-label="Beta output"
+                aria-valuemin="0"
+                aria-valuemax="100"
+              ></button>
+            </div>
+            <p class="plasma-fader__value">BETA Output: 28%</p>
+          </div>
+        </div>
+      </section>
+      <section class="widget-section" aria-labelledby="matrix-grid">
+        <div class="widget-section__meta">
+          <h2 class="widget-section__title" id="matrix-grid">Quantum Node Matrix</h2>
+          <span class="widget-section__tag">Multi-select grid</span>
+        </div>
+        <div class="node-matrix" data-widget="node-matrix" data-value="A1,B2">
+          <input type="hidden" name="matrix-selection" value="A1,B2" />
+          <div class="node-matrix__grid">
+            <button class="node-matrix__node" data-node="A1" data-row="0" data-col="0" data-coord="A1" aria-pressed="true">
+              Pulse Gate
+            </button>
+            <button class="node-matrix__node" data-node="A2" data-row="0" data-col="1" data-coord="A2" aria-pressed="false">
+              Cache Span
+            </button>
+            <button class="node-matrix__node" data-node="A3" data-row="0" data-col="2" data-coord="A3" aria-pressed="false">
+              Relay Bloom
+            </button>
+            <button class="node-matrix__node" data-node="B1" data-row="1" data-col="0" data-coord="B1" aria-pressed="false">
+              Deep Echo
+            </button>
+            <button class="node-matrix__node" data-node="B2" data-row="1" data-col="1" data-coord="B2" aria-pressed="true">
+              Link Spine
+            </button>
+            <button class="node-matrix__node" data-node="B3" data-row="1" data-col="2" data-coord="B3" aria-pressed="false">
+              Flux Loom
+            </button>
+            <button class="node-matrix__node" data-node="C1" data-row="2" data-col="0" data-coord="C1" aria-pressed="false">
+              Null Trace
+            </button>
+            <button class="node-matrix__node" data-node="C2" data-row="2" data-col="1" data-coord="C2" aria-pressed="false">
+              Thermal Web
+            </button>
+            <button class="node-matrix__node" data-node="C3" data-row="2" data-col="2" data-coord="C3" aria-pressed="false">
+              Horizon Ping
+            </button>
+          </div>
+          <p class="node-matrix__summary">Active nodes: A1 · B2</p>
+        </div>
+      </section>
+      <section class="widget-section" aria-labelledby="cipher-wheel">
+        <div class="widget-section__meta">
+          <h2 class="widget-section__title" id="cipher-wheel">Cipher Wheel Array</h2>
+          <span class="widget-section__tag">Three-ring encoder</span>
+        </div>
+        <div class="cipher-wheel" data-widget="cipher-wheel" data-alphabet="ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789">
+          <input type="hidden" name="cipher-key" value="NET" />
+          <div class="cipher-wheel__rings">
+            <div class="cipher-wheel__ring" data-ring-index="0" data-label="Ring 1" data-value="N">
+              <span class="cipher-wheel__label">Ring 1</span>
+              <span class="cipher-wheel__window">N</span>
+              <div class="cipher-wheel__controls">
+                <button type="button" data-action="decrement" aria-label="Rotate ring 1 backward">−</button>
+                <button type="button" data-action="increment" aria-label="Rotate ring 1 forward">＋</button>
+              </div>
+            </div>
+            <div class="cipher-wheel__ring" data-ring-index="1" data-label="Ring 2" data-value="E">
+              <span class="cipher-wheel__label">Ring 2</span>
+              <span class="cipher-wheel__window">E</span>
+              <div class="cipher-wheel__controls">
+                <button type="button" data-action="decrement" aria-label="Rotate ring 2 backward">−</button>
+                <button type="button" data-action="increment" aria-label="Rotate ring 2 forward">＋</button>
+              </div>
+            </div>
+            <div class="cipher-wheel__ring" data-ring-index="2" data-label="Ring 3" data-value="T">
+              <span class="cipher-wheel__label">Ring 3</span>
+              <span class="cipher-wheel__window">T</span>
+              <div class="cipher-wheel__controls">
+                <button type="button" data-action="decrement" aria-label="Rotate ring 3 backward">−</button>
+                <button type="button" data-action="increment" aria-label="Rotate ring 3 forward">＋</button>
+              </div>
+            </div>
+          </div>
+          <p class="cipher-wheel__readout">Cipher: NET</p>
+        </div>
+      </section>
+      <section class="widget-section" aria-labelledby="flux-keypad">
+        <div class="widget-section__meta">
+          <h2 class="widget-section__title" id="flux-keypad">Flux Authentication Pad</h2>
+          <span class="widget-section__tag">Retro keypad</span>
+        </div>
+        <div class="flux-keypad" data-widget="flux-keypad" data-max-length="6">
+          <input type="hidden" name="flux-code" value="" />
+          <div class="flux-keypad__display">
+            <span data-role="display">······</span>
+            <span data-role="status">Standby</span>
+          </div>
+          <div class="flux-keypad__grid">
+            <button class="flux-keypad__key" type="button" data-key="7">7</button>
+            <button class="flux-keypad__key" type="button" data-key="8">8</button>
+            <button class="flux-keypad__key" type="button" data-key="9">9</button>
+            <button class="flux-keypad__key" type="button" data-key="4">4</button>
+            <button class="flux-keypad__key" type="button" data-key="5">5</button>
+            <button class="flux-keypad__key" type="button" data-key="6">6</button>
+            <button class="flux-keypad__key" type="button" data-key="1">1</button>
+            <button class="flux-keypad__key" type="button" data-key="2">2</button>
+            <button class="flux-keypad__key" type="button" data-key="3">3</button>
+            <button class="flux-keypad__key" type="button" data-key="0">0</button>
+            <button class="flux-keypad__key" type="button" data-key="*">*</button>
+            <button class="flux-keypad__key" type="button" data-key="#">#</button>
+          </div>
+          <div class="flux-keypad__actions">
+            <button type="button" data-action="clear">Clear</button>
+            <button type="button" data-action="backspace">Back</button>
+            <button type="button" data-action="submit">Commit</button>
+          </div>
+        </div>
+      </section>
+      <section class="widget-section" aria-labelledby="synth-sequencer">
+        <div class="widget-section__meta">
+          <h2 class="widget-section__title" id="synth-sequencer">Synthwave Sequencer</h2>
+          <span class="widget-section__tag">Animated toggle bank</span>
+        </div>
+        <div class="sequencer-grid" data-widget="sequencer-grid">
+          <input type="hidden" name="sequencer-pattern" value="" />
+          <div class="sequencer-grid__steps">
+            <button class="sequencer-grid__step" type="button" data-step="1" aria-pressed="true">1</button>
+            <button class="sequencer-grid__step" type="button" data-step="2" aria-pressed="false">2</button>
+            <button class="sequencer-grid__step" type="button" data-step="3" aria-pressed="true">3</button>
+            <button class="sequencer-grid__step" type="button" data-step="4" aria-pressed="false">4</button>
+            <button class="sequencer-grid__step" type="button" data-step="5" aria-pressed="false">5</button>
+            <button class="sequencer-grid__step" type="button" data-step="6" aria-pressed="true">6</button>
+            <button class="sequencer-grid__step" type="button" data-step="7" aria-pressed="false">7</button>
+            <button class="sequencer-grid__step" type="button" data-step="8" aria-pressed="true">8</button>
+          </div>
+          <div class="sequencer-grid__controls">
+            <button type="button" data-action="play">Play</button>
+            <button type="button" data-action="stop">Stop</button>
+            <button type="button" data-action="clear">Clear</button>
+          </div>
+          <p class="widget-note" data-role="sequence-output">Pattern: ■ · ■ · · ■ · ■</p>
+        </div>
+      </section>
+      <section class="widget-section" aria-labelledby="radar-monitor">
+        <div class="widget-section__meta">
+          <h2 class="widget-section__title" id="radar-monitor">Radar Sweep Monitor</h2>
+          <span class="widget-section__tag">Live detection scope</span>
+        </div>
+        <div class="radar-monitor" data-widget="radar-monitor">
+          <div class="radar-monitor__scope">
+            <div class="radar-monitor__grid"></div>
+            <div class="radar-monitor__sweep"></div>
+            <span class="radar-monitor__target" data-id="North Gate" data-threshold="45" style="top: 22%; left: 52%"></span>
+            <span class="radar-monitor__target" data-id="Signal Ledge" data-threshold="180" style="top: 64%; left: 72%"></span>
+            <span class="radar-monitor__target" data-id="Uplink Node" data-threshold="300" style="top: 48%; left: 28%"></span>
+          </div>
+          <div class="radar-monitor__log" aria-live="polite">Sweep initialized…</div>
+        </div>
+      </section>
+      <section class="widget-section" aria-labelledby="tunnel-meter">
+        <div class="widget-section__meta">
+          <h2 class="widget-section__title" id="tunnel-meter">Spectral Data Tunnel</h2>
+          <span class="widget-section__tag">Animated bar stack</span>
+        </div>
+        <div class="tunnel-meter" data-widget="tunnel-meter">
+          <div class="tunnel-meter__row" data-channel="uplink" data-value="42">
+            <span class="tunnel-meter__label">Uplink</span>
+            <div class="tunnel-meter__bar"><span class="tunnel-meter__bar-fill"></span></div>
+            <span class="tunnel-meter__value">42%</span>
+          </div>
+          <div class="tunnel-meter__row" data-channel="backbone" data-value="65">
+            <span class="tunnel-meter__label">Backbone</span>
+            <div class="tunnel-meter__bar"><span class="tunnel-meter__bar-fill"></span></div>
+            <span class="tunnel-meter__value">65%</span>
+          </div>
+          <div class="tunnel-meter__row" data-channel="egress" data-value="28">
+            <span class="tunnel-meter__label">Egress</span>
+            <div class="tunnel-meter__bar"><span class="tunnel-meter__bar-fill"></span></div>
+            <span class="tunnel-meter__value">28%</span>
+          </div>
+        </div>
+      </section>
+      <section class="widget-section" aria-labelledby="launch-lever">
+        <div class="widget-section__meta">
+          <h2 class="widget-section__title" id="launch-lever">Launch Authorizer</h2>
+          <span class="widget-section__tag">Detented lever</span>
+        </div>
+        <div class="launch-lever" data-widget="launch-lever" data-value="0">
+          <div class="launch-lever__track">
+            <div class="launch-lever__rail"></div>
+            <button
+              class="launch-lever__thumb"
+              type="button"
+              aria-label="Engage launch vector"
+              aria-valuemin="0"
+              aria-valuemax="100"
+            >
+              ARM
+            </button>
+          </div>
+          <p class="launch-lever__status">Awaiting authorization</p>
+        </div>
+      </section>
+      <section class="widget-section" aria-labelledby="constellation-router">
+        <div class="widget-section__meta">
+          <h2 class="widget-section__title" id="constellation-router">Constellation Router</h2>
+          <span class="widget-section__tag">Radial selector</span>
+        </div>
+        <div class="constellation-router" data-widget="constellation-router">
+          <input type="hidden" name="constellation-route" value="zenith" />
+          <div class="constellation-router__field">
+            <button
+              class="constellation-router__node"
+              type="button"
+              style="top: 14%; left: 50%"
+              data-node="zenith"
+              data-active="true"
+            >
+              Z
+            </button>
+            <button class="constellation-router__node" type="button" style="top: 32%; left: 82%" data-node="aperture">A</button>
+            <button class="constellation-router__node" type="button" style="top: 74%; left: 78%" data-node="vault">V</button>
+            <button class="constellation-router__node" type="button" style="top: 82%; left: 48%" data-node="delta">D</button>
+            <button class="constellation-router__node" type="button" style="top: 66%; left: 18%" data-node="spire">S</button>
+            <button class="constellation-router__node" type="button" style="top: 28%; left: 20%" data-node="meridian">M</button>
+          </div>
+          <p class="constellation-router__readout">Route locked to zenith</p>
+        </div>
+      </section>
+      <section class="widget-section" aria-labelledby="holo-console">
+        <div class="widget-section__meta">
+          <h2 class="widget-section__title" id="holo-console">Holo Console</h2>
+          <span class="widget-section__tag">Neon textarea</span>
+        </div>
+        <div class="holo-console" data-widget="holo-console">
+          <input type="hidden" name="console-buffer" value="" />
+          <div class="holo-console__input">
+            <textarea maxlength="240" placeholder="Drop operator notes or mission codes"></textarea>
+            <div class="holo-console__overlay"></div>
+          </div>
+          <div class="holo-console__preview" aria-live="polite">// awaiting uplink text</div>
+          <div class="holo-console__meta">
+            <span data-role="char-count">0 / 240</span>
+            <span data-role="console-status">Echo idle</span>
+          </div>
+        </div>
+      </section>
+      <section class="widget-section" aria-labelledby="cryo-switch">
+        <div class="widget-section__meta">
+          <h2 class="widget-section__title" id="cryo-switch">Cryo Capsule Switch</h2>
+          <span class="widget-section__tag">Three-stage slider</span>
+        </div>
+        <div class="cryo-switch" data-widget="cryo-switch" data-value="1">
+          <input type="hidden" name="cryo-phase" value="1" />
+          <div class="cryo-switch__shell">
+            <div class="cryo-switch__rail">
+              <button
+                class="cryo-switch__handle"
+                type="button"
+                aria-label="Cycle cryo phase"
+                aria-valuemin="0"
+                aria-valuemax="2"
+              >
+                Idle
+              </button>
+            </div>
+            <div class="cryo-switch__phases">
+              <span>Hibernate</span>
+              <span>Idle</span>
+              <span>Revive</span>
+            </div>
+          </div>
+          <p class="cryo-switch__status">Capsule idle</p>
+        </div>
+      </section>
+    </main>
+    <script src="./widgets.js" type="module"></script>
+  </body>
+</html>

--- a/madia.new/public/secret/net/widgets.css
+++ b/madia.new/public/secret/net/widgets.css
@@ -1,0 +1,1317 @@
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600;700&display=swap");
+
+:root {
+  font-family: "IBM Plex Mono", "Fira Code", "Menlo", monospace;
+  color-scheme: dark;
+}
+
+body.widget-lab {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(circle at top, rgba(36, 86, 129, 0.35) 0%, rgba(2, 7, 16, 0.92) 52%),
+    linear-gradient(180deg, rgba(8, 18, 28, 0.85), rgba(2, 6, 14, 0.98));
+  color: #e5ffee;
+}
+
+.scanlines::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(rgba(0, 0, 0, 0) 96%, rgba(0, 0, 0, 0.18) 100%);
+  background-size: 100% 3px;
+  pointer-events: none;
+  opacity: 0.65;
+  mix-blend-mode: screen;
+}
+
+.widget-lab__header {
+  position: relative;
+  padding: clamp(1.5rem, 4vw, 3rem) clamp(1.5rem, 5vw, 4rem) clamp(1rem, 3vw, 2rem);
+  overflow: hidden;
+}
+
+.widget-lab__header::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(rgba(56, 248, 122, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(56, 248, 122, 0.08) 1px, transparent 1px);
+  background-size: 38px 38px;
+  opacity: 0.6;
+  transform: skewY(-6deg) translateY(-15%);
+  pointer-events: none;
+}
+
+.widget-lab__header > * {
+  position: relative;
+}
+
+.widget-lab__eyebrow {
+  margin: 0;
+  font-size: clamp(0.75rem, 2vw, 0.9rem);
+  letter-spacing: 0.36em;
+  text-transform: uppercase;
+  color: #f4b400;
+}
+
+.widget-lab__title {
+  margin: clamp(0.4rem, 1vw, 0.75rem) 0 0.35rem;
+  font-size: clamp(2.1rem, 5vw, 3.6rem);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.widget-lab__tagline,
+.widget-lab__intro {
+  margin: 0;
+  max-width: 52ch;
+  font-size: clamp(0.9rem, 2.2vw, 1.05rem);
+  color: rgba(148, 197, 183, 0.82);
+}
+
+.widget-lab__intro {
+  padding: 0 clamp(1.5rem, 5vw, 4rem) clamp(1.5rem, 4vw, 3rem);
+}
+
+.widget-lab__intro strong {
+  color: #38f87a;
+}
+
+.widget-testbed {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  padding: 0 clamp(1.5rem, 5vw, 4rem) clamp(3rem, 6vw, 4.5rem);
+}
+
+.widget-section {
+  background: linear-gradient(180deg, rgba(6, 16, 32, 0.95), rgba(4, 10, 20, 0.92));
+  border: 1px solid rgba(56, 248, 122, 0.24);
+  border-radius: 20px;
+  box-shadow: 0 24px 42px rgba(4, 12, 24, 0.6);
+  padding: clamp(1.25rem, 3vw, 2.25rem);
+  position: relative;
+  overflow: hidden;
+}
+
+.widget-section::before {
+  content: "";
+  position: absolute;
+  inset: -40% -10% auto;
+  height: 65%;
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0.12), transparent 60%);
+  transform: skewY(-8deg);
+  pointer-events: none;
+}
+
+.widget-section__meta {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 1.8rem;
+  flex-wrap: wrap;
+}
+
+.widget-section__title {
+  margin: 0;
+  font-size: clamp(1.3rem, 3vw, 1.9rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.widget-section__tag {
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 183, 0.78);
+}
+
+.widget-grid {
+  position: relative;
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.75rem);
+}
+
+@media (min-width: 960px) {
+  .widget-grid[data-columns="2"] {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .widget-grid[data-columns="3"] {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+/* -------------------------------------------------- */
+/* Directory Switchboard (Neon Select)                 */
+/* -------------------------------------------------- */
+
+.neon-select {
+  position: relative;
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(56, 248, 122, 0.4);
+  border-radius: 12px;
+  background: linear-gradient(180deg, rgba(8, 20, 32, 0.85), rgba(5, 10, 20, 0.75));
+}
+
+.neon-select:focus-within {
+  border-color: rgba(56, 248, 122, 0.8);
+  box-shadow: 0 0 0 2px rgba(56, 248, 122, 0.25);
+}
+
+.neon-select__label {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 183, 0.78);
+}
+
+.neon-select__rail {
+  position: relative;
+  display: grid;
+  gap: 0.4rem;
+  grid-auto-columns: 1fr;
+}
+
+.neon-select__option {
+  position: relative;
+  display: grid;
+  align-items: center;
+  justify-items: start;
+  gap: 0.35rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(56, 248, 122, 0.35);
+  background: rgba(4, 12, 24, 0.65);
+  color: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+}
+
+.neon-select__option::after {
+  content: attr(data-hint);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(117, 186, 161, 0.7);
+}
+
+.neon-select__option[aria-selected="true"] {
+  border-color: rgba(56, 248, 122, 0.95);
+  box-shadow: 0 0 0 2px rgba(56, 248, 122, 0.35), 0 18px 28px rgba(40, 162, 96, 0.32);
+  background: linear-gradient(135deg, rgba(56, 248, 122, 0.2), rgba(56, 248, 122, 0.35));
+  transform: translateY(-1px);
+}
+
+.neon-select__option:focus-visible {
+  outline: none;
+  border-color: rgba(244, 180, 0, 0.8);
+  box-shadow: 0 0 0 2px rgba(244, 180, 0, 0.35);
+}
+
+.neon-select__option-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+/* -------------------------------------------------- */
+/* Beacon Mode Array (Segment Toggle)                  */
+/* -------------------------------------------------- */
+
+.segment-toggle {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.segment-toggle__rail {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.6rem;
+}
+
+.segment-toggle__option {
+  position: relative;
+  padding: 0.8rem 0.9rem;
+  border-radius: 12px;
+  border: 1px solid rgba(56, 248, 122, 0.4);
+  background: linear-gradient(180deg, rgba(8, 24, 42, 0.85), rgba(7, 16, 32, 0.75));
+  color: inherit;
+  text-align: left;
+  display: grid;
+  gap: 0.35rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+}
+
+.segment-toggle__option::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease;
+}
+
+.segment-toggle__option[aria-checked="true"] {
+  border-color: rgba(244, 180, 0, 0.85);
+  box-shadow: 0 0 0 1px rgba(244, 180, 0, 0.5), 0 18px 28px rgba(244, 180, 0, 0.25);
+  transform: translateY(-1px);
+}
+
+.segment-toggle__option[aria-checked="true"]::before {
+  border-color: rgba(56, 248, 122, 0.4);
+}
+
+.segment-toggle__label {
+  font-size: 0.8rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 183, 0.8);
+}
+
+.segment-toggle__value {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+.segment-toggle__option:focus-visible {
+  outline: none;
+  border-color: rgba(56, 248, 122, 0.9);
+  box-shadow: 0 0 0 2px rgba(56, 248, 122, 0.3);
+}
+
+.net-command {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  padding: 0.85rem 1.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(56, 248, 122, 0.65);
+  background: radial-gradient(circle at 30% 30%, rgba(56, 248, 122, 0.4), rgba(8, 24, 32, 0.95));
+  color: inherit;
+  font-size: 1rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.net-command::before {
+  content: "◉";
+  font-size: 1.2rem;
+  color: rgba(244, 180, 0, 0.9);
+  text-shadow: 0 0 12px rgba(244, 180, 0, 0.9);
+}
+
+.net-command:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 28px rgba(56, 248, 122, 0.35);
+}
+
+.net-command:active {
+  transform: translateY(0);
+  box-shadow: 0 12px 18px rgba(21, 96, 58, 0.3);
+}
+
+.net-command:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(244, 180, 0, 0.4);
+}
+
+/* -------------------------------------------------- */
+/* Telemetry Overwatch (Status Rail + Scrubber)        */
+/* -------------------------------------------------- */
+
+.status-rail {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.status-rail__row {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.status-rail__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 183, 0.85);
+}
+
+.status-rail__bar {
+  position: relative;
+  height: 18px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(8, 16, 26, 0.75), rgba(6, 10, 20, 0.9));
+  overflow: hidden;
+  border: 1px solid rgba(56, 248, 122, 0.25);
+}
+
+.status-rail__bar-fill {
+  position: absolute;
+  inset: 0;
+  transform-origin: left center;
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0.15), rgba(56, 248, 122, 0.55));
+  box-shadow: 0 0 14px rgba(56, 248, 122, 0.45);
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.status-rail__bar[data-state="warning"] .status-rail__bar-fill {
+  background: linear-gradient(90deg, rgba(244, 180, 0, 0.2), rgba(244, 180, 0, 0.6));
+  box-shadow: 0 0 14px rgba(244, 180, 0, 0.45);
+}
+
+.status-rail__bar[data-state="danger"] .status-rail__bar-fill {
+  background: linear-gradient(90deg, rgba(255, 95, 109, 0.25), rgba(255, 95, 109, 0.7));
+  box-shadow: 0 0 14px rgba(255, 95, 109, 0.5);
+}
+
+.status-rail__value {
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 183, 0.75);
+  justify-self: end;
+}
+
+.packet-scrubber {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.packet-scrubber__face {
+  position: relative;
+  height: 180px;
+  border-radius: 18px;
+  border: 1px solid rgba(56, 248, 122, 0.35);
+  background: radial-gradient(circle at center, rgba(56, 248, 122, 0.25), rgba(6, 12, 24, 0.95));
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.packet-scrubber__dial {
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  border: 2px solid rgba(244, 180, 0, 0.55);
+  position: relative;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at 30% 30%, rgba(244, 180, 0, 0.25), rgba(8, 16, 26, 0.95));
+  box-shadow: inset 0 0 24px rgba(244, 180, 0, 0.35), 0 0 28px rgba(244, 180, 0, 0.25);
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.packet-scrubber__pointer {
+  position: absolute;
+  width: 4px;
+  height: 55px;
+  background: linear-gradient(180deg, rgba(244, 180, 0, 0.95), rgba(244, 180, 0, 0.2));
+  top: 15px;
+  border-radius: 999px;
+  transform-origin: center 45px;
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.packet-scrubber__spectrum {
+  position: absolute;
+  inset: 12px;
+  border-radius: 50%;
+  border: 1px dashed rgba(56, 248, 122, 0.25);
+  pointer-events: none;
+}
+
+.packet-scrubber__legend {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 183, 0.8);
+}
+
+.packet-scrubber__legend strong {
+  color: var(--net-accent, #38f87a);
+}
+
+.packet-scrubber input[type="range"] {
+  width: 100%;
+  -webkit-appearance: none;
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0.12), rgba(56, 248, 122, 0.2));
+  height: 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(56, 248, 122, 0.35);
+  box-shadow: inset 0 0 14px rgba(56, 248, 122, 0.25);
+}
+
+.packet-scrubber input[type="range"]::-moz-range-track {
+  background: linear-gradient(90deg, rgba(56, 248, 122, 0.12), rgba(56, 248, 122, 0.2));
+  height: 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(56, 248, 122, 0.35);
+  box-shadow: inset 0 0 14px rgba(56, 248, 122, 0.25);
+}
+
+.packet-scrubber input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 40%, rgba(244, 180, 0, 0.9), rgba(244, 180, 0, 0.3));
+  border: 1px solid rgba(244, 180, 0, 0.6);
+  box-shadow: 0 0 12px rgba(244, 180, 0, 0.45);
+}
+
+.packet-scrubber input[type="range"]::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 40%, rgba(244, 180, 0, 0.9), rgba(244, 180, 0, 0.3));
+  border: 1px solid rgba(244, 180, 0, 0.6);
+  box-shadow: 0 0 12px rgba(244, 180, 0, 0.45);
+}
+
+.packet-scrubber input[type="range"]:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(56, 248, 122, 0.3);
+}
+
+.packet-scrubber__dial::after {
+  content: attr(data-value) "%";
+  font-size: 1.6rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+}
+
+@media (min-width: 960px) {
+  .status-rail__row {
+    grid-template-columns: 160px 1fr 80px;
+  }
+}
+
+/* -------------------------------------------------- */
+/* Orbital Vector Dial                                */
+/* -------------------------------------------------- */
+
+.orbital-dial {
+  position: relative;
+  display: grid;
+  gap: 1rem;
+  justify-items: center;
+  padding: 1.5rem;
+  border-radius: 24px;
+  border: 1px solid rgba(116, 200, 255, 0.35);
+  background: radial-gradient(circle at 25% 25%, rgba(116, 200, 255, 0.2), rgba(8, 16, 28, 0.9));
+}
+
+.orbital-dial__ring {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  border-radius: 50%;
+  border: 2px solid rgba(116, 200, 255, 0.35);
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  box-shadow: inset 0 0 32px rgba(116, 200, 255, 0.25);
+}
+
+.orbital-dial__ring::before,
+.orbital-dial__ring::after {
+  content: "";
+  position: absolute;
+  inset: 18px;
+  border-radius: 50%;
+  border: 1px dashed rgba(56, 248, 122, 0.3);
+}
+
+.orbital-dial__ring::after {
+  inset: 58px;
+  border-style: solid;
+  border-color: rgba(244, 180, 0, 0.45);
+  opacity: 0.4;
+}
+
+.orbital-dial__control {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-items: center;
+}
+
+.orbital-dial__knob {
+  width: 68px;
+  height: 68px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, rgba(244, 180, 0, 0.8), rgba(8, 16, 26, 0.95));
+  border: 2px solid rgba(244, 180, 0, 0.6);
+  box-shadow: 0 0 28px rgba(244, 180, 0, 0.45);
+  cursor: grab;
+  display: grid;
+  place-items: center;
+  position: relative;
+  transform: rotate(var(--dial-angle, 0deg));
+  transition: transform 0.08s linear;
+}
+
+.orbital-dial__knob:active {
+  cursor: grabbing;
+}
+
+.orbital-dial__needle {
+  position: absolute;
+  width: 6px;
+  height: 92px;
+  top: 14px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(116, 200, 255, 0.95), rgba(116, 200, 255, 0.1));
+  transform-origin: center 86px;
+  transform: rotate(var(--dial-angle, 0deg));
+  transition: transform 0.08s linear;
+}
+
+.orbital-dial__readout {
+  font-size: 1.1rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.orbital-dial__readout strong {
+  color: rgba(116, 200, 255, 0.95);
+}
+
+/* -------------------------------------------------- */
+/* Plasma Column Fader                                 */
+/* -------------------------------------------------- */
+
+.plasma-fader {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.plasma-fader__column {
+  grid-column: span 2;
+  display: grid;
+  gap: 0.65rem;
+}
+
+@media (min-width: 640px) {
+  .plasma-fader__column {
+    grid-column: span 1;
+  }
+}
+
+.plasma-fader__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 183, 0.78);
+}
+
+.plasma-fader__track {
+  position: relative;
+  height: 240px;
+  border-radius: 18px;
+  border: 1px solid rgba(56, 248, 122, 0.35);
+  background: linear-gradient(180deg, rgba(5, 10, 20, 0.9), rgba(12, 34, 52, 0.95));
+  padding: 1.25rem 1.75rem;
+  display: grid;
+  justify-items: center;
+}
+
+.plasma-fader__slot {
+  position: relative;
+  width: 12px;
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(38, 232, 122, 0.15), rgba(38, 232, 122, 0.45));
+  box-shadow: inset 0 0 18px rgba(38, 232, 122, 0.35);
+}
+
+.plasma-fader__thumb {
+  position: absolute;
+  left: 50%;
+  top: var(--thumb-top, 50%);
+  transform: translate(-50%, -50%);
+  width: 44px;
+  height: 44px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(244, 180, 0, 0.9), rgba(244, 180, 0, 0.35));
+  border: 1px solid rgba(244, 180, 0, 0.6);
+  box-shadow: 0 0 20px rgba(244, 180, 0, 0.45);
+  cursor: grab;
+  display: grid;
+  place-items: center;
+  color: #041016;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.plasma-fader__thumb:active {
+  cursor: grabbing;
+}
+
+.plasma-fader__value {
+  font-size: 1.1rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(56, 248, 122, 0.85);
+}
+
+/* -------------------------------------------------- */
+/* Quantum Node Matrix                                 */
+/* -------------------------------------------------- */
+
+.node-matrix {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.node-matrix__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.node-matrix__node {
+  position: relative;
+  padding: 1rem;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(20, 40, 68, 0.9), rgba(6, 12, 24, 0.95));
+  border: 1px solid rgba(116, 200, 255, 0.25);
+  color: inherit;
+  text-align: left;
+  display: grid;
+  gap: 0.35rem;
+  cursor: pointer;
+  box-shadow: inset 0 0 24px rgba(12, 36, 58, 0.45);
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.node-matrix__node::before {
+  content: attr(data-coord);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 183, 0.7);
+}
+
+.node-matrix__node[aria-pressed="true"] {
+  border-color: rgba(56, 248, 122, 0.85);
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 20px 32px rgba(38, 232, 122, 0.28), inset 0 0 34px rgba(56, 248, 122, 0.32);
+}
+
+.node-matrix__node:focus-visible {
+  outline: none;
+  border-color: rgba(244, 180, 0, 0.8);
+  box-shadow: 0 0 0 2px rgba(244, 180, 0, 0.45);
+}
+
+.node-matrix__summary {
+  font-size: 0.9rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(116, 200, 255, 0.85);
+}
+
+/* -------------------------------------------------- */
+/* Cipher Wheel                                        */
+/* -------------------------------------------------- */
+
+.cipher-wheel {
+  display: grid;
+  gap: 1.2rem;
+  justify-items: center;
+}
+
+.cipher-wheel__rings {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.cipher-wheel__ring {
+  position: relative;
+  padding: 1.25rem 1rem 1.75rem;
+  border-radius: 18px;
+  border: 1px solid rgba(244, 180, 0, 0.3);
+  background: linear-gradient(180deg, rgba(52, 24, 56, 0.65), rgba(12, 10, 26, 0.92));
+  display: grid;
+  gap: 0.6rem;
+  justify-items: center;
+}
+
+.cipher-wheel__label {
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(244, 180, 0, 0.8);
+}
+
+.cipher-wheel__window {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  border: 2px solid rgba(244, 180, 0, 0.4);
+  box-shadow: inset 0 0 24px rgba(244, 180, 0, 0.25);
+  background: radial-gradient(circle at 40% 40%, rgba(244, 180, 0, 0.6), rgba(32, 16, 34, 0.95));
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+}
+
+.cipher-wheel__controls {
+  display: inline-flex;
+  gap: 0.5rem;
+}
+
+.cipher-wheel__controls button {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  border: 1px solid rgba(244, 180, 0, 0.6);
+  background: rgba(40, 18, 42, 0.75);
+  color: rgba(244, 180, 0, 0.95);
+  font-size: 1.35rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.cipher-wheel__controls button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(244, 180, 0, 0.45);
+}
+
+.cipher-wheel__controls button:active {
+  transform: translateY(1px);
+}
+
+.cipher-wheel__readout {
+  font-size: 1rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(244, 180, 0, 0.95);
+}
+
+/* -------------------------------------------------- */
+/* Flux Keypad                                         */
+/* -------------------------------------------------- */
+
+.flux-keypad {
+  display: grid;
+  gap: 1rem;
+  justify-items: center;
+}
+
+.flux-keypad__display {
+  min-width: 280px;
+  padding: 0.85rem 1.2rem;
+  border-radius: 16px;
+  border: 1px solid rgba(56, 248, 122, 0.35);
+  background: linear-gradient(90deg, rgba(6, 14, 24, 0.9), rgba(10, 28, 38, 0.95));
+  font-size: 1.4rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.flux-keypad__display span {
+  color: rgba(56, 248, 122, 0.95);
+}
+
+.flux-keypad__grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.6rem;
+}
+
+.flux-keypad__key {
+  padding: 0.75rem 0;
+  border-radius: 12px;
+  border: 1px solid rgba(56, 248, 122, 0.35);
+  background: linear-gradient(180deg, rgba(8, 16, 28, 0.88), rgba(14, 28, 38, 0.92));
+  color: rgba(56, 248, 122, 0.95);
+  font-size: 1.35rem;
+  letter-spacing: 0.18em;
+  cursor: pointer;
+  transition: transform 0.12s ease, box-shadow 0.18s ease;
+}
+
+.flux-keypad__key:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(244, 180, 0, 0.5);
+}
+
+.flux-keypad__key:active {
+  transform: translateY(1px);
+}
+
+.flux-keypad__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.flux-keypad__actions button {
+  padding: 0.65rem 1.4rem;
+  border-radius: 12px;
+  border: 1px solid rgba(244, 180, 0, 0.45);
+  background: rgba(42, 22, 12, 0.75);
+  color: rgba(244, 180, 0, 0.95);
+  letter-spacing: 0.18em;
+  cursor: pointer;
+  text-transform: uppercase;
+}
+
+/* -------------------------------------------------- */
+/* Synthwave Sequencer                                 */
+/* -------------------------------------------------- */
+
+.sequencer-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.sequencer-grid__steps {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.sequencer-grid__step {
+  position: relative;
+  padding: 0.9rem 0;
+  border-radius: 14px;
+  border: 1px solid rgba(116, 200, 255, 0.35);
+  background: linear-gradient(180deg, rgba(8, 20, 32, 0.86), rgba(6, 12, 24, 0.92));
+  color: rgba(116, 200, 255, 0.85);
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.sequencer-grid__step::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  background: linear-gradient(120deg, rgba(116, 200, 255, 0.3), rgba(56, 248, 222, 0.55));
+  transition: opacity 0.18s ease;
+}
+
+.sequencer-grid__step[aria-pressed="true"]::after {
+  opacity: 1;
+}
+
+.sequencer-grid__step[data-phase="active"] {
+  box-shadow: 0 0 0 2px rgba(244, 180, 0, 0.45), 0 20px 32px rgba(244, 180, 0, 0.25);
+}
+
+.sequencer-grid__controls {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.sequencer-grid__controls button {
+  padding: 0.6rem 1.2rem;
+  border-radius: 12px;
+  border: 1px solid rgba(116, 200, 255, 0.4);
+  background: rgba(8, 16, 28, 0.85);
+  color: rgba(116, 200, 255, 0.95);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+/* -------------------------------------------------- */
+/* Radar Sweep Monitor                                 */
+/* -------------------------------------------------- */
+
+.radar-monitor {
+  display: grid;
+  gap: 1rem;
+}
+
+.radar-monitor__scope {
+  position: relative;
+  width: min(320px, 100%);
+  aspect-ratio: 1 / 1;
+  margin: 0 auto;
+  border-radius: 50%;
+  border: 2px solid rgba(56, 248, 122, 0.45);
+  background: radial-gradient(circle at center, rgba(56, 248, 122, 0.18), rgba(4, 10, 16, 0.95));
+  box-shadow: inset 0 0 24px rgba(56, 248, 122, 0.32);
+  overflow: hidden;
+}
+
+.radar-monitor__grid {
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(circle, rgba(56, 248, 122, 0.18) 1px, transparent 1px),
+    linear-gradient(0deg, rgba(56, 248, 122, 0.12) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(56, 248, 122, 0.12) 1px, transparent 1px);
+  background-size: 22px 22px;
+  opacity: 0.35;
+}
+
+.radar-monitor__sweep {
+  position: absolute;
+  inset: 0;
+  background: conic-gradient(from 90deg, rgba(56, 248, 122, 0.45), rgba(56, 248, 122, 0));
+  transform: rotate(var(--sweep-angle, 0deg));
+  transform-origin: center;
+  transition: transform 0.12s linear;
+}
+
+.radar-monitor__target {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(244, 180, 0, 0.95);
+  box-shadow: 0 0 16px rgba(244, 180, 0, 0.65);
+  transform: translate(-50%, -50%) scale(0);
+  transition: transform 0.4s ease;
+}
+
+.radar-monitor__target[data-state="active"] {
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.radar-monitor__log {
+  border-radius: 14px;
+  border: 1px solid rgba(56, 248, 122, 0.25);
+  background: rgba(4, 12, 20, 0.8);
+  padding: 0.75rem 1rem;
+  font-size: 0.85rem;
+  color: rgba(148, 197, 183, 0.85);
+  max-height: 160px;
+  overflow: auto;
+}
+
+/* -------------------------------------------------- */
+/* Spectral Data Tunnel                                */
+/* -------------------------------------------------- */
+
+.tunnel-meter {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.tunnel-meter__row {
+  display: grid;
+  grid-template-columns: 140px 1fr 70px;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.tunnel-meter__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 183, 0.75);
+}
+
+.tunnel-meter__bar {
+  position: relative;
+  height: 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(116, 200, 255, 0.35);
+  overflow: hidden;
+  background: rgba(8, 16, 28, 0.88);
+}
+
+.tunnel-meter__bar-fill {
+  position: absolute;
+  inset: 0;
+  transform-origin: left;
+  background: linear-gradient(90deg, rgba(116, 200, 255, 0.15), rgba(56, 248, 222, 0.55));
+  box-shadow: 0 0 18px rgba(116, 200, 255, 0.45);
+  transition: transform 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.tunnel-meter__value {
+  font-size: 0.8rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(116, 200, 255, 0.85);
+}
+
+/* -------------------------------------------------- */
+/* Launch Lever                                        */
+/* -------------------------------------------------- */
+
+.launch-lever {
+  position: relative;
+  display: grid;
+  gap: 1.1rem;
+}
+
+.launch-lever__track {
+  position: relative;
+  height: 70px;
+  border-radius: 999px;
+  border: 1px solid rgba(244, 180, 0, 0.45);
+  background: linear-gradient(90deg, rgba(44, 18, 4, 0.85), rgba(80, 34, 10, 0.85));
+  display: flex;
+  align-items: center;
+  padding: 0 1rem;
+}
+
+.launch-lever__rail {
+  position: relative;
+  flex: 1;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(244, 180, 0, 0.35);
+}
+
+.launch-lever__thumb {
+  position: absolute;
+  top: 50%;
+  left: var(--lever-percent, 0%);
+  transform: translate(-50%, -50%);
+  width: 78px;
+  height: 78px;
+  border-radius: 22px;
+  background: radial-gradient(circle at 35% 30%, rgba(244, 180, 0, 0.92), rgba(44, 18, 4, 0.95));
+  border: 1px solid rgba(244, 180, 0, 0.65);
+  box-shadow: 0 0 26px rgba(244, 180, 0, 0.45);
+  display: grid;
+  place-items: center;
+  color: #1a0902;
+  font-size: 0.8rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  cursor: grab;
+}
+
+.launch-lever__thumb:active {
+  cursor: grabbing;
+}
+
+.launch-lever__status {
+  font-size: 0.9rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(244, 180, 0, 0.95);
+  text-align: center;
+}
+
+/* -------------------------------------------------- */
+/* Constellation Router                                */
+/* -------------------------------------------------- */
+
+.constellation-router {
+  position: relative;
+  display: grid;
+  gap: 1.2rem;
+}
+
+.constellation-router__field {
+  position: relative;
+  width: min(320px, 100%);
+  aspect-ratio: 1 / 1;
+  margin: 0 auto;
+  border-radius: 50%;
+  border: 1px solid rgba(116, 200, 255, 0.35);
+  background: radial-gradient(circle at center, rgba(10, 34, 66, 0.85), rgba(4, 10, 16, 0.95));
+  box-shadow: inset 0 0 32px rgba(116, 200, 255, 0.25);
+}
+
+.constellation-router__node {
+  position: absolute;
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  border: 1px solid rgba(116, 200, 255, 0.4);
+  background: rgba(10, 34, 66, 0.8);
+  color: rgba(116, 200, 255, 0.9);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.constellation-router__node[aria-checked="true"] {
+  transform: translate(-50%, -50%) scale(1.08);
+  box-shadow: 0 18px 28px rgba(116, 200, 255, 0.32);
+  background: rgba(18, 64, 112, 0.9);
+}
+
+.constellation-router__node:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(244, 180, 0, 0.45);
+}
+
+.constellation-router__readout {
+  text-align: center;
+  font-size: 0.95rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(116, 200, 255, 0.9);
+}
+
+/* -------------------------------------------------- */
+/* Holo Console                                        */
+/* -------------------------------------------------- */
+
+.holo-console {
+  position: relative;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.holo-console__input {
+  position: relative;
+  border-radius: 18px;
+  border: 1px solid rgba(116, 200, 255, 0.35);
+  overflow: hidden;
+  background: rgba(4, 12, 20, 0.85);
+}
+
+.holo-console__input textarea {
+  width: 100%;
+  min-height: 140px;
+  background: transparent;
+  color: inherit;
+  padding: 1rem 1.25rem;
+  border: none;
+  resize: vertical;
+  font: inherit;
+}
+
+.holo-console__input textarea:focus {
+  outline: none;
+}
+
+.holo-console__overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  opacity: 0.25;
+  background: repeating-linear-gradient(180deg, rgba(56, 248, 222, 0.3) 0 2px, transparent 2px 4px);
+}
+
+.holo-console__preview {
+  border-radius: 16px;
+  border: 1px solid rgba(56, 248, 222, 0.3);
+  background: rgba(2, 12, 22, 0.75);
+  padding: 0.85rem 1.2rem;
+  color: rgba(56, 248, 222, 0.9);
+  min-height: 80px;
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  white-space: pre-wrap;
+}
+
+.holo-console__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 183, 0.7);
+}
+
+/* -------------------------------------------------- */
+/* Cryo Capsule Switch                                 */
+/* -------------------------------------------------- */
+
+.cryo-switch {
+  display: grid;
+  gap: 1rem;
+  justify-items: center;
+}
+
+.cryo-switch__shell {
+  position: relative;
+  width: min(320px, 100%);
+  border-radius: 28px;
+  border: 1px solid rgba(116, 200, 255, 0.35);
+  padding: 1.25rem 1.5rem;
+  background: linear-gradient(120deg, rgba(18, 40, 72, 0.9), rgba(4, 12, 24, 0.9));
+  display: grid;
+  gap: 1rem;
+}
+
+.cryo-switch__rail {
+  position: relative;
+  height: 60px;
+  border-radius: 999px;
+  border: 1px solid rgba(244, 180, 0, 0.45);
+  background: rgba(20, 12, 4, 0.85);
+}
+
+.cryo-switch__handle {
+  position: absolute;
+  top: 50%;
+  left: var(--switch-percent, 50%);
+  transform: translate(-50%, -50%);
+  width: 82px;
+  height: 82px;
+  border-radius: 24px;
+  background: radial-gradient(circle at 35% 35%, rgba(244, 180, 0, 0.95), rgba(32, 12, 2, 0.95));
+  border: 1px solid rgba(244, 180, 0, 0.65);
+  box-shadow: 0 0 24px rgba(244, 180, 0, 0.4);
+  display: grid;
+  place-items: center;
+  color: #120602;
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.cryo-switch__phases {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(244, 180, 0, 0.8);
+}
+
+.cryo-switch__status {
+  font-size: 0.95rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(244, 180, 0, 0.95);
+}
+
+/* -------------------------------------------------- */
+/* Utility classes for callouts                         */
+/* -------------------------------------------------- */
+
+.widget-note {
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 183, 0.65);
+}

--- a/madia.new/public/secret/net/widgets.js
+++ b/madia.new/public/secret/net/widgets.js
@@ -1,0 +1,1259 @@
+const clamp = (value, min = 0, max = 100) => {
+  const number = Number.parseFloat(value);
+  if (Number.isNaN(number)) {
+    return min;
+  }
+  return Math.min(max, Math.max(min, number));
+};
+
+const clampAngle = (angle) => {
+  const number = Number.parseFloat(angle);
+  if (Number.isNaN(number)) {
+    return 0;
+  }
+  const normalized = number % 360;
+  return normalized < 0 ? normalized + 360 : normalized;
+};
+
+const cycleFocus = (items, current, direction) => {
+  if (!items.length) {
+    return null;
+  }
+  const index = items.indexOf(current);
+  if (index === -1) {
+    return items[0];
+  }
+  const nextIndex = (index + direction + items.length) % items.length;
+  return items[nextIndex];
+};
+
+const formatPercent = (value) => `${Math.round(value)}%`;
+
+const findHiddenInput = (root) => {
+  if (!(root instanceof HTMLElement)) {
+    return null;
+  }
+  return root.querySelector('input[type="hidden"]');
+};
+
+const dispatchWidgetEvent = (root, name, detail = {}) => {
+  if (!(root instanceof HTMLElement)) {
+    return;
+  }
+  root.dispatchEvent(
+    new CustomEvent(name, {
+      bubbles: true,
+      detail,
+    })
+  );
+};
+
+/* -------------------------------------------------- */
+/* Neon Select                                         */
+/* -------------------------------------------------- */
+
+const initNeonSelect = (root) => {
+  if (!(root instanceof HTMLElement)) {
+    return;
+  }
+
+  const options = Array.from(root.querySelectorAll(".neon-select__option"));
+  const hiddenInput = findHiddenInput(root);
+
+  if (!options.length) {
+    return;
+  }
+
+  const getInitialOption = () => {
+    if (hiddenInput && hiddenInput.value) {
+      return options.find((option) => option.dataset.value === hiddenInput.value) || options[0];
+    }
+    if (root.dataset.value) {
+      return options.find((option) => option.dataset.value === root.dataset.value) || options[0];
+    }
+    return options[0];
+  };
+
+  let selected = getInitialOption();
+
+  const setSelected = (target, focus = false) => {
+    if (!target) {
+      return;
+    }
+    selected = target;
+    options.forEach((option) => {
+      const isSelected = option === target;
+      option.setAttribute("aria-selected", String(isSelected));
+      option.setAttribute("tabindex", isSelected ? "0" : "-1");
+    });
+    const value = target.dataset.value || "";
+    root.dataset.value = value;
+    if (hiddenInput) {
+      hiddenInput.value = value;
+    }
+    dispatchWidgetEvent(root, "net:select-change", { value });
+    if (focus) {
+      target.focus();
+    }
+  };
+
+  options.forEach((option) => {
+    option.type = "button";
+    option.setAttribute("role", "option");
+    option.addEventListener("click", () => {
+      setSelected(option, true);
+    });
+    option.addEventListener("keydown", (event) => {
+      switch (event.key) {
+        case "ArrowUp":
+        case "ArrowLeft": {
+          const previous = cycleFocus(options, option, -1);
+          if (previous) {
+            event.preventDefault();
+            setSelected(previous, true);
+          }
+          break;
+        }
+        case "ArrowDown":
+        case "ArrowRight": {
+          const next = cycleFocus(options, option, 1);
+          if (next) {
+            event.preventDefault();
+            setSelected(next, true);
+          }
+          break;
+        }
+        case "Home": {
+          event.preventDefault();
+          setSelected(options[0], true);
+          break;
+        }
+        case "End": {
+          event.preventDefault();
+          setSelected(options[options.length - 1], true);
+          break;
+        }
+        case "Enter":
+        case " ": {
+          event.preventDefault();
+          setSelected(option, true);
+          break;
+        }
+        default:
+          break;
+      }
+    });
+  });
+
+  root.setAttribute("role", "listbox");
+  if (!root.hasAttribute("tabindex")) {
+    root.setAttribute("tabindex", "0");
+  }
+
+  root.addEventListener("focus", (event) => {
+    if (event.target === root && selected) {
+      selected.focus();
+    }
+  });
+
+  setSelected(selected);
+};
+
+/* -------------------------------------------------- */
+/* Segment Toggle                                      */
+/* -------------------------------------------------- */
+
+const initSegmentToggle = (group) => {
+  if (!(group instanceof HTMLElement)) {
+    return;
+  }
+
+  const buttons = Array.from(group.querySelectorAll(".segment-toggle__option"));
+  const hiddenInput = findHiddenInput(group);
+
+  if (!buttons.length) {
+    return;
+  }
+
+  const getInitialButton = () => {
+    if (hiddenInput && hiddenInput.value) {
+      return buttons.find((button) => button.dataset.value === hiddenInput.value) || buttons[0];
+    }
+    if (group.dataset.value) {
+      return buttons.find((button) => button.dataset.value === group.dataset.value) || buttons[0];
+    }
+    return buttons[0];
+  };
+
+  let active = getInitialButton();
+
+  const setActive = (target, focus = false) => {
+    if (!target) {
+      return;
+    }
+    active = target;
+    buttons.forEach((button) => {
+      const isActive = button === target;
+      button.setAttribute("aria-checked", String(isActive));
+      button.setAttribute("tabindex", isActive ? "0" : "-1");
+    });
+    const value = target.dataset.value || "";
+    group.dataset.value = value;
+    if (hiddenInput) {
+      hiddenInput.value = value;
+    }
+    dispatchWidgetEvent(group, "net:segment-change", { value });
+    if (focus) {
+      target.focus();
+    }
+  };
+
+  buttons.forEach((button) => {
+    button.type = "button";
+    button.setAttribute("role", "radio");
+    button.addEventListener("click", () => {
+      setActive(button, true);
+    });
+    button.addEventListener("keydown", (event) => {
+      switch (event.key) {
+        case "ArrowUp":
+        case "ArrowLeft": {
+          const previous = cycleFocus(buttons, button, -1);
+          if (previous) {
+            event.preventDefault();
+            setActive(previous, true);
+          }
+          break;
+        }
+        case "ArrowDown":
+        case "ArrowRight": {
+          const next = cycleFocus(buttons, button, 1);
+          if (next) {
+            event.preventDefault();
+            setActive(next, true);
+          }
+          break;
+        }
+        case "Home": {
+          event.preventDefault();
+          setActive(buttons[0], true);
+          break;
+        }
+        case "End": {
+          event.preventDefault();
+          setActive(buttons[buttons.length - 1], true);
+          break;
+        }
+        default:
+          break;
+      }
+    });
+  });
+
+  group.setAttribute("role", "radiogroup");
+  setActive(active);
+};
+
+/* -------------------------------------------------- */
+/* Status Rails + Packet Scrubber                      */
+/* -------------------------------------------------- */
+
+const updateStatusBar = (bar, value) => {
+  if (!(bar instanceof HTMLElement)) {
+    return;
+  }
+  const progress = clamp(value ?? bar.dataset.progress ?? 0, 0, 100);
+  bar.dataset.progress = String(progress);
+  const fill = bar.querySelector(".status-rail__bar-fill");
+  if (fill) {
+    fill.style.transform = `scaleX(${progress / 100})`;
+  }
+  const row = bar.closest(".status-rail__row");
+  if (row) {
+    const valueEl = row.querySelector(".status-rail__value");
+    if (valueEl) {
+      valueEl.textContent = formatPercent(progress);
+    }
+  }
+  bar.setAttribute("aria-valuenow", Math.round(progress));
+  bar.setAttribute("aria-valuetext", `${Math.round(progress)} percent`);
+};
+
+const initStatusRail = (root) => {
+  if (!(root instanceof HTMLElement)) {
+    return;
+  }
+  const bars = Array.from(root.querySelectorAll(".status-rail__bar"));
+  bars.forEach((bar) => updateStatusBar(bar));
+};
+
+const initPacketScrubber = (scrubber) => {
+  if (!(scrubber instanceof HTMLElement)) {
+    return;
+  }
+  const dial = scrubber.querySelector(".packet-scrubber__dial");
+  const pointer = scrubber.querySelector(".packet-scrubber__pointer");
+  const control = scrubber.querySelector('[data-role="scrubber-input"]');
+
+  const setValue = (value) => {
+    const progress = clamp(value ?? scrubber.dataset.value ?? 0, 0, 100);
+    scrubber.dataset.value = String(progress);
+    if (dial) {
+      dial.dataset.value = progress.toFixed(0);
+    }
+    if (pointer) {
+      const rotation = -120 + (progress / 100) * 240;
+      pointer.style.transform = `rotate(${rotation}deg)`;
+    }
+  };
+
+  if (control instanceof HTMLInputElement) {
+    control.addEventListener("input", () => {
+      setValue(control.value);
+    });
+    control.addEventListener("change", () => {
+      const value = clamp(control.value, 0, 100);
+      setValue(value);
+      dispatchWidgetEvent(scrubber, "net:scrubber-change", { value });
+    });
+  }
+
+  setValue(scrubber.dataset.value || (control ? control.value : 0));
+
+  scrubber.addEventListener("net:segment-change", (event) => {
+    if (event?.detail?.value !== undefined) {
+      setValue(event.detail.value);
+    }
+  });
+};
+
+const autoPulse = (root) => {
+  const bars = Array.from(root.querySelectorAll(".status-rail__bar"));
+  if (!bars.length) {
+    return;
+  }
+  setInterval(() => {
+    bars.forEach((bar, index) => {
+      const base = 35 + index * 15;
+      const swing = Math.sin(Date.now() / 600 + index) * 18;
+      updateStatusBar(bar, base + swing + Math.random() * 8);
+    });
+  }, 1500);
+};
+
+/* -------------------------------------------------- */
+/* Orbital Dial                                        */
+/* -------------------------------------------------- */
+
+const initOrbitalDial = (root) => {
+  if (!(root instanceof HTMLElement)) {
+    return;
+  }
+  const knob = root.querySelector(".orbital-dial__knob");
+  const needle = root.querySelector(".orbital-dial__needle");
+  const readout = root.querySelector(".orbital-dial__readout strong");
+  const hiddenInput = findHiddenInput(root);
+
+  if (!(knob instanceof HTMLButtonElement) || !needle || !readout) {
+    return;
+  }
+
+  const rectCache = { width: 0, height: 0, left: 0, top: 0 };
+
+  const refreshRect = () => {
+    const rect = knob.parentElement?.getBoundingClientRect();
+    if (rect) {
+      rectCache.width = rect.width;
+      rectCache.height = rect.height;
+      rectCache.left = rect.left;
+      rectCache.top = rect.top;
+    }
+  };
+
+  const setValue = (value, dispatch = true) => {
+    const angle = clampAngle(value ?? root.dataset.value ?? 0);
+    root.dataset.value = angle.toFixed(0);
+    knob.style.setProperty("--dial-angle", `${angle}deg`);
+    needle.style.setProperty("--dial-angle", `${angle}deg`);
+    knob.setAttribute("aria-valuenow", angle.toFixed(0));
+    knob.setAttribute("aria-valuetext", `${angle.toFixed(0)} degrees`);
+    readout.textContent = `${angle.toFixed(0)}°`;
+    if (hiddenInput) {
+      hiddenInput.value = angle.toFixed(0);
+    }
+    if (dispatch) {
+      dispatchWidgetEvent(root, "net:orbital-change", { value: angle });
+    }
+  };
+
+  const computeAngleFromEvent = (event) => {
+    refreshRect();
+    const centerX = rectCache.left + rectCache.width / 2;
+    const centerY = rectCache.top + rectCache.height / 2;
+    const angle = Math.atan2(centerY - event.clientY, event.clientX - centerX);
+    return clampAngle(90 - (angle * 180) / Math.PI);
+  };
+
+  const handlePointerMove = (event) => {
+    event.preventDefault();
+    const angle = computeAngleFromEvent(event);
+    setValue(angle);
+  };
+
+  const handlePointerUp = () => {
+    window.removeEventListener("pointermove", handlePointerMove);
+    window.removeEventListener("pointerup", handlePointerUp);
+  };
+
+  knob.addEventListener("pointerdown", (event) => {
+    event.preventDefault();
+    knob.setPointerCapture(event.pointerId);
+    handlePointerMove(event);
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
+  });
+
+  knob.addEventListener("keydown", (event) => {
+    const current = Number.parseFloat(root.dataset.value || "0");
+    let next = current;
+    switch (event.key) {
+      case "ArrowLeft":
+      case "ArrowDown":
+        next = current - 5;
+        break;
+      case "ArrowRight":
+      case "ArrowUp":
+        next = current + 5;
+        break;
+      case "Home":
+        next = 0;
+        break;
+      case "End":
+        next = 359;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    setValue(next);
+  });
+
+  knob.setAttribute("role", "slider");
+  knob.setAttribute("aria-valuemin", "0");
+  knob.setAttribute("aria-valuemax", "359");
+
+  setValue(root.dataset.value || 0, false);
+};
+
+/* -------------------------------------------------- */
+/* Plasma Column Fader                                 */
+/* -------------------------------------------------- */
+
+const initPlasmaFader = (root) => {
+  if (!(root instanceof HTMLElement)) {
+    return;
+  }
+  const channels = Array.from(root.querySelectorAll(".plasma-fader__column"));
+  if (!channels.length) {
+    return;
+  }
+
+  channels.forEach((column) => {
+    const thumb = column.querySelector(".plasma-fader__thumb");
+    const valueText = column.querySelector(".plasma-fader__value");
+    const columnInput = column.querySelector('input[type="hidden"]');
+    if (!(thumb instanceof HTMLButtonElement) || !valueText) {
+      return;
+    }
+
+    const channelId = column.dataset.channel || "channel";
+
+    const setValue = (value, dispatch = true) => {
+      const percent = clamp(value ?? column.dataset.value ?? 0, 0, 100);
+      column.dataset.value = String(percent);
+      thumb.style.setProperty("--thumb-top", `${100 - percent}%`);
+      thumb.textContent = `${Math.round(percent)}%`;
+      thumb.setAttribute("aria-valuenow", Math.round(percent));
+      thumb.setAttribute("aria-valuetext", `${Math.round(percent)} percent`);
+      valueText.textContent = `${channelId.toUpperCase()} Output: ${formatPercent(percent)}`;
+      if (columnInput) {
+        columnInput.value = String(Math.round(percent));
+      }
+      if (dispatch) {
+        dispatchWidgetEvent(column, "net:fader-change", {
+          channel: channelId,
+          value: percent,
+        });
+      }
+    };
+
+    const track = column.querySelector(".plasma-fader__track");
+    const slot = column.querySelector(".plasma-fader__slot");
+
+    const updateFromPointer = (event) => {
+      const reference = slot || track;
+      if (!reference) {
+        return;
+      }
+      const rect = reference.getBoundingClientRect();
+      const ratio = 1 - (event.clientY - rect.top) / rect.height;
+      const percent = clamp(ratio * 100, 0, 100);
+      setValue(percent);
+    };
+
+    const handlePointerMove = (event) => {
+      event.preventDefault();
+      updateFromPointer(event);
+    };
+
+    const handlePointerUp = () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+    };
+
+    thumb.addEventListener("pointerdown", (event) => {
+      event.preventDefault();
+      thumb.setPointerCapture(event.pointerId);
+      updateFromPointer(event);
+      window.addEventListener("pointermove", handlePointerMove);
+      window.addEventListener("pointerup", handlePointerUp);
+    });
+
+    thumb.addEventListener("keydown", (event) => {
+      const current = Number.parseFloat(column.dataset.value || "0");
+      let next = current;
+      switch (event.key) {
+        case "ArrowUp":
+          next = current + 5;
+          break;
+        case "ArrowDown":
+          next = current - 5;
+          break;
+        case "PageUp":
+          next = current + 10;
+          break;
+        case "PageDown":
+          next = current - 10;
+          break;
+        case "Home":
+          next = 0;
+          break;
+        case "End":
+          next = 100;
+          break;
+        default:
+          return;
+      }
+      event.preventDefault();
+      setValue(next);
+    });
+
+    thumb.setAttribute("role", "slider");
+    thumb.setAttribute("aria-valuemin", "0");
+    thumb.setAttribute("aria-valuemax", "100");
+
+    setValue(column.dataset.value || (columnInput ? columnInput.value : 0), false);
+  });
+};
+
+/* -------------------------------------------------- */
+/* Node Matrix                                         */
+/* -------------------------------------------------- */
+
+const initNodeMatrix = (root) => {
+  if (!(root instanceof HTMLElement)) {
+    return;
+  }
+  const nodes = Array.from(root.querySelectorAll(".node-matrix__node"));
+  const summary = root.querySelector(".node-matrix__summary");
+  const hiddenInput = findHiddenInput(root);
+
+  if (!nodes.length || !summary) {
+    return;
+  }
+
+  const updateSummary = () => {
+    const active = nodes
+      .filter((node) => node.getAttribute("aria-pressed") === "true")
+      .map((node) => node.dataset.node || "")
+      .filter(Boolean);
+    const text = active.length ? active.join(" · ") : "No nodes armed";
+    summary.textContent = `Active nodes: ${text}`;
+    root.dataset.value = active.join(",");
+    if (hiddenInput) {
+      hiddenInput.value = root.dataset.value;
+    }
+    dispatchWidgetEvent(root, "net:matrix-change", { nodes: active });
+  };
+
+  nodes.forEach((node) => {
+    node.type = "button";
+    node.setAttribute("role", "switch");
+    if (!node.hasAttribute("tabindex")) {
+      node.setAttribute("tabindex", "0");
+    }
+    node.addEventListener("click", () => {
+      const current = node.getAttribute("aria-pressed") === "true";
+      node.setAttribute("aria-pressed", String(!current));
+      updateSummary();
+    });
+    node.addEventListener("keydown", (event) => {
+      const row = Number.parseInt(node.dataset.row || "0", 10);
+      const col = Number.parseInt(node.dataset.col || "0", 10);
+      let target = null;
+      switch (event.key) {
+        case "ArrowUp":
+          target = nodes.find((item) => Number.parseInt(item.dataset.row || "0", 10) === row - 1 && Number.parseInt(item.dataset.col || "0", 10) === col);
+          break;
+        case "ArrowDown":
+          target = nodes.find((item) => Number.parseInt(item.dataset.row || "0", 10) === row + 1 && Number.parseInt(item.dataset.col || "0", 10) === col);
+          break;
+        case "ArrowLeft":
+          target = nodes.find((item) => Number.parseInt(item.dataset.row || "0", 10) === row && Number.parseInt(item.dataset.col || "0", 10) === col - 1);
+          break;
+        case "ArrowRight":
+          target = nodes.find((item) => Number.parseInt(item.dataset.row || "0", 10) === row && Number.parseInt(item.dataset.col || "0", 10) === col + 1);
+          break;
+        case "Enter":
+        case " ":
+          event.preventDefault();
+          node.click();
+          return;
+        default:
+          return;
+      }
+      if (target) {
+        event.preventDefault();
+        target.focus();
+      }
+    });
+  });
+
+  updateSummary();
+};
+
+/* -------------------------------------------------- */
+/* Cipher Wheel                                        */
+/* -------------------------------------------------- */
+
+const initCipherWheel = (root) => {
+  if (!(root instanceof HTMLElement)) {
+    return;
+  }
+  const rings = Array.from(root.querySelectorAll(".cipher-wheel__ring"));
+  const readout = root.querySelector(".cipher-wheel__readout");
+  const hiddenInput = findHiddenInput(root);
+
+  if (!rings.length || !readout) {
+    return;
+  }
+
+  const alphabet = root.dataset.alphabet || "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+  const updateReadout = () => {
+    const key = rings
+      .map((ring) => ring.dataset.value || alphabet[0] || "")
+      .join("");
+    readout.textContent = `Cipher: ${key}`;
+    root.dataset.value = key;
+    if (hiddenInput) {
+      hiddenInput.value = key;
+    }
+    dispatchWidgetEvent(root, "net:cipher-change", { key });
+  };
+
+  rings.forEach((ring, index) => {
+    const windowEl = ring.querySelector(".cipher-wheel__window");
+    const controls = Array.from(ring.querySelectorAll(".cipher-wheel__controls button"));
+    const ringLabel = ring.dataset.label || `Ring ${index + 1}`;
+
+    if (!windowEl || !controls.length) {
+      return;
+    }
+
+    const setValue = (value) => {
+      const char = value.toUpperCase();
+      const charIndex = alphabet.indexOf(char);
+      const fallbackIndex = charIndex === -1 ? 0 : charIndex;
+      const output = alphabet[fallbackIndex] || alphabet[0] || "";
+      ring.dataset.value = output;
+      windowEl.textContent = output;
+      windowEl.setAttribute("aria-label", `${ringLabel} set to ${output}`);
+      updateReadout();
+    };
+
+    const adjust = (delta) => {
+      const current = ring.dataset.value || alphabet[0] || "";
+      const indexCurrent = alphabet.indexOf(current);
+      const nextIndex = indexCurrent === -1 ? 0 : (indexCurrent + delta + alphabet.length) % alphabet.length;
+      setValue(alphabet[nextIndex]);
+    };
+
+    controls.forEach((button) => {
+      button.addEventListener("click", () => {
+        const action = button.dataset.action;
+        adjust(action === "increment" ? 1 : -1);
+      });
+      button.addEventListener("keydown", (event) => {
+        if (event.key === "ArrowUp" || event.key === "+") {
+          event.preventDefault();
+          adjust(1);
+        } else if (event.key === "ArrowDown" || event.key === "-") {
+          event.preventDefault();
+          adjust(-1);
+        }
+      });
+    });
+
+    setValue(ring.dataset.value || alphabet[Math.floor(Math.random() * alphabet.length)]);
+  });
+
+  updateReadout();
+};
+
+/* -------------------------------------------------- */
+/* Flux Keypad                                         */
+/* -------------------------------------------------- */
+
+const initFluxKeypad = (root) => {
+  if (!(root instanceof HTMLElement)) {
+    return;
+  }
+  const display = root.querySelector('[data-role="display"]');
+  const status = root.querySelector('[data-role="status"]');
+  const keys = Array.from(root.querySelectorAll(".flux-keypad__key"));
+  const hiddenInput = findHiddenInput(root);
+  const maxLength = Number.parseInt(root.dataset.maxLength || "6", 10);
+
+  if (!display || !status || !keys.length) {
+    return;
+  }
+
+  let buffer = "";
+
+  const render = (announce = false) => {
+    display.textContent = buffer.padEnd(maxLength, "·");
+    if (hiddenInput) {
+      hiddenInput.value = buffer;
+    }
+    if (announce) {
+      status.textContent = `Code staged: ${buffer || "none"}`;
+    }
+  };
+
+  const append = (digit) => {
+    if (buffer.length >= maxLength) {
+      status.textContent = "Buffer full";
+      return;
+    }
+    buffer += digit;
+    render(true);
+  };
+
+  keys.forEach((key) => {
+    key.type = "button";
+    key.addEventListener("click", () => {
+      append(key.dataset.key || "");
+    });
+  });
+
+  const actions = Array.from(root.querySelectorAll(".flux-keypad__actions button"));
+
+  actions.forEach((button) => {
+    button.addEventListener("click", () => {
+      switch (button.dataset.action) {
+        case "clear":
+          buffer = "";
+          status.textContent = "Buffer cleared";
+          render(false);
+          break;
+        case "backspace":
+          buffer = buffer.slice(0, -1);
+          status.textContent = "Digit removed";
+          render(false);
+          break;
+        case "submit":
+          if (!buffer.length) {
+            status.textContent = "No code staged";
+            break;
+          }
+          status.textContent = `Code transmitted (${buffer.length})`;
+          dispatchWidgetEvent(root, "net:keypad-submit", { value: buffer });
+          break;
+        default:
+          break;
+      }
+    });
+  });
+
+  render(false);
+};
+
+/* -------------------------------------------------- */
+/* Sequencer                                           */
+/* -------------------------------------------------- */
+
+const initSequencer = (root) => {
+  if (!(root instanceof HTMLElement)) {
+    return;
+  }
+  const steps = Array.from(root.querySelectorAll(".sequencer-grid__step"));
+  const controls = Array.from(root.querySelectorAll(".sequencer-grid__controls button"));
+  const readout = root.querySelector('[data-role="sequence-output"]');
+  const hiddenInput = findHiddenInput(root);
+
+  if (!steps.length || !controls.length || !readout) {
+    return;
+  }
+
+  let playing = false;
+  let timerId = 0;
+  let phase = 0;
+
+  const computePattern = () =>
+    steps
+      .map((step) => (step.getAttribute("aria-pressed") === "true" ? "■" : "·"))
+      .join(" ");
+
+  const renderPattern = () => {
+    const pattern = computePattern();
+    readout.textContent = `Pattern: ${pattern}`;
+    if (hiddenInput) {
+      hiddenInput.value = pattern;
+    }
+    dispatchWidgetEvent(root, "net:sequencer-change", { pattern });
+  };
+
+  const setPlaying = (state) => {
+    if (playing === state) {
+      return;
+    }
+    playing = state;
+    if (!playing) {
+      window.clearInterval(timerId);
+      steps.forEach((step) => step.removeAttribute("data-phase"));
+      return;
+    }
+    phase = 0;
+    timerId = window.setInterval(() => {
+      steps.forEach((step, index) => {
+        step.dataset.phase = index === phase ? "active" : "";
+      });
+      const activeSteps = steps.filter((step) => step.dataset.phase === "active" && step.getAttribute("aria-pressed") === "true");
+      if (activeSteps.length) {
+        dispatchWidgetEvent(root, "net:sequencer-trigger", { index: phase });
+      }
+      phase = (phase + 1) % steps.length;
+    }, 320);
+  };
+
+  steps.forEach((step) => {
+    step.type = "button";
+    step.setAttribute("role", "switch");
+    step.addEventListener("click", () => {
+      const current = step.getAttribute("aria-pressed") === "true";
+      step.setAttribute("aria-pressed", String(!current));
+      renderPattern();
+    });
+    step.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        step.click();
+      }
+    });
+  });
+
+  controls.forEach((button) => {
+    button.addEventListener("click", () => {
+      switch (button.dataset.action) {
+        case "play":
+          setPlaying(true);
+          break;
+        case "stop":
+          setPlaying(false);
+          break;
+        case "clear":
+          steps.forEach((step) => step.setAttribute("aria-pressed", "false"));
+          renderPattern();
+          break;
+        default:
+          break;
+      }
+    });
+  });
+
+  renderPattern();
+};
+
+/* -------------------------------------------------- */
+/* Radar Monitor                                       */
+/* -------------------------------------------------- */
+
+const initRadarMonitor = (root) => {
+  if (!(root instanceof HTMLElement)) {
+    return;
+  }
+  const sweep = root.querySelector(".radar-monitor__sweep");
+  const targets = Array.from(root.querySelectorAll(".radar-monitor__target"));
+  const log = root.querySelector(".radar-monitor__log");
+
+  if (!sweep || !log) {
+    return;
+  }
+
+  let angle = 0;
+
+  const pushLog = (message) => {
+    const stamp = new Date().toLocaleTimeString(undefined, { hour12: false });
+    const entry = document.createElement("div");
+    entry.textContent = `[${stamp}] ${message}`;
+    log.append(entry);
+    log.scrollTop = log.scrollHeight;
+  };
+
+  const tick = () => {
+    angle = (angle + 2) % 360;
+    sweep.style.setProperty("--sweep-angle", `${angle}deg`);
+    targets.forEach((target) => {
+      const threshold = Number.parseFloat(target.dataset.threshold || "0");
+      const offset = Math.abs(angle - threshold);
+      if (offset < 6 || offset > 354) {
+        if (target.dataset.state !== "active") {
+          target.dataset.state = "active";
+          pushLog(`Signal spike at ${target.dataset.id || "unknown"}`);
+          dispatchWidgetEvent(root, "net:radar-hit", { id: target.dataset.id, angle });
+        }
+      } else if (target.dataset.state === "active") {
+        target.dataset.state = "";
+      }
+    });
+    window.requestAnimationFrame(tick);
+  };
+
+  window.requestAnimationFrame(tick);
+};
+
+/* -------------------------------------------------- */
+/* Tunnel Meter                                        */
+/* -------------------------------------------------- */
+
+const initTunnelMeter = (root) => {
+  if (!(root instanceof HTMLElement)) {
+    return;
+  }
+  const rows = Array.from(root.querySelectorAll(".tunnel-meter__row"));
+  if (!rows.length) {
+    return;
+  }
+
+  const setRowValue = (row, value) => {
+    const bar = row.querySelector(".tunnel-meter__bar-fill");
+    const readout = row.querySelector(".tunnel-meter__value");
+    const percent = clamp(value ?? row.dataset.value ?? 0, 0, 100);
+    row.dataset.value = String(percent);
+    if (bar) {
+      bar.style.transform = `scaleX(${percent / 100})`;
+    }
+    if (readout) {
+      readout.textContent = formatPercent(percent);
+    }
+  };
+
+  rows.forEach((row) => setRowValue(row));
+
+  setInterval(() => {
+    rows.forEach((row, index) => {
+      const base = Number.parseFloat(row.dataset.value || "0");
+      const swing = Math.sin(Date.now() / 800 + index) * 12;
+      setRowValue(row, clamp(base + swing + Math.random() * 6, 0, 100));
+    });
+  }, 1200);
+};
+
+/* -------------------------------------------------- */
+/* Launch Lever                                        */
+/* -------------------------------------------------- */
+
+const initLaunchLever = (root) => {
+  if (!(root instanceof HTMLElement)) {
+    return;
+  }
+  const thumb = root.querySelector(".launch-lever__thumb");
+  const status = root.querySelector(".launch-lever__status");
+  if (!(thumb instanceof HTMLButtonElement) || !status) {
+    return;
+  }
+
+  const setPercent = (value, announce = true) => {
+    const percent = clamp(value, 0, 100);
+    root.dataset.value = String(percent);
+    thumb.style.setProperty("--lever-percent", `${percent}%`);
+    thumb.setAttribute("aria-valuenow", Math.round(percent));
+    thumb.setAttribute("aria-valuetext", `${Math.round(percent)} percent armed`);
+    if (!announce) {
+      return;
+    }
+    if (percent >= 98) {
+      status.textContent = "Launch vector committed";
+      dispatchWidgetEvent(root, "net:lever-commit", { value: percent });
+      setTimeout(() => {
+        setPercent(0, false);
+        status.textContent = "Lever resetting";
+        setTimeout(() => {
+          status.textContent = "Awaiting authorization";
+        }, 750);
+      }, 900);
+    } else {
+      status.textContent = `Alignment ${formatPercent(percent)}`;
+    }
+  };
+
+  const track = root.querySelector(".launch-lever__rail");
+
+  const updateFromPointer = (event) => {
+    const reference = track || thumb.parentElement;
+    if (!reference) {
+      return;
+    }
+    const rect = reference.getBoundingClientRect();
+    const ratio = (event.clientX - rect.left) / rect.width;
+    const percent = clamp(ratio * 100, 0, 100);
+    setPercent(percent);
+  };
+
+  const handlePointerMove = (event) => {
+    event.preventDefault();
+    updateFromPointer(event);
+  };
+
+  const handlePointerUp = () => {
+    window.removeEventListener("pointermove", handlePointerMove);
+    window.removeEventListener("pointerup", handlePointerUp);
+  };
+
+  thumb.addEventListener("pointerdown", (event) => {
+    event.preventDefault();
+    thumb.setPointerCapture(event.pointerId);
+    updateFromPointer(event);
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
+  });
+
+  thumb.addEventListener("keydown", (event) => {
+    const current = Number.parseFloat(root.dataset.value || "0");
+    let next = current;
+    switch (event.key) {
+      case "ArrowLeft":
+        next = current - 5;
+        break;
+      case "ArrowRight":
+        next = current + 5;
+        break;
+      case "Home":
+        next = 0;
+        break;
+      case "End":
+        next = 100;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    setPercent(next);
+  });
+
+  thumb.setAttribute("role", "slider");
+  thumb.setAttribute("aria-valuemin", "0");
+  thumb.setAttribute("aria-valuemax", "100");
+
+  setPercent(Number.parseFloat(root.dataset.value || "0"), false);
+  status.textContent = "Awaiting authorization";
+};
+
+/* -------------------------------------------------- */
+/* Constellation Router                                */
+/* -------------------------------------------------- */
+
+const initConstellationRouter = (root) => {
+  if (!(root instanceof HTMLElement)) {
+    return;
+  }
+  const nodes = Array.from(root.querySelectorAll(".constellation-router__node"));
+  const readout = root.querySelector(".constellation-router__readout");
+  const hiddenInput = findHiddenInput(root);
+
+  if (!nodes.length || !readout) {
+    return;
+  }
+
+  const setActive = (target, shouldFocus = true) => {
+    nodes.forEach((node) => {
+      const isActive = node === target;
+      node.setAttribute("aria-checked", String(isActive));
+      if (isActive && shouldFocus) {
+        node.focus();
+      }
+    });
+    const value = target?.dataset.node || "";
+    root.dataset.value = value;
+    readout.textContent = value ? `Route locked to ${value}` : "No route selected";
+    if (hiddenInput) {
+      hiddenInput.value = value;
+    }
+    if (value) {
+      dispatchWidgetEvent(root, "net:constellation-change", { value });
+    }
+  };
+
+  nodes.forEach((node) => {
+    node.type = "button";
+    node.setAttribute("role", "radio");
+    node.addEventListener("click", () => setActive(node));
+    node.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        setActive(node);
+      }
+    });
+  });
+
+  setActive(nodes.find((node) => node.dataset.active === "true") || nodes[0], false);
+};
+
+/* -------------------------------------------------- */
+/* Holo Console                                        */
+/* -------------------------------------------------- */
+
+const initHoloConsole = (root) => {
+  if (!(root instanceof HTMLElement)) {
+    return;
+  }
+  const textarea = root.querySelector("textarea");
+  const preview = root.querySelector(".holo-console__preview");
+  const charCount = root.querySelector('[data-role="char-count"]');
+  const status = root.querySelector('[data-role="console-status"]');
+  const hiddenInput = findHiddenInput(root);
+
+  if (!(textarea instanceof HTMLTextAreaElement) || !preview || !charCount || !status) {
+    return;
+  }
+
+  const max = Number.parseInt(textarea.getAttribute("maxlength") || "240", 10);
+
+  const render = () => {
+    const value = textarea.value;
+    preview.textContent = value || "// awaiting uplink text";
+    charCount.textContent = `${value.length} / ${max}`;
+    status.textContent = value.length ? "Echo online" : "Echo idle";
+    if (hiddenInput) {
+      hiddenInput.value = value;
+    }
+    dispatchWidgetEvent(root, "net:console-change", { value });
+  };
+
+  textarea.addEventListener("input", render);
+  render();
+};
+
+/* -------------------------------------------------- */
+/* Cryo Switch                                         */
+/* -------------------------------------------------- */
+
+const initCryoSwitch = (root) => {
+  if (!(root instanceof HTMLElement)) {
+    return;
+  }
+  const handle = root.querySelector(".cryo-switch__handle");
+  const status = root.querySelector(".cryo-switch__status");
+  const hiddenInput = findHiddenInput(root);
+
+  if (!(handle instanceof HTMLButtonElement) || !status) {
+    return;
+  }
+
+  const phases = [
+    { label: "Hibernate", percent: 5, status: "Cryo lock engaged" },
+    { label: "Idle", percent: 50, status: "Capsule idle" },
+    { label: "Revive", percent: 95, status: "Revival sequence primed" },
+  ];
+
+  const setPhase = (index, announce = true) => {
+    const safeIndex = ((index % phases.length) + phases.length) % phases.length;
+    const phase = phases[safeIndex];
+    root.dataset.value = String(safeIndex);
+    handle.style.setProperty("--switch-percent", `${phase.percent}%`);
+    handle.textContent = phase.label;
+    handle.setAttribute("aria-valuenow", String(safeIndex));
+    handle.setAttribute("aria-valuetext", phase.label);
+    if (hiddenInput) {
+      hiddenInput.value = String(safeIndex);
+    }
+    if (announce) {
+      status.textContent = phase.status;
+      dispatchWidgetEvent(root, "net:cryo-change", { index: safeIndex, label: phase.label });
+    }
+  };
+
+  handle.addEventListener("click", () => {
+    const next = Number.parseInt(root.dataset.value || "1", 10) + 1;
+    setPhase(next);
+  });
+
+  handle.addEventListener("keydown", (event) => {
+    let next = Number.parseInt(root.dataset.value || "1", 10);
+    switch (event.key) {
+      case "ArrowLeft":
+      case "ArrowDown":
+        next -= 1;
+        break;
+      case "ArrowRight":
+      case "ArrowUp":
+        next += 1;
+        break;
+      case "Home":
+        next = 0;
+        break;
+      case "End":
+        next = phases.length - 1;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    setPhase(next);
+  });
+
+  handle.setAttribute("role", "slider");
+  handle.setAttribute("aria-valuemin", "0");
+  handle.setAttribute("aria-valuemax", String(phases.length - 1));
+
+  setPhase(Number.parseInt(root.dataset.value || "1", 10), false);
+};
+
+/* -------------------------------------------------- */
+/* Initialise all widgets                              */
+/* -------------------------------------------------- */
+
+window.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll("[data-widget='neon-select']").forEach((node) => initNeonSelect(node));
+  document.querySelectorAll("[data-widget='segment-toggle']").forEach((node) => initSegmentToggle(node));
+  document.querySelectorAll("[data-widget='status-rail']").forEach((node) => initStatusRail(node));
+  document.querySelectorAll("[data-widget='packet-scrubber']").forEach((node) => initPacketScrubber(node));
+  document.querySelectorAll("[data-widget='orbital-dial']").forEach((node) => initOrbitalDial(node));
+  document.querySelectorAll("[data-widget='plasma-fader']").forEach((node) => initPlasmaFader(node));
+  document.querySelectorAll("[data-widget='node-matrix']").forEach((node) => initNodeMatrix(node));
+  document.querySelectorAll("[data-widget='cipher-wheel']").forEach((node) => initCipherWheel(node));
+  document.querySelectorAll("[data-widget='flux-keypad']").forEach((node) => initFluxKeypad(node));
+  document.querySelectorAll("[data-widget='sequencer-grid']").forEach((node) => initSequencer(node));
+  document.querySelectorAll("[data-widget='radar-monitor']").forEach((node) => initRadarMonitor(node));
+  document.querySelectorAll("[data-widget='tunnel-meter']").forEach((node) => initTunnelMeter(node));
+  document.querySelectorAll("[data-widget='launch-lever']").forEach((node) => initLaunchLever(node));
+  document.querySelectorAll("[data-widget='constellation-router']").forEach((node) => initConstellationRouter(node));
+  document.querySelectorAll("[data-widget='holo-console']").forEach((node) => initHoloConsole(node));
+  document.querySelectorAll("[data-widget='cryo-switch']").forEach((node) => initCryoSwitch(node));
+
+  const pulseHost = document.querySelector("[data-widget='status-rail']");
+  if (pulseHost) {
+    autoPulse(pulseHost);
+  }
+});


### PR DESCRIPTION
## Summary
- rebuild the Net widget stylesheet with neon dial, fader, matrix, keypad, radar, and console skins for the expanded control set
- script comprehensive behaviors for the new controls including drag dials, multi-select grids, sequencers, radar sweeps, and cryo switches
- refresh the hidden testbed to exhibit the full gallery of retro-futuristic replacements ready for game integration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e907cb2f948328a4f713863f652117