### PR TITLE
Refactor FTP Flightdeck and Borderline Broadcast to use widget selects

### DIFF
--- a/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.css
+++ b/madia.new/public/secret/net/borderline-broadcast/borderline-broadcast.css
@@ -2,6 +2,20 @@ body {
   background: radial-gradient(circle at top left, rgba(56, 248, 122, 0.12), transparent 55%), var(--net-bg);
 }
 
+.policy-control {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.policy-label {
+  margin: 0;
+  font-weight: 500;
+}
+
+.policy-control .neon-select {
+  width: 100%;
+}
+
 .execute-button {
   margin-top: 0.75rem;
 }

--- a/madia.new/public/secret/net/borderline-broadcast/index.html
+++ b/madia.new/public/secret/net/borderline-broadcast/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Borderline Broadcast</title>
     <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="../widgets.css" />
     <link rel="stylesheet" href="./borderline-broadcast.css" />
   </head>
   <body>
@@ -39,33 +40,66 @@
         <h2 id="bgp-brief">Policy console</h2>
         <p>Choose the policy actions for each event.</p>
         <form id="bgp-form" class="form-grid">
-          <label>
-            Backbone-1 local preference
-            <select name="local-pref">
-              <option value="">--</option>
-              <option value="keep">Leave at default 100</option>
-              <option value="raise">Raise to 150</option>
-              <option value="lower">Drop to 80</option>
-            </select>
-          </label>
-          <label>
-            Transit-backup AS path handling
-            <select name="as-path">
-              <option value="">--</option>
-              <option value="none">No prepending</option>
-              <option value="double">Prepend our ASN twice</option>
-              <option value="triple">Prepend our ASN three times</option>
-            </select>
-          </label>
-          <label>
-            Community 64512:90 (blackhole requests)
-            <select name="community">
-              <option value="">--</option>
-              <option value="propagate">Propagate normally</option>
-              <option value="blackhole">Discard route on import</option>
-              <option value="log">Accept but log only</option>
-            </select>
-          </label>
+          <div class="policy-control">
+            <p class="policy-label" id="local-pref-label">Backbone-1 local preference</p>
+            <div class="neon-select" data-widget="neon-select" aria-labelledby="local-pref-label">
+              <input type="hidden" name="local-pref" value="" />
+              <div class="neon-select__rail">
+                <button class="neon-select__option" data-value="" type="button">
+                  <span class="neon-select__option-title">Unassigned</span>
+                </button>
+                <button class="neon-select__option" data-value="keep" type="button">
+                  <span class="neon-select__option-title">Leave at default 100</span>
+                </button>
+                <button class="neon-select__option" data-value="raise" type="button">
+                  <span class="neon-select__option-title">Raise to 150</span>
+                </button>
+                <button class="neon-select__option" data-value="lower" type="button">
+                  <span class="neon-select__option-title">Drop to 80</span>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div class="policy-control">
+            <p class="policy-label" id="as-path-label">Transit-backup AS path handling</p>
+            <div class="neon-select" data-widget="neon-select" aria-labelledby="as-path-label">
+              <input type="hidden" name="as-path" value="" />
+              <div class="neon-select__rail">
+                <button class="neon-select__option" data-value="" type="button">
+                  <span class="neon-select__option-title">Unassigned</span>
+                </button>
+                <button class="neon-select__option" data-value="none" type="button">
+                  <span class="neon-select__option-title">No prepending</span>
+                </button>
+                <button class="neon-select__option" data-value="double" type="button">
+                  <span class="neon-select__option-title">Prepend our ASN twice</span>
+                </button>
+                <button class="neon-select__option" data-value="triple" type="button">
+                  <span class="neon-select__option-title">Prepend our ASN three times</span>
+                </button>
+              </div>
+            </div>
+          </div>
+          <div class="policy-control">
+            <p class="policy-label" id="community-label">Community 64512:90 (blackhole requests)</p>
+            <div class="neon-select" data-widget="neon-select" aria-labelledby="community-label">
+              <input type="hidden" name="community" value="" />
+              <div class="neon-select__rail">
+                <button class="neon-select__option" data-value="" type="button">
+                  <span class="neon-select__option-title">Unassigned</span>
+                </button>
+                <button class="neon-select__option" data-value="propagate" type="button">
+                  <span class="neon-select__option-title">Propagate normally</span>
+                </button>
+                <button class="neon-select__option" data-value="blackhole" type="button">
+                  <span class="neon-select__option-title">Discard route on import</span>
+                </button>
+                <button class="neon-select__option" data-value="log" type="button">
+                  <span class="neon-select__option-title">Accept but log only</span>
+                </button>
+              </div>
+            </div>
+          </div>
           <button type="submit" class="execute-button">Deploy policies</button>
         </form>
         <div class="status-board" id="status-board" aria-live="polite">Session flapping. Apply damping plan…</div>
@@ -121,6 +155,7 @@
       </section>
     </main>
     <footer>Peering etiquette keeps the network breathing.</footer>
+    <script src="../widgets.js" type="module"></script>
     <script type="module" src="./borderline-broadcast.js"></script>
   </body>
 </html>

--- a/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.css
+++ b/madia.new/public/secret/net/ftp-flightdeck/ftp-flightdeck.css
@@ -14,17 +14,18 @@ main {
   gap: 1rem;
 }
 
-label {
+.command-control {
   display: grid;
   gap: 0.4rem;
+}
+
+.command-label {
+  margin: 0;
   font-weight: 500;
 }
 
-select {
-  background: rgba(0, 14, 26, 0.95);
-  border: 1px solid rgba(110, 255, 210, 0.4);
-  color: var(--text-primary);
-  padding: 0.4rem 0.6rem;
+.command-control .neon-select {
+  width: 100%;
 }
 
 .status-board[data-state="success"] {

--- a/madia.new/public/secret/net/ftp-flightdeck/index.html
+++ b/madia.new/public/secret/net/ftp-flightdeck/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>FTP Flightdeck</title>
     <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="../widgets.css" />
     <link rel="stylesheet" href="./ftp-flightdeck.css" />
   </head>
   <body>
@@ -46,78 +47,216 @@
           <fieldset>
             <legend>Sequencing</legend>
             <div class="command-grid">
-              <label>
-                <code>open staging.wired.lan</code>
-                <select name="open">
-                  <option value="">--</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                  <option value="5">5</option>
-                  <option value="6">6</option>
-                </select>
-              </label>
-              <label>
-                <code>user deploy</code>
-                <select name="user">
-                  <option value="">--</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                  <option value="5">5</option>
-                  <option value="6">6</option>
-                </select>
-              </label>
-              <label>
-                <code>passive</code>
-                <select name="passive">
-                  <option value="">--</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                  <option value="5">5</option>
-                  <option value="6">6</option>
-                </select>
-              </label>
-              <label>
-                <code>cd /var/www/releases</code>
-                <select name="cd">
-                  <option value="">--</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                  <option value="5">5</option>
-                  <option value="6">6</option>
-                </select>
-              </label>
-              <label>
-                <code>put build.tar.gz</code>
-                <select name="put">
-                  <option value="">--</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                  <option value="5">5</option>
-                  <option value="6">6</option>
-                </select>
-              </label>
-              <label>
-                <code>quit</code>
-                <select name="quit">
-                  <option value="">--</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                  <option value="5">5</option>
-                  <option value="6">6</option>
-                </select>
-              </label>
+              <div class="command-control" data-command="open">
+                <p class="command-label" id="command-open">
+                  <code>open staging.wired.lan</code>
+                </p>
+                <div
+                  class="neon-select"
+                  data-widget="neon-select"
+                  aria-labelledby="command-open"
+                >
+                  <input type="hidden" name="open" value="" />
+                  <div class="neon-select__rail">
+                    <button class="neon-select__option" data-value="" type="button">
+                      <span class="neon-select__option-title">Unassigned</span>
+                    </button>
+                    <button class="neon-select__option" data-value="1" type="button">
+                      <span class="neon-select__option-title">Slot 1</span>
+                    </button>
+                    <button class="neon-select__option" data-value="2" type="button">
+                      <span class="neon-select__option-title">Slot 2</span>
+                    </button>
+                    <button class="neon-select__option" data-value="3" type="button">
+                      <span class="neon-select__option-title">Slot 3</span>
+                    </button>
+                    <button class="neon-select__option" data-value="4" type="button">
+                      <span class="neon-select__option-title">Slot 4</span>
+                    </button>
+                    <button class="neon-select__option" data-value="5" type="button">
+                      <span class="neon-select__option-title">Slot 5</span>
+                    </button>
+                    <button class="neon-select__option" data-value="6" type="button">
+                      <span class="neon-select__option-title">Slot 6</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="command-control" data-command="user">
+                <p class="command-label" id="command-user">
+                  <code>user deploy</code>
+                </p>
+                <div
+                  class="neon-select"
+                  data-widget="neon-select"
+                  aria-labelledby="command-user"
+                >
+                  <input type="hidden" name="user" value="" />
+                  <div class="neon-select__rail">
+                    <button class="neon-select__option" data-value="" type="button">
+                      <span class="neon-select__option-title">Unassigned</span>
+                    </button>
+                    <button class="neon-select__option" data-value="1" type="button">
+                      <span class="neon-select__option-title">Slot 1</span>
+                    </button>
+                    <button class="neon-select__option" data-value="2" type="button">
+                      <span class="neon-select__option-title">Slot 2</span>
+                    </button>
+                    <button class="neon-select__option" data-value="3" type="button">
+                      <span class="neon-select__option-title">Slot 3</span>
+                    </button>
+                    <button class="neon-select__option" data-value="4" type="button">
+                      <span class="neon-select__option-title">Slot 4</span>
+                    </button>
+                    <button class="neon-select__option" data-value="5" type="button">
+                      <span class="neon-select__option-title">Slot 5</span>
+                    </button>
+                    <button class="neon-select__option" data-value="6" type="button">
+                      <span class="neon-select__option-title">Slot 6</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="command-control" data-command="passive">
+                <p class="command-label" id="command-passive">
+                  <code>passive</code>
+                </p>
+                <div
+                  class="neon-select"
+                  data-widget="neon-select"
+                  aria-labelledby="command-passive"
+                >
+                  <input type="hidden" name="passive" value="" />
+                  <div class="neon-select__rail">
+                    <button class="neon-select__option" data-value="" type="button">
+                      <span class="neon-select__option-title">Unassigned</span>
+                    </button>
+                    <button class="neon-select__option" data-value="1" type="button">
+                      <span class="neon-select__option-title">Slot 1</span>
+                    </button>
+                    <button class="neon-select__option" data-value="2" type="button">
+                      <span class="neon-select__option-title">Slot 2</span>
+                    </button>
+                    <button class="neon-select__option" data-value="3" type="button">
+                      <span class="neon-select__option-title">Slot 3</span>
+                    </button>
+                    <button class="neon-select__option" data-value="4" type="button">
+                      <span class="neon-select__option-title">Slot 4</span>
+                    </button>
+                    <button class="neon-select__option" data-value="5" type="button">
+                      <span class="neon-select__option-title">Slot 5</span>
+                    </button>
+                    <button class="neon-select__option" data-value="6" type="button">
+                      <span class="neon-select__option-title">Slot 6</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="command-control" data-command="cd">
+                <p class="command-label" id="command-cd">
+                  <code>cd /var/www/releases</code>
+                </p>
+                <div
+                  class="neon-select"
+                  data-widget="neon-select"
+                  aria-labelledby="command-cd"
+                >
+                  <input type="hidden" name="cd" value="" />
+                  <div class="neon-select__rail">
+                    <button class="neon-select__option" data-value="" type="button">
+                      <span class="neon-select__option-title">Unassigned</span>
+                    </button>
+                    <button class="neon-select__option" data-value="1" type="button">
+                      <span class="neon-select__option-title">Slot 1</span>
+                    </button>
+                    <button class="neon-select__option" data-value="2" type="button">
+                      <span class="neon-select__option-title">Slot 2</span>
+                    </button>
+                    <button class="neon-select__option" data-value="3" type="button">
+                      <span class="neon-select__option-title">Slot 3</span>
+                    </button>
+                    <button class="neon-select__option" data-value="4" type="button">
+                      <span class="neon-select__option-title">Slot 4</span>
+                    </button>
+                    <button class="neon-select__option" data-value="5" type="button">
+                      <span class="neon-select__option-title">Slot 5</span>
+                    </button>
+                    <button class="neon-select__option" data-value="6" type="button">
+                      <span class="neon-select__option-title">Slot 6</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="command-control" data-command="put">
+                <p class="command-label" id="command-put">
+                  <code>put build.tar.gz</code>
+                </p>
+                <div
+                  class="neon-select"
+                  data-widget="neon-select"
+                  aria-labelledby="command-put"
+                >
+                  <input type="hidden" name="put" value="" />
+                  <div class="neon-select__rail">
+                    <button class="neon-select__option" data-value="" type="button">
+                      <span class="neon-select__option-title">Unassigned</span>
+                    </button>
+                    <button class="neon-select__option" data-value="1" type="button">
+                      <span class="neon-select__option-title">Slot 1</span>
+                    </button>
+                    <button class="neon-select__option" data-value="2" type="button">
+                      <span class="neon-select__option-title">Slot 2</span>
+                    </button>
+                    <button class="neon-select__option" data-value="3" type="button">
+                      <span class="neon-select__option-title">Slot 3</span>
+                    </button>
+                    <button class="neon-select__option" data-value="4" type="button">
+                      <span class="neon-select__option-title">Slot 4</span>
+                    </button>
+                    <button class="neon-select__option" data-value="5" type="button">
+                      <span class="neon-select__option-title">Slot 5</span>
+                    </button>
+                    <button class="neon-select__option" data-value="6" type="button">
+                      <span class="neon-select__option-title">Slot 6</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="command-control" data-command="quit">
+                <p class="command-label" id="command-quit">
+                  <code>quit</code>
+                </p>
+                <div
+                  class="neon-select"
+                  data-widget="neon-select"
+                  aria-labelledby="command-quit"
+                >
+                  <input type="hidden" name="quit" value="" />
+                  <div class="neon-select__rail">
+                    <button class="neon-select__option" data-value="" type="button">
+                      <span class="neon-select__option-title">Unassigned</span>
+                    </button>
+                    <button class="neon-select__option" data-value="1" type="button">
+                      <span class="neon-select__option-title">Slot 1</span>
+                    </button>
+                    <button class="neon-select__option" data-value="2" type="button">
+                      <span class="neon-select__option-title">Slot 2</span>
+                    </button>
+                    <button class="neon-select__option" data-value="3" type="button">
+                      <span class="neon-select__option-title">Slot 3</span>
+                    </button>
+                    <button class="neon-select__option" data-value="4" type="button">
+                      <span class="neon-select__option-title">Slot 4</span>
+                    </button>
+                    <button class="neon-select__option" data-value="5" type="button">
+                      <span class="neon-select__option-title">Slot 5</span>
+                    </button>
+                    <button class="neon-select__option" data-value="6" type="button">
+                      <span class="neon-select__option-title">Slot 6</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
             </div>
           </fieldset>
           <button type="submit" class="execute-button">Initiate transfer</button>
@@ -169,6 +308,7 @@
       </section>
     </main>
     <footer>Keep the channel clear and the payload intact.</footer>
+    <script src="../widgets.js" type="module"></script>
     <script type="module" src="./ftp-flightdeck.js"></script>
   </body>
 </html>

--- a/madia.new/public/secret/net/widgets.js
+++ b/madia.new/public/secret/net/widgets.js
@@ -48,6 +48,26 @@ const dispatchWidgetEvent = (root, name, detail = {}) => {
   );
 };
 
+const syncHiddenInput = (input, value) => {
+  if (!(input instanceof HTMLInputElement)) {
+    return;
+  }
+  if (input.value === value) {
+    return;
+  }
+  input.value = value;
+  input.dispatchEvent(
+    new Event("input", {
+      bubbles: true,
+    })
+  );
+  input.dispatchEvent(
+    new Event("change", {
+      bubbles: true,
+    })
+  );
+};
+
 /* -------------------------------------------------- */
 /* Neon Select                                         */
 /* -------------------------------------------------- */
@@ -89,7 +109,7 @@ const initNeonSelect = (root) => {
     const value = target.dataset.value || "";
     root.dataset.value = value;
     if (hiddenInput) {
-      hiddenInput.value = value;
+      syncHiddenInput(hiddenInput, value);
     }
     dispatchWidgetEvent(root, "net:select-change", { value });
     if (focus) {
@@ -200,7 +220,7 @@ const initSegmentToggle = (group) => {
     const value = target.dataset.value || "";
     group.dataset.value = value;
     if (hiddenInput) {
-      hiddenInput.value = value;
+      syncHiddenInput(hiddenInput, value);
     }
     dispatchWidgetEvent(group, "net:segment-change", { value });
     if (focus) {
@@ -379,7 +399,7 @@ const initOrbitalDial = (root) => {
     knob.setAttribute("aria-valuetext", `${angle.toFixed(0)} degrees`);
     readout.textContent = `${angle.toFixed(0)}°`;
     if (hiddenInput) {
-      hiddenInput.value = angle.toFixed(0);
+      syncHiddenInput(hiddenInput, angle.toFixed(0));
     }
     if (dispatch) {
       dispatchWidgetEvent(root, "net:orbital-change", { value: angle });
@@ -581,7 +601,7 @@ const initNodeMatrix = (root) => {
     summary.textContent = `Active nodes: ${text}`;
     root.dataset.value = active.join(",");
     if (hiddenInput) {
-      hiddenInput.value = root.dataset.value;
+      syncHiddenInput(hiddenInput, root.dataset.value || "");
     }
     dispatchWidgetEvent(root, "net:matrix-change", { nodes: active });
   };
@@ -657,7 +677,7 @@ const initCipherWheel = (root) => {
     readout.textContent = `Cipher: ${key}`;
     root.dataset.value = key;
     if (hiddenInput) {
-      hiddenInput.value = key;
+      syncHiddenInput(hiddenInput, key);
     }
     dispatchWidgetEvent(root, "net:cipher-change", { key });
   };
@@ -734,7 +754,7 @@ const initFluxKeypad = (root) => {
   const render = (announce = false) => {
     display.textContent = buffer.padEnd(maxLength, "·");
     if (hiddenInput) {
-      hiddenInput.value = buffer;
+      syncHiddenInput(hiddenInput, buffer);
     }
     if (announce) {
       status.textContent = `Code staged: ${buffer || "none"}`;
@@ -819,7 +839,7 @@ const initSequencer = (root) => {
     const pattern = computePattern();
     readout.textContent = `Pattern: ${pattern}`;
     if (hiddenInput) {
-      hiddenInput.value = pattern;
+      syncHiddenInput(hiddenInput, pattern);
     }
     dispatchWidgetEvent(root, "net:sequencer-change", { pattern });
   };
@@ -1098,7 +1118,7 @@ const initConstellationRouter = (root) => {
     root.dataset.value = value;
     readout.textContent = value ? `Route locked to ${value}` : "No route selected";
     if (hiddenInput) {
-      hiddenInput.value = value;
+      syncHiddenInput(hiddenInput, value);
     }
     if (value) {
       dispatchWidgetEvent(root, "net:constellation-change", { value });
@@ -1146,7 +1166,7 @@ const initHoloConsole = (root) => {
     charCount.textContent = `${value.length} / ${max}`;
     status.textContent = value.length ? "Echo online" : "Echo idle";
     if (hiddenInput) {
-      hiddenInput.value = value;
+      syncHiddenInput(hiddenInput, value);
     }
     dispatchWidgetEvent(root, "net:console-change", { value });
   };
@@ -1186,7 +1206,7 @@ const initCryoSwitch = (root) => {
     handle.setAttribute("aria-valuenow", String(safeIndex));
     handle.setAttribute("aria-valuetext", phase.label);
     if (hiddenInput) {
-      hiddenInput.value = String(safeIndex);
+      syncHiddenInput(hiddenInput, String(safeIndex));
     }
     if (announce) {
       status.textContent = phase.status;


### PR DESCRIPTION
## Summary
- replace the FTP Flightdeck command ordering dropdowns with the neon select widget styling
- swap Borderline Broadcast policy dropdowns to neon select widgets and adjust styling
- update the shared Net widget script to emit input/change events when hidden values sync so form listeners still react

## Testing
- not run (static assets)

------
https://chatgpt.com/codex/tasks/task_e_68e92d72baec8328b74a5766ce310675