### PR TITLE
Refactor Net controls to use widget switchboard

### DIFF
--- a/madia.new/public/secret/net/cache-cascade/cache-cascade.css
+++ b/madia.new/public/secret/net/cache-cascade/cache-cascade.css
@@ -7,12 +7,50 @@ body {
   gap: 1rem;
 }
 
-.stream-grid label {
-  align-items: stretch;
-  gap: 0.5rem;
+.stream-control {
+  display: grid;
+  gap: 0.75rem;
 }
 
-.stream-grid select {
+.stream-control__title {
+  margin: 0;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}
+
+.stream-control__name {
+  font-weight: 600;
+}
+
+.stream-control__tag {
+  font-size: 0.75rem;
+  color: rgba(148, 197, 183, 0.75);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.stream-control__fields {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.stream-control__field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.control-label {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 197, 183, 0.78);
+}
+
+.stream-control .neon-select {
   width: 100%;
 }
 

--- a/madia.new/public/secret/net/cache-cascade/index.html
+++ b/madia.new/public/secret/net/cache-cascade/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Cache Cascade</title>
     <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="../widgets.css" />
     <link rel="stylesheet" href="./cache-cascade.css" />
   </head>
   <body>
@@ -38,51 +39,174 @@
           <fieldset>
             <legend>Streams</legend>
             <div class="stream-grid">
-              <label>
-                Static assets (cdn.partner.net)
-                <select name="static">
-                  <option value="">Routing</option>
-                  <option value="direct">Serve direct</option>
-                  <option value="parent">Send to parent cache</option>
-                  <option value="sibling">Share with sibling cache</option>
-                </select>
-                <select name="static-ttl">
-                  <option value="">TTL</option>
-                  <option value="15">15 minutes</option>
-                  <option value="60">60 minutes</option>
-                  <option value="120">120 minutes</option>
-                </select>
-              </label>
-              <label>
-                Newsroom CMS (cms.local)
-                <select name="cms">
-                  <option value="">Routing</option>
-                  <option value="direct">Serve direct</option>
-                  <option value="parent">Send to parent cache</option>
-                  <option value="sibling">Share with sibling cache</option>
-                </select>
-                <select name="cms-ttl">
-                  <option value="">TTL</option>
-                  <option value="5">5 minutes</option>
-                  <option value="15">15 minutes</option>
-                  <option value="60">60 minutes</option>
-                </select>
-              </label>
-              <label>
-                Software mirror (mirror.archive)
-                <select name="mirror">
-                  <option value="">Routing</option>
-                  <option value="direct">Serve direct</option>
-                  <option value="parent">Send to parent cache</option>
-                  <option value="sibling">Share with sibling cache</option>
-                </select>
-                <select name="mirror-ttl">
-                  <option value="">TTL</option>
-                  <option value="30">30 minutes</option>
-                  <option value="120">120 minutes</option>
-                  <option value="240">240 minutes</option>
-                </select>
-              </label>
+              <div class="stream-control">
+                <p class="stream-control__title">
+                  <span class="stream-control__name">Static assets</span>
+                  <span class="stream-control__tag">cdn.partner.net</span>
+                </p>
+                <div class="stream-control__fields">
+                  <div class="stream-control__field">
+                    <p class="control-label" id="static-route-label">Routing</p>
+                    <div
+                      class="neon-select"
+                      data-widget="neon-select"
+                      aria-labelledby="static-route-label"
+                    >
+                      <input type="hidden" name="static" value="" />
+                      <div class="neon-select__rail">
+                        <button class="neon-select__option" data-value="" type="button">
+                          <span class="neon-select__option-title">Routing</span>
+                        </button>
+                        <button class="neon-select__option" data-value="direct" type="button">
+                          <span class="neon-select__option-title">Serve direct</span>
+                        </button>
+                        <button class="neon-select__option" data-value="parent" type="button">
+                          <span class="neon-select__option-title">Send to parent cache</span>
+                        </button>
+                        <button class="neon-select__option" data-value="sibling" type="button">
+                          <span class="neon-select__option-title">Share with sibling cache</span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="stream-control__field">
+                    <p class="control-label" id="static-ttl-label">TTL</p>
+                    <div
+                      class="neon-select"
+                      data-widget="neon-select"
+                      aria-labelledby="static-ttl-label"
+                    >
+                      <input type="hidden" name="static-ttl" value="" />
+                      <div class="neon-select__rail">
+                        <button class="neon-select__option" data-value="" type="button">
+                          <span class="neon-select__option-title">TTL</span>
+                        </button>
+                        <button class="neon-select__option" data-value="15" type="button">
+                          <span class="neon-select__option-title">15 minutes</span>
+                        </button>
+                        <button class="neon-select__option" data-value="60" type="button">
+                          <span class="neon-select__option-title">60 minutes</span>
+                        </button>
+                        <button class="neon-select__option" data-value="120" type="button">
+                          <span class="neon-select__option-title">120 minutes</span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="stream-control">
+                <p class="stream-control__title">
+                  <span class="stream-control__name">Newsroom CMS</span>
+                  <span class="stream-control__tag">cms.local</span>
+                </p>
+                <div class="stream-control__fields">
+                  <div class="stream-control__field">
+                    <p class="control-label" id="cms-route-label">Routing</p>
+                    <div
+                      class="neon-select"
+                      data-widget="neon-select"
+                      aria-labelledby="cms-route-label"
+                    >
+                      <input type="hidden" name="cms" value="" />
+                      <div class="neon-select__rail">
+                        <button class="neon-select__option" data-value="" type="button">
+                          <span class="neon-select__option-title">Routing</span>
+                        </button>
+                        <button class="neon-select__option" data-value="direct" type="button">
+                          <span class="neon-select__option-title">Serve direct</span>
+                        </button>
+                        <button class="neon-select__option" data-value="parent" type="button">
+                          <span class="neon-select__option-title">Send to parent cache</span>
+                        </button>
+                        <button class="neon-select__option" data-value="sibling" type="button">
+                          <span class="neon-select__option-title">Share with sibling cache</span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="stream-control__field">
+                    <p class="control-label" id="cms-ttl-label">TTL</p>
+                    <div
+                      class="neon-select"
+                      data-widget="neon-select"
+                      aria-labelledby="cms-ttl-label"
+                    >
+                      <input type="hidden" name="cms-ttl" value="" />
+                      <div class="neon-select__rail">
+                        <button class="neon-select__option" data-value="" type="button">
+                          <span class="neon-select__option-title">TTL</span>
+                        </button>
+                        <button class="neon-select__option" data-value="5" type="button">
+                          <span class="neon-select__option-title">5 minutes</span>
+                        </button>
+                        <button class="neon-select__option" data-value="15" type="button">
+                          <span class="neon-select__option-title">15 minutes</span>
+                        </button>
+                        <button class="neon-select__option" data-value="60" type="button">
+                          <span class="neon-select__option-title">60 minutes</span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="stream-control">
+                <p class="stream-control__title">
+                  <span class="stream-control__name">Software mirror</span>
+                  <span class="stream-control__tag">mirror.archive</span>
+                </p>
+                <div class="stream-control__fields">
+                  <div class="stream-control__field">
+                    <p class="control-label" id="mirror-route-label">Routing</p>
+                    <div
+                      class="neon-select"
+                      data-widget="neon-select"
+                      aria-labelledby="mirror-route-label"
+                    >
+                      <input type="hidden" name="mirror" value="" />
+                      <div class="neon-select__rail">
+                        <button class="neon-select__option" data-value="" type="button">
+                          <span class="neon-select__option-title">Routing</span>
+                        </button>
+                        <button class="neon-select__option" data-value="direct" type="button">
+                          <span class="neon-select__option-title">Serve direct</span>
+                        </button>
+                        <button class="neon-select__option" data-value="parent" type="button">
+                          <span class="neon-select__option-title">Send to parent cache</span>
+                        </button>
+                        <button class="neon-select__option" data-value="sibling" type="button">
+                          <span class="neon-select__option-title">Share with sibling cache</span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="stream-control__field">
+                    <p class="control-label" id="mirror-ttl-label">TTL</p>
+                    <div
+                      class="neon-select"
+                      data-widget="neon-select"
+                      aria-labelledby="mirror-ttl-label"
+                    >
+                      <input type="hidden" name="mirror-ttl" value="" />
+                      <div class="neon-select__rail">
+                        <button class="neon-select__option" data-value="" type="button">
+                          <span class="neon-select__option-title">TTL</span>
+                        </button>
+                        <button class="neon-select__option" data-value="30" type="button">
+                          <span class="neon-select__option-title">30 minutes</span>
+                        </button>
+                        <button class="neon-select__option" data-value="120" type="button">
+                          <span class="neon-select__option-title">120 minutes</span>
+                        </button>
+                        <button class="neon-select__option" data-value="240" type="button">
+                          <span class="neon-select__option-title">240 minutes</span>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </fieldset>
           <button type="submit" class="execute-button">Commit hierarchy</button>
@@ -139,6 +263,7 @@
       </section>
     </main>
     <footer>Remember: always warm the cache before the press release.</footer>
+    <script src="../widgets.js" type="module"></script>
     <script type="module" src="./cache-cascade.js"></script>
   </body>
 </html>

--- a/madia.new/public/secret/net/hopline-diagnostics/hopline-diagnostics.css
+++ b/madia.new/public/secret/net/hopline-diagnostics/hopline-diagnostics.css
@@ -28,17 +28,18 @@ main {
   gap: 1rem;
 }
 
-label {
+.route-control {
   display: grid;
   gap: 0.4rem;
-  font-weight: 500;
 }
 
-select {
-  background: rgba(0, 16, 24, 0.95);
-  border: 1px solid rgba(80, 255, 200, 0.35);
-  color: var(--text-primary);
-  padding: 0.4rem 0.6rem;
+.route-control__label {
+  margin: 0;
+  font-weight: 600;
+}
+
+.route-control .neon-select {
+  width: 100%;
 }
 
 .status-board[data-state="success"] {

--- a/madia.new/public/secret/net/hopline-diagnostics/index.html
+++ b/madia.new/public/secret/net/hopline-diagnostics/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Hopline Diagnostics</title>
     <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="../widgets.css" />
     <link rel="stylesheet" href="./hopline-diagnostics.css" />
   </head>
   <body>
@@ -56,33 +57,66 @@ $ traceroute studio.lan
           <fieldset>
             <legend>Prefix to router mapping</legend>
             <div class="route-grid">
-              <label>
-                10.20.0.0/16 data lab
-                <select name="lab">
-                  <option value="">--</option>
-                  <option value="edge-hub">edge-hub</option>
-                  <option value="metro-border">metro-border</option>
-                  <option value="studio-loop">studio-loop</option>
-                </select>
-              </label>
-              <label>
-                172.22.40.0/21 studio wing
-                <select name="studio">
-                  <option value="">--</option>
-                  <option value="edge-hub">edge-hub</option>
-                  <option value="metro-border">metro-border</option>
-                  <option value="studio-loop">studio-loop</option>
-                </select>
-              </label>
-              <label>
-                198.51.100.0/28 ISP handoff
-                <select name="isp">
-                  <option value="">--</option>
-                  <option value="edge-hub">edge-hub</option>
-                  <option value="metro-border">metro-border</option>
-                  <option value="studio-loop">studio-loop</option>
-                </select>
-              </label>
+              <div class="route-control">
+                <p class="route-control__label">10.20.0.0/16 data lab</p>
+                <div class="neon-select" data-widget="neon-select" aria-label="Select router for 10.20.0.0/16">
+                  <input type="hidden" name="lab" value="" />
+                  <div class="neon-select__rail">
+                    <button class="neon-select__option" data-value="" type="button">
+                      <span class="neon-select__option-title">--</span>
+                    </button>
+                    <button class="neon-select__option" data-value="edge-hub" type="button">
+                      <span class="neon-select__option-title">edge-hub</span>
+                    </button>
+                    <button class="neon-select__option" data-value="metro-border" type="button">
+                      <span class="neon-select__option-title">metro-border</span>
+                    </button>
+                    <button class="neon-select__option" data-value="studio-loop" type="button">
+                      <span class="neon-select__option-title">studio-loop</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="route-control">
+                <p class="route-control__label">172.22.40.0/21 studio wing</p>
+                <div class="neon-select" data-widget="neon-select" aria-label="Select router for 172.22.40.0/21">
+                  <input type="hidden" name="studio" value="" />
+                  <div class="neon-select__rail">
+                    <button class="neon-select__option" data-value="" type="button">
+                      <span class="neon-select__option-title">--</span>
+                    </button>
+                    <button class="neon-select__option" data-value="edge-hub" type="button">
+                      <span class="neon-select__option-title">edge-hub</span>
+                    </button>
+                    <button class="neon-select__option" data-value="metro-border" type="button">
+                      <span class="neon-select__option-title">metro-border</span>
+                    </button>
+                    <button class="neon-select__option" data-value="studio-loop" type="button">
+                      <span class="neon-select__option-title">studio-loop</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="route-control">
+                <p class="route-control__label">198.51.100.0/28 ISP handoff</p>
+                <div class="neon-select" data-widget="neon-select" aria-label="Select router for 198.51.100.0/28">
+                  <input type="hidden" name="isp" value="" />
+                  <div class="neon-select__rail">
+                    <button class="neon-select__option" data-value="" type="button">
+                      <span class="neon-select__option-title">--</span>
+                    </button>
+                    <button class="neon-select__option" data-value="edge-hub" type="button">
+                      <span class="neon-select__option-title">edge-hub</span>
+                    </button>
+                    <button class="neon-select__option" data-value="metro-border" type="button">
+                      <span class="neon-select__option-title">metro-border</span>
+                    </button>
+                    <button class="neon-select__option" data-value="studio-loop" type="button">
+                      <span class="neon-select__option-title">studio-loop</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
             </div>
           </fieldset>
           <button type="submit" class="execute-button">Deploy routes</button>
@@ -128,6 +162,7 @@ $ traceroute studio.lan
       </section>
     </main>
     <footer>Keep the traceroute green and the pager silent.</footer>
+    <script src="../widgets.js" type="module"></script>
     <script type="module" src="./hopline-diagnostics.js"></script>
   </body>
 </html>

--- a/madia.new/public/secret/net/kernel-forge-20/index.html
+++ b/madia.new/public/secret/net/kernel-forge-20/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Kernel Forge 2.0</title>
     <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="../widgets.css" />
     <link rel="stylesheet" href="./kernel-forge-20.css" />
   </head>
   <body>
@@ -59,13 +60,25 @@
           </fieldset>
           <fieldset>
             <legend>Device Drivers</legend>
-            <label>
-              3c59x driver
-              <select name="nic-mode">
-                <option value="module">Build as module</option>
-                <option value="builtin">Compile into kernel</option>
-              </select>
-            </label>
+            <div class="driver-mode">
+              <p class="control-label" id="nic-mode-label">3c59x driver</p>
+              <div
+                class="segment-toggle"
+                data-widget="segment-toggle"
+                data-value="module"
+                aria-labelledby="nic-mode-label"
+              >
+                <input type="hidden" name="nic-mode" value="module" />
+                <div class="segment-toggle__options">
+                  <button class="segment-toggle__option" data-value="module" type="button">
+                    <span class="segment-toggle__label">Build as module</span>
+                  </button>
+                  <button class="segment-toggle__option" data-value="builtin" type="button">
+                    <span class="segment-toggle__label">Compile into kernel</span>
+                  </button>
+                </div>
+              </div>
+            </div>
             <div class="checkbox-grid">
               <label>
                 Include SCSI support
@@ -116,6 +129,7 @@
       </section>
     </main>
     <footer>Remember to copy System.map once it boots.</footer>
+    <script src="../widgets.js" type="module"></script>
     <script type="module" src="./kernel-forge-20.js"></script>
   </body>
 </html>

--- a/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.css
+++ b/madia.new/public/secret/net/kernel-forge-20/kernel-forge-20.css
@@ -11,6 +11,24 @@ body {
   color: var(--net-muted);
 }
 
+.control-label {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(198, 234, 232, 0.75);
+}
+
+.driver-mode {
+  display: grid;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.driver-mode .segment-toggle {
+  width: 100%;
+}
+
 .execute-button {
   margin-top: 0.75rem;
 }

--- a/madia.new/public/secret/net/lan-beacon-scout/index.html
+++ b/madia.new/public/secret/net/lan-beacon-scout/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>LAN Beacon Scout</title>
     <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="../widgets.css" />
     <link rel="stylesheet" href="./lan-beacon-scout.css" />
   </head>
   <body>
@@ -58,25 +59,54 @@
           <fieldset>
             <legend>Current sweep</legend>
             <p id="briefing-copy" class="briefing"></p>
-            <label for="broadcast-select">Broadcast target</label>
-            <select id="broadcast-select" name="broadcast">
-              <option value="">Select a broadcast range…</option>
-            </select>
+            <p class="control-label" id="broadcast-label">Broadcast target</p>
+            <div
+              class="neon-select"
+              data-widget="neon-select"
+              data-role="broadcast-select"
+              aria-labelledby="broadcast-label"
+            >
+              <input type="hidden" name="broadcast" value="" />
+              <div class="neon-select__rail">
+                <button class="neon-select__option" data-value="" type="button">
+                  <span class="neon-select__option-title">Select a broadcast range…</span>
+                </button>
+                <button class="neon-select__option" data-value="" data-slot="0" type="button">
+                  <span class="neon-select__option-title">Option 1</span>
+                </button>
+                <button class="neon-select__option" data-value="" data-slot="1" type="button">
+                  <span class="neon-select__option-title">Option 2</span>
+                </button>
+                <button class="neon-select__option" data-value="" data-slot="2" type="button">
+                  <span class="neon-select__option-title">Option 3</span>
+                </button>
+              </div>
+            </div>
             <span class="helper-text" id="broadcast-hint"></span>
-            <div class="radio-grid">
-              <span class="radio-label">Discovery method</span>
-              <label>
-                Quick ARP Probe
-                <input type="radio" name="method" value="arp" />
-              </label>
-              <label>
-                UDP Echo Spray
-                <input type="radio" name="method" value="udp" />
-              </label>
-              <label>
-                NetBIOS Name Pulse
-                <input type="radio" name="method" value="netbios" />
-              </label>
+            <div class="method-toggle">
+              <span class="method-toggle__label" id="method-label">Discovery method</span>
+              <div
+                class="segment-toggle"
+                data-widget="segment-toggle"
+                data-role="method-toggle"
+                aria-labelledby="method-label"
+              >
+                <input type="hidden" name="method" value="" />
+                <div class="segment-toggle__options">
+                  <button class="segment-toggle__option" data-value="" type="button">
+                    <span class="segment-toggle__label">Select method</span>
+                  </button>
+                  <button class="segment-toggle__option" data-value="arp" type="button">
+                    <span class="segment-toggle__label">Quick ARP Probe</span>
+                  </button>
+                  <button class="segment-toggle__option" data-value="udp" type="button">
+                    <span class="segment-toggle__label">UDP Echo Spray</span>
+                  </button>
+                  <button class="segment-toggle__option" data-value="netbios" type="button">
+                    <span class="segment-toggle__label">NetBIOS Name Pulse</span>
+                  </button>
+                </div>
+              </div>
             </div>
             <button type="submit" class="execute-button">Send beacon</button>
           </fieldset>
@@ -113,6 +143,7 @@
       </section>
     </main>
     <footer>Broadcast responsibly. Beige boxes are listening.</footer>
+    <script src="../widgets.js" type="module"></script>
     <script type="module" src="./lan-beacon-scout.js"></script>
   </body>
 </html>

--- a/madia.new/public/secret/net/lan-beacon-scout/lan-beacon-scout.css
+++ b/madia.new/public/secret/net/lan-beacon-scout/lan-beacon-scout.css
@@ -61,15 +61,18 @@ main {
   color: rgba(148, 197, 183, 0.7);
 }
 
-.radio-grid {
-  margin-bottom: 1rem;
-}
-
-.radio-grid .radio-label {
+.control-label,
+.method-toggle__label {
   font-size: 0.75rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: rgba(148, 197, 183, 0.8);
+}
+
+.method-toggle {
+  display: grid;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
 }
 
 .map-panel {

--- a/madia.new/public/secret/net/nat-handshake-lab/index.html
+++ b/madia.new/public/secret/net/nat-handshake-lab/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>NAT Handshake Lab</title>
     <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="../widgets.css" />
     <link rel="stylesheet" href="./nat-handshake-lab.css" />
   </head>
   <body>
@@ -126,61 +127,157 @@
                 <p class="summary">
                   Needs low-latency voice via UDP 3478. Remote base polls with STUN every 20 seconds.
                 </p>
-                <label for="mapping-stun">Mapping style</label>
-                <select id="mapping-stun" name="mapping-stun">
-                  <option value="">Choose a mapping…</option>
-                  <option value="static">Static pinhole</option>
-                  <option value="restricted">Restricted cone</option>
-                  <option value="preserving">Port-preserving</option>
-                  <option value="symmetric">Symmetric</option>
-                </select>
-                <label for="keepalive-stun">Keepalive tactic</label>
-                <select id="keepalive-stun" name="keepalive-stun">
-                  <option value="">Choose a keepalive…</option>
-                  <option value="stun">STUN binding refresh</option>
-                  <option value="udp">Manual UDP ping</option>
-                  <option value="alg">Application-layer gateway assist</option>
-                </select>
+                <p class="control-label" id="mapping-stun-label">Mapping style</p>
+                <div
+                  class="neon-select"
+                  data-widget="neon-select"
+                  aria-labelledby="mapping-stun-label"
+                >
+                  <input type="hidden" name="mapping-stun" value="" />
+                  <div class="neon-select__rail">
+                    <button class="neon-select__option" data-value="" type="button">
+                      <span class="neon-select__option-title">Choose a mapping…</span>
+                    </button>
+                    <button class="neon-select__option" data-value="static" type="button">
+                      <span class="neon-select__option-title">Static pinhole</span>
+                    </button>
+                    <button class="neon-select__option" data-value="restricted" type="button">
+                      <span class="neon-select__option-title">Restricted cone</span>
+                    </button>
+                    <button class="neon-select__option" data-value="preserving" type="button">
+                      <span class="neon-select__option-title">Port-preserving</span>
+                    </button>
+                    <button class="neon-select__option" data-value="symmetric" type="button">
+                      <span class="neon-select__option-title">Symmetric</span>
+                    </button>
+                  </div>
+                </div>
+                <p class="control-label" id="keepalive-stun-label">Keepalive tactic</p>
+                <div
+                  class="neon-select"
+                  data-widget="neon-select"
+                  aria-labelledby="keepalive-stun-label"
+                >
+                  <input type="hidden" name="keepalive-stun" value="" />
+                  <div class="neon-select__rail">
+                    <button class="neon-select__option" data-value="" type="button">
+                      <span class="neon-select__option-title">Choose a keepalive…</span>
+                    </button>
+                    <button class="neon-select__option" data-value="stun" type="button">
+                      <span class="neon-select__option-title">STUN binding refresh</span>
+                    </button>
+                    <button class="neon-select__option" data-value="udp" type="button">
+                      <span class="neon-select__option-title">Manual UDP ping</span>
+                    </button>
+                    <button class="neon-select__option" data-value="alg" type="button">
+                      <span class="neon-select__option-title">Application-layer gateway assist</span>
+                    </button>
+                  </div>
+                </div>
               </article>
               <article class="session-card" data-session="ftp">
                 <h3>Graphics Vendor FTP</h3>
                 <p class="summary">
                   Passive-mode file drop. Control on TCP 21, ephemeral data ports follow client suggestion.
                 </p>
-                <label for="mapping-ftp">Mapping style</label>
-                <select id="mapping-ftp" name="mapping-ftp">
-                  <option value="">Choose a mapping…</option>
-                  <option value="static">Static pinhole</option>
-                  <option value="restricted">Restricted cone</option>
-                  <option value="preserving">Port-preserving</option>
-                  <option value="symmetric">Symmetric</option>
-                </select>
-                <label for="keepalive-ftp">Keepalive tactic</label>
-                <select id="keepalive-ftp" name="keepalive-ftp">
-                  <option value="">Choose a keepalive…</option>
-                  <option value="stun">STUN binding refresh</option>
-                  <option value="udp">Manual UDP ping</option>
-                  <option value="alg">Application-layer gateway assist</option>
-                </select>
+                <p class="control-label" id="mapping-ftp-label">Mapping style</p>
+                <div
+                  class="neon-select"
+                  data-widget="neon-select"
+                  aria-labelledby="mapping-ftp-label"
+                >
+                  <input type="hidden" name="mapping-ftp" value="" />
+                  <div class="neon-select__rail">
+                    <button class="neon-select__option" data-value="" type="button">
+                      <span class="neon-select__option-title">Choose a mapping…</span>
+                    </button>
+                    <button class="neon-select__option" data-value="static" type="button">
+                      <span class="neon-select__option-title">Static pinhole</span>
+                    </button>
+                    <button class="neon-select__option" data-value="restricted" type="button">
+                      <span class="neon-select__option-title">Restricted cone</span>
+                    </button>
+                    <button class="neon-select__option" data-value="preserving" type="button">
+                      <span class="neon-select__option-title">Port-preserving</span>
+                    </button>
+                    <button class="neon-select__option" data-value="symmetric" type="button">
+                      <span class="neon-select__option-title">Symmetric</span>
+                    </button>
+                  </div>
+                </div>
+                <p class="control-label" id="keepalive-ftp-label">Keepalive tactic</p>
+                <div
+                  class="neon-select"
+                  data-widget="neon-select"
+                  aria-labelledby="keepalive-ftp-label"
+                >
+                  <input type="hidden" name="keepalive-ftp" value="" />
+                  <div class="neon-select__rail">
+                    <button class="neon-select__option" data-value="" type="button">
+                      <span class="neon-select__option-title">Choose a keepalive…</span>
+                    </button>
+                    <button class="neon-select__option" data-value="stun" type="button">
+                      <span class="neon-select__option-title">STUN binding refresh</span>
+                    </button>
+                    <button class="neon-select__option" data-value="udp" type="button">
+                      <span class="neon-select__option-title">Manual UDP ping</span>
+                    </button>
+                    <button class="neon-select__option" data-value="alg" type="button">
+                      <span class="neon-select__option-title">Application-layer gateway assist</span>
+                    </button>
+                  </div>
+                </div>
               </article>
               <article class="session-card" data-session="tunnel">
                 <h3>Investigations VPN Tunnel</h3>
                 <p class="summary">ESP-over-UDP fallback, expects periodic DPD keepalives and consistent outer ports.</p>
-                <label for="mapping-tunnel">Mapping style</label>
-                <select id="mapping-tunnel" name="mapping-tunnel">
-                  <option value="">Choose a mapping…</option>
-                  <option value="static">Static pinhole</option>
-                  <option value="restricted">Restricted cone</option>
-                  <option value="preserving">Port-preserving</option>
-                  <option value="symmetric">Symmetric</option>
-                </select>
-                <label for="keepalive-tunnel">Keepalive tactic</label>
-                <select id="keepalive-tunnel" name="keepalive-tunnel">
-                  <option value="">Choose a keepalive…</option>
-                  <option value="stun">STUN binding refresh</option>
-                  <option value="udp">Manual UDP ping</option>
-                  <option value="alg">Application-layer gateway assist</option>
-                </select>
+                <p class="control-label" id="mapping-tunnel-label">Mapping style</p>
+                <div
+                  class="neon-select"
+                  data-widget="neon-select"
+                  aria-labelledby="mapping-tunnel-label"
+                >
+                  <input type="hidden" name="mapping-tunnel" value="" />
+                  <div class="neon-select__rail">
+                    <button class="neon-select__option" data-value="" type="button">
+                      <span class="neon-select__option-title">Choose a mapping…</span>
+                    </button>
+                    <button class="neon-select__option" data-value="static" type="button">
+                      <span class="neon-select__option-title">Static pinhole</span>
+                    </button>
+                    <button class="neon-select__option" data-value="restricted" type="button">
+                      <span class="neon-select__option-title">Restricted cone</span>
+                    </button>
+                    <button class="neon-select__option" data-value="preserving" type="button">
+                      <span class="neon-select__option-title">Port-preserving</span>
+                    </button>
+                    <button class="neon-select__option" data-value="symmetric" type="button">
+                      <span class="neon-select__option-title">Symmetric</span>
+                    </button>
+                  </div>
+                </div>
+                <p class="control-label" id="keepalive-tunnel-label">Keepalive tactic</p>
+                <div
+                  class="neon-select"
+                  data-widget="neon-select"
+                  aria-labelledby="keepalive-tunnel-label"
+                >
+                  <input type="hidden" name="keepalive-tunnel" value="" />
+                  <div class="neon-select__rail">
+                    <button class="neon-select__option" data-value="" type="button">
+                      <span class="neon-select__option-title">Choose a keepalive…</span>
+                    </button>
+                    <button class="neon-select__option" data-value="stun" type="button">
+                      <span class="neon-select__option-title">STUN binding refresh</span>
+                    </button>
+                    <button class="neon-select__option" data-value="udp" type="button">
+                      <span class="neon-select__option-title">Manual UDP ping</span>
+                    </button>
+                    <button class="neon-select__option" data-value="alg" type="button">
+                      <span class="neon-select__option-title">Application-layer gateway assist</span>
+                    </button>
+                  </div>
+                </div>
               </article>
             </div>
             <button type="submit" class="execute-button">Negotiate mappings</button>
@@ -194,6 +291,7 @@
       </section>
     </main>
     <footer>Keep the translators lean and the crew online.</footer>
+    <script src="../widgets.js" type="module"></script>
     <script type="module" src="./nat-handshake-lab.js"></script>
   </body>
 </html>

--- a/madia.new/public/secret/net/nat-handshake-lab/nat-handshake-lab.css
+++ b/madia.new/public/secret/net/nat-handshake-lab/nat-handshake-lab.css
@@ -235,6 +235,14 @@ main {
   overflow: hidden;
 }
 
+.session-card .control-label {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 197, 183, 0.78);
+}
+
 .session-card::after {
   content: "";
   position: absolute;

--- a/madia.new/public/secret/net/root-zone-relay/index.html
+++ b/madia.new/public/secret/net/root-zone-relay/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Root Zone Relay</title>
     <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="../widgets.css" />
     <link rel="stylesheet" href="./root-zone-relay.css" />
   </head>
   <body>
@@ -54,16 +55,27 @@
         <form id="zone-form" class="form-grid">
           <fieldset data-record="www">
             <legend>www</legend>
-            <label>
-              Record Type
-              <select name="www-type" required>
-                <option value="">Select</option>
-                <option value="A">A</option>
-                <option value="CNAME">CNAME</option>
-                <option value="MX">MX</option>
-              </select>
-            </label>
-            <label>
+            <div class="form-field" data-field="www-type">
+              <p class="control-label" id="www-type-label">Record Type</p>
+              <div class="neon-select" data-widget="neon-select" aria-labelledby="www-type-label">
+                <input type="hidden" name="www-type" value="" />
+                <div class="neon-select__rail">
+                  <button class="neon-select__option" data-value="" type="button">
+                    <span class="neon-select__option-title">Select</span>
+                  </button>
+                  <button class="neon-select__option" data-value="A" type="button">
+                    <span class="neon-select__option-title">A</span>
+                  </button>
+                  <button class="neon-select__option" data-value="CNAME" type="button">
+                    <span class="neon-select__option-title">CNAME</span>
+                  </button>
+                  <button class="neon-select__option" data-value="MX" type="button">
+                    <span class="neon-select__option-title">MX</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+            <label class="form-field" data-field="www-value">
               Value
               <input
                 type="text"
@@ -73,7 +85,7 @@
                 required
               />
             </label>
-            <label>
+            <label class="form-field" data-field="www-ttl">
               TTL
               <input
                 type="number"
@@ -87,16 +99,27 @@
           </fieldset>
           <fieldset data-record="mail">
             <legend>mail</legend>
-            <label>
-              Record Type
-              <select name="mail-type" required>
-                <option value="">Select</option>
-                <option value="MX">MX</option>
-                <option value="A">A</option>
-                <option value="CNAME">CNAME</option>
-              </select>
-            </label>
-            <label>
+            <div class="form-field" data-field="mail-type">
+              <p class="control-label" id="mail-type-label">Record Type</p>
+              <div class="neon-select" data-widget="neon-select" aria-labelledby="mail-type-label">
+                <input type="hidden" name="mail-type" value="" />
+                <div class="neon-select__rail">
+                  <button class="neon-select__option" data-value="" type="button">
+                    <span class="neon-select__option-title">Select</span>
+                  </button>
+                  <button class="neon-select__option" data-value="MX" type="button">
+                    <span class="neon-select__option-title">MX</span>
+                  </button>
+                  <button class="neon-select__option" data-value="A" type="button">
+                    <span class="neon-select__option-title">A</span>
+                  </button>
+                  <button class="neon-select__option" data-value="CNAME" type="button">
+                    <span class="neon-select__option-title">CNAME</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+            <label class="form-field" data-field="mail-value">
               Target host
               <input
                 type="text"
@@ -106,7 +129,7 @@
                 required
               />
             </label>
-            <label>
+            <label class="form-field" data-field="mail-priority">
               Priority
               <input
                 type="number"
@@ -120,16 +143,27 @@
           </fieldset>
           <fieldset data-record="root">
             <legend>Root (@)</legend>
-            <label>
-              Record Type
-              <select name="root-type" required>
-                <option value="">Select</option>
-                <option value="NS">NS</option>
-                <option value="SOA">SOA</option>
-                <option value="A">A</option>
-              </select>
-            </label>
-            <label>
+            <div class="form-field" data-field="root-type">
+              <p class="control-label" id="root-type-label">Record Type</p>
+              <div class="neon-select" data-widget="neon-select" aria-labelledby="root-type-label">
+                <input type="hidden" name="root-type" value="" />
+                <div class="neon-select__rail">
+                  <button class="neon-select__option" data-value="" type="button">
+                    <span class="neon-select__option-title">Select</span>
+                  </button>
+                  <button class="neon-select__option" data-value="NS" type="button">
+                    <span class="neon-select__option-title">NS</span>
+                  </button>
+                  <button class="neon-select__option" data-value="SOA" type="button">
+                    <span class="neon-select__option-title">SOA</span>
+                  </button>
+                  <button class="neon-select__option" data-value="A" type="button">
+                    <span class="neon-select__option-title">A</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+            <label class="form-field" data-field="root-value">
               Target host
               <input
                 type="text"
@@ -189,6 +223,7 @@
       </section>
     </main>
     <footer>Based on IETF RFCs that kept the '96 backbone humming.</footer>
+    <script src="../widgets.js" type="module"></script>
     <script type="module" src="./root-zone-relay.js"></script>
   </body>
 </html>

--- a/madia.new/public/secret/net/root-zone-relay/root-zone-relay.css
+++ b/madia.new/public/secret/net/root-zone-relay/root-zone-relay.css
@@ -173,15 +173,22 @@ body {
   color: rgba(198, 234, 232, 0.78);
 }
 
-.form-grid label {
+.form-grid .form-field {
   display: grid;
   gap: 0.35rem;
   font-size: 0.92rem;
   color: rgba(198, 234, 232, 0.75);
 }
 
-.form-grid select,
-.form-grid input {
+.control-label {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(198, 234, 232, 0.7);
+}
+
+.form-grid .form-field input {
   border-radius: 10px;
   border: 1px solid rgba(110, 255, 210, 0.2);
   background: rgba(3, 18, 26, 0.88);
@@ -191,24 +198,32 @@ body {
   transition: border-color 0.3s ease, box-shadow 0.3s ease;
 }
 
-.form-grid [data-state="warn"] {
+.form-grid .form-field[data-state="warn"] {
   border-color: rgba(255, 182, 73, 0.65);
   box-shadow: 0 0 10px rgba(255, 182, 73, 0.22);
 }
 
-.form-grid [data-state="good"] {
+.form-grid .form-field[data-state="good"] {
   border-color: rgba(110, 255, 210, 0.6);
   box-shadow: 0 0 12px rgba(110, 255, 210, 0.24);
 }
 
-.form-grid [data-state="good"] select,
-.form-grid [data-state="good"] input {
+.form-grid .form-field[data-state="good"] input {
   border-color: rgba(110, 255, 210, 0.6);
 }
 
-.form-grid [data-state="warn"] select,
-.form-grid [data-state="warn"] input {
+.form-grid .form-field[data-state="warn"] input {
   border-color: rgba(255, 182, 73, 0.7);
+}
+
+.form-grid .form-field[data-state="good"] .neon-select {
+  border-color: rgba(110, 255, 210, 0.65);
+  box-shadow: 0 0 12px rgba(110, 255, 210, 0.22);
+}
+
+.form-grid .form-field[data-state="warn"] .neon-select {
+  border-color: rgba(255, 182, 73, 0.7);
+  box-shadow: 0 0 12px rgba(255, 182, 73, 0.2);
 }
 
 .diagnostic-console {

--- a/madia.new/public/secret/net/root-zone-relay/root-zone-relay.js
+++ b/madia.new/public/secret/net/root-zone-relay/root-zone-relay.js
@@ -55,6 +55,11 @@ const controlLookup = {};
 Object.values(recordFields)
   .flat()
   .forEach((field) => {
+    const container = form?.querySelector(`[data-field="${field}"]`);
+    if (container instanceof HTMLElement) {
+      controlLookup[field] = container;
+      return;
+    }
     const control = form?.querySelector(`[name="${field}"]`);
     if (control instanceof HTMLElement) {
       controlLookup[field] = control;

--- a/madia.new/public/secret/net/stream-parser-depot/index.html
+++ b/madia.new/public/secret/net/stream-parser-depot/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Stream Parser Depot</title>
     <link rel="stylesheet" href="../common.css" />
+    <link rel="stylesheet" href="../widgets.css" />
     <link rel="stylesheet" href="./stream-parser-depot.css" />
   </head>
   <body>
@@ -57,26 +58,52 @@ rad_reply: Access-Reject packet
           <fieldset>
             <legend>Step selection</legend>
             <div class="parser-grid">
-              <label>
-                Filter stage
-                <select name="filter">
-                  <option value="">--</option>
-                  <option value="awk-user">awk '/User-Name/ {u=$3}'</option>
-                  <option value="awk-pair">awk '/Access-Request/ {print $NF}'</option>
-                  <option value="sed-block">sed -n '1,6p'</option>
-                  <option value="sed-pull">sed -n '/Access-Accept/,$p'</option>
-                </select>
-              </label>
-              <label>
-                Format stage
-                <select name="format">
-                  <option value="">--</option>
-                  <option value="awk-print">awk 'NR==1 {printf "%s ", $1}'</option>
-                  <option value="awk-join">awk 'NR%2==1 {printf $0 " "}'</option>
-                  <option value="sed-trim">sed 's/["=]//g;s/User-Name //;s/\\t//g'</option>
-                  <option value="sed-collapse">sed -n 's/.*= \"\(.*\)\"/\1/p'</option>
-                </select>
-              </label>
+              <div class="parser-field">
+                <p class="control-label" id="filter-label">Filter stage</p>
+                <div class="neon-select" data-widget="neon-select" aria-labelledby="filter-label">
+                  <input type="hidden" name="filter" value="" />
+                  <div class="neon-select__rail">
+                    <button class="neon-select__option" data-value="" type="button">
+                      <span class="neon-select__option-title">--</span>
+                    </button>
+                    <button class="neon-select__option" data-value="awk-user" type="button">
+                      <span class="neon-select__option-title">awk '/User-Name/ {u=$3}'</span>
+                    </button>
+                    <button class="neon-select__option" data-value="awk-pair" type="button">
+                      <span class="neon-select__option-title">awk '/Access-Request/ {print $NF}'</span>
+                    </button>
+                    <button class="neon-select__option" data-value="sed-block" type="button">
+                      <span class="neon-select__option-title">sed -n '1,6p'</span>
+                    </button>
+                    <button class="neon-select__option" data-value="sed-pull" type="button">
+                      <span class="neon-select__option-title">sed -n '/Access-Accept/,$p'</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="parser-field">
+                <p class="control-label" id="format-label">Format stage</p>
+                <div class="neon-select" data-widget="neon-select" aria-labelledby="format-label">
+                  <input type="hidden" name="format" value="" />
+                  <div class="neon-select__rail">
+                    <button class="neon-select__option" data-value="" type="button">
+                      <span class="neon-select__option-title">--</span>
+                    </button>
+                    <button class="neon-select__option" data-value="awk-print" type="button">
+                      <span class="neon-select__option-title">awk 'NR==1 {printf &quot;%s &quot;, $1}'</span>
+                    </button>
+                    <button class="neon-select__option" data-value="awk-join" type="button">
+                      <span class="neon-select__option-title">awk 'NR%2==1 {printf $0 &quot; &quot;}'</span>
+                    </button>
+                    <button class="neon-select__option" data-value="sed-trim" type="button">
+                      <span class="neon-select__option-title">sed 's/["=]//g;s/User-Name //;s/\\t//g'</span>
+                    </button>
+                    <button class="neon-select__option" data-value="sed-collapse" type="button">
+                      <span class="neon-select__option-title">sed -n 's/.*= \"\(.*\)\"/\1/p'</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
             </div>
           </fieldset>
           <button type="submit" class="execute-button">Run pipeline</button>
@@ -109,6 +136,7 @@ rad_reply: Access-Reject packet
       </section>
     </main>
     <footer>Keep the pager brief and the regex sharp.</footer>
+    <script src="../widgets.js" type="module"></script>
     <script type="module" src="./stream-parser-depot.js"></script>
   </body>
 </html>

--- a/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.css
+++ b/madia.new/public/secret/net/stream-parser-depot/stream-parser-depot.css
@@ -21,17 +21,21 @@ main {
   gap: 1rem;
 }
 
-label {
+.parser-field {
   display: grid;
   gap: 0.4rem;
-  font-weight: 500;
 }
 
-select {
-  background: rgba(0, 16, 26, 0.95);
-  border: 1px solid rgba(138, 255, 219, 0.4);
-  color: var(--text-primary);
-  padding: 0.4rem 0.6rem;
+.control-label {
+  margin: 0;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(138, 255, 219, 0.7);
+}
+
+.parser-field .neon-select {
+  width: 100%;
 }
 
 .status-board[data-state="success"] {


### PR DESCRIPTION
## Summary
- replace the remaining Net mini-game dropdowns with neon select widgets and wire up the switchboard styles/scripts
- rebuild LAN Beacon Scout interactions around the neon select and segment toggle widgets, updating its controller logic
- convert Kernel Forge 2.0's NIC mode picker to the segment toggle for consistency with the widget suite

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e932b103f083289bbbca7c3d9e5b87